### PR TITLE
Clean up meter-sim fork leftovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,7 @@ Simulates the full optical path from star catalog to detector output, including:
 
 ## Building
 
-Requires `libcfitsio-dev` for FITS support:
-
 ```bash
-# Ubuntu/Debian
-sudo apt-get install libcfitsio-dev
-
 # Build
 cargo build --release
 
@@ -32,9 +27,6 @@ cargo run --release --bin sensor_shootout -- --experiments 100
 
 # Single-shot debug mode pointing at the Pleiades
 cargo run --release --bin sensor_shootout -- --single-shot-debug "56.75,24.12" --experiments 1
-
-# Estimate detection limits
-cargo run --release --bin sensor_floor_est
 ```
 
 ## Dependencies

--- a/simulator/src/bin/motion_simulator.rs
+++ b/simulator/src/bin/motion_simulator.rs
@@ -211,7 +211,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // See TODO.md: Simulator - Motion Simulation
     println!("\n[STUB] Motion simulation not yet implemented");
     println!("This is a placeholder for future development");
 

--- a/simulator/src/bin/sensor_noise_renderer.rs
+++ b/simulator/src/bin/sensor_noise_renderer.rs
@@ -231,7 +231,6 @@ fn main() {
         let exposure_s = args.exposure_ms as f64 / 1000.0;
         let dark_electrons = dark_current * exposure_s;
 
-        // See TODO.md: Simulator - Noise Modeling - Add zodiacal background
         let total_expected_noise = (read_noise.powi(2) + dark_electrons).sqrt();
 
         println!("Expected noise components:");

--- a/simulator/src/hardware/telescope.rs
+++ b/simulator/src/hardware/telescope.rs
@@ -515,7 +515,7 @@ pub mod models {
             "Weasel",
             Length::from_meters(0.47), // 470mm aperture
             Length::from_meters(3.45), // 3450mm focal length
-            0.70,                      // See TODO.md: Simulator - Hardware
+            0.70,
         )
     });
 }

--- a/simulator/src/sims/scene_runner.rs
+++ b/simulator/src/sims/scene_runner.rs
@@ -793,7 +793,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // See TODO.md: Simulator - Scene Processing - Fix catalog mock
+    #[ignore]
     fn test_run_experiment_basic() {
         // Create minimal test setup
         let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary
Cleanup of artifacts left over from the meter-sim repo this was forked from.

- Removed stale `TODO.md` references from 4 source files (TODO.md was migrated to GitHub issues and deleted during the extraction)
- Removed `libcfitsio-dev` dependency from README — no longer used
- Removed non-existent `sensor_floor_est` binary from README examples
- Restored detailed Rust code style guidelines dropped during the fork (comments, imports, testing)
- Restored expanded git commit practices with rationale
- Restored CI monitoring and shell command sections
- Added code editing and system access guidelines

## Test plan
- [x] `cargo build` passes