### PR TITLE
Add multi-sensor focal plane array rendering

### DIFF
--- a/simulator/examples/undersampled_psf_bias.rs
+++ b/simulator/examples/undersampled_psf_bias.rs
@@ -10,6 +10,7 @@ use plotters::prelude::*;
 use rayon::prelude::*;
 use shared::image_proc::detection::{detect_stars_unified, StarFinder};
 use shared::units::{Temperature, TemperatureExt};
+use simulator::hardware::satellite::FocalPlaneConfig;
 use simulator::hardware::sensor::models::IMX455;
 use simulator::hardware::telescope::models::IDEAL_50CM;
 use simulator::hardware::SatelliteConfig;
@@ -90,14 +91,16 @@ fn run_bias_experiment(params: &BiasExperimentParams) -> BiasExperimentResults {
         let star = create_star_at_position(true_x, true_y, params.magnitude, &params.satellite);
 
         // Create scene and render
+        let fp = FocalPlaneConfig::from_satellite(&params.satellite);
         let scene = Scene::from_stars(
-            params.satellite.clone(),
-            vec![star],
+            fp,
+            vec![vec![star]],
             Equatorial::from_degrees(0.0, 0.0), // Dummy pointing
             params.coordinates,
         );
-        let render_result =
-            scene.render_with_seed(&params.exposure, Some(params.seed + trial as u64));
+        let render_result = scene
+            .render_with_seed(&params.exposure, Some(params.seed + trial as u64))
+            .remove(0);
 
         // Calculate background RMS
         let background_rms = render_result.background_rms();

--- a/simulator/src/bin/mag_to_flux.rs
+++ b/simulator/src/bin/mag_to_flux.rs
@@ -6,6 +6,7 @@ use shared::image_proc::detection::{detect_stars_unified, StarFinder};
 use shared::image_proc::{save_u8_image, stretch_histogram, u16_to_u8_scaled};
 use shared::range_arg::RangeArg;
 use shared::units::{Temperature, TemperatureExt};
+use simulator::hardware::satellite::FocalPlaneConfig;
 use simulator::hardware::SatelliteConfig;
 use simulator::image_proc::render::StarInFrame;
 use simulator::photometry::zodiacal::SolarAngularCoordinates;
@@ -242,16 +243,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             };
 
             // Create scene with single star
+            let fp = FocalPlaneConfig::from_satellite(&satellite_config);
             let scene = Scene::from_stars(
-                satellite_config.clone(),
-                vec![star_in_frame],
+                fp,
+                vec![vec![star_in_frame]],
                 Equatorial::from_degrees(0.0, 0.0), // Dummy pointing
                 SolarAngularCoordinates::zodiacal_minimum(),
             );
 
             // Render the scene
             let exposure = Duration::from_secs(1);
-            let render_result = scene.render_with_seed(&exposure, Some(42));
+            let render_result = scene.render_with_seed(&exposure, Some(42)).remove(0);
 
             // Save image if requested
             if args.save_images {

--- a/simulator/src/bin/motion_simulator.rs
+++ b/simulator/src/bin/motion_simulator.rs
@@ -1,75 +1,51 @@
-//! Motion simulation for space telescope tracking and attitude control
-//!
-//! This simulator models spacecraft motion, attitude dynamics, and star tracking
-//! for space telescope applications. It provides functionality for:
-//!
-//! 1. Spacecraft attitude propagation and control
-//! 2. Star tracker simulation with realistic noise and errors
-//! 3. Pointing stability analysis
-//! 4. Tracking performance evaluation
-//!
-//! Usage:
-//! ```
-//! cargo run --bin motion_simulator -- [OPTIONS]
-//! ```
-//!
-//! See --help for detailed options.
-
-use clap::{Parser, ValueEnum};
-use log::debug;
-use shared::units::{LengthExt, Temperature, TemperatureExt, Wavelength};
-use simulator::hardware::telescope::{models, TelescopeConfig};
+use clap::Parser;
+use log::info;
+use simulator::hardware::satellite::FocalPlaneConfig;
+use simulator::hardware::SatelliteConfig;
 use simulator::shared_args::{DurationArg, SensorModel, SharedSimulationArgs};
+use simulator::sims::trajectory::{
+    fov_envelope, render_trajectory, Trajectory, TrajectoryRenderConfig,
+};
+use simulator::star_math::field_diameter_for_array;
+use simulator::units::{AngleExt, LengthExt, TemperatureExt};
+use starfield::catalogs::StarCatalog;
+use starfield::Equatorial;
+use std::path::Path;
+use std::time::Instant;
 
-/// Available telescope models for selection
-#[derive(Debug, Clone, ValueEnum)]
-enum TelescopeModel {
-    /// Small 50mm telescope (f/10)
-    Small50mm,
-    /// 50cm Demo telescope (f/20) - Default
-    Demo50cm,
-    /// 1m Final telescope (f/10)
-    Final1m,
-    /// Weasel telescope (f/7.3)
-    Weasel,
-}
-
-impl std::fmt::Display for TelescopeModel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TelescopeModel::Small50mm => write!(f, "small50mm"),
-            TelescopeModel::Demo50cm => write!(f, "demo50cm"),
-            TelescopeModel::Final1m => write!(f, "final1m"),
-            TelescopeModel::Weasel => write!(f, "weasel"),
-        }
+/// Parse coordinates string in format "ra,dec" (degrees)
+fn parse_ra_dec(s: &str) -> Result<Equatorial, String> {
+    let parts: Vec<&str> = s.split(',').collect();
+    if parts.len() != 2 {
+        return Err("Coordinates must be in format 'ra,dec' (degrees)".to_string());
     }
-}
-
-impl TelescopeModel {
-    /// Get the corresponding TelescopeConfig for the selected model
-    fn to_config(&self) -> &'static TelescopeConfig {
-        match self {
-            TelescopeModel::Small50mm => &models::SMALL_50MM,
-            TelescopeModel::Demo50cm => &models::IDEAL_50CM,
-            TelescopeModel::Final1m => &models::IDEAL_100CM,
-            TelescopeModel::Weasel => &models::WEASEL,
-        }
+    let ra = parts[0]
+        .trim()
+        .parse::<f64>()
+        .map_err(|_| "Invalid RA value".to_string())?;
+    let dec = parts[1]
+        .trim()
+        .parse::<f64>()
+        .map_err(|_| "Invalid Dec value".to_string())?;
+    if !(0.0..360.0).contains(&ra) {
+        return Err("RA must be in range [0, 360) degrees".to_string());
     }
+    if !(-90.0..=90.0).contains(&dec) {
+        return Err("Dec must be in range [-90, 90] degrees".to_string());
+    }
+    Ok(Equatorial::from_degrees(ra, dec))
 }
 
-/// Command line arguments for motion simulation
 #[derive(Parser, Debug)]
 #[command(
     name = "Motion Simulator",
-    about = "Simulates spacecraft motion and star tracking dynamics",
-    long_about = "Motion simulation for space telescope tracking and attitude control.\n\n\
-        This simulator models spacecraft motion, attitude dynamics, and star tracking \
-        for space telescope applications. It provides functionality for:\n  \
-        - Spacecraft attitude propagation and control\n  \
-        - Star tracker simulation with realistic noise and errors\n  \
-        - Pointing stability analysis\n  \
-        - Tracking performance evaluation\n\n\
-        Note: This is currently a stub with planned future implementation."
+    about = "Render a sequence of 16-bit PNG frames along a trajectory",
+    long_about = "Renders a moving image stream for a focal plane sensor array.\n\n\
+        The telescope sweeps from a start pointing to an end pointing over \
+        a specified duration. The star catalog is queried once with a broad \
+        field of view encompassing the entire trajectory, then each frame \
+        is rendered by re-projecting cached stars at the interpolated pointing.\n\n\
+        Output is a sequence of 16-bit grayscale PNG files, one per sensor per frame."
 )]
 struct Args {
     #[command(flatten)]
@@ -77,142 +53,132 @@ struct Args {
 
     #[arg(
         long,
-        default_value_t = TelescopeModel::Demo50cm,
-        help = "Telescope model to use for simulation",
-        long_help = "Telescope optical configuration for the simulation. Available models:\n  \
-            - small50mm: Small 50mm aperture telescope (f/10)\n  \
-            - demo50cm: 50cm demo telescope (f/20) - default\n  \
-            - final1m: 1m final telescope design (f/10)\n  \
-            - weasel: Weasel telescope (f/7.3)"
-    )]
-    telescope: TelescopeModel,
-
-    #[arg(
-        long,
-        default_value_t = SensorModel::Gsense6510bsi,
-        help = "Sensor model to use for simulation",
-        long_help = "Camera sensor model defining pixel size, read noise, dark current, \
-            and other characteristics. The sensor choice affects detection limits and \
-            noise floor calculations."
+        default_value_t = SensorModel::Imx455,
+        help = "Sensor model for the focal plane"
     )]
     sensor: SensorModel,
 
     #[arg(
         long,
-        default_value = "60s",
-        help = "Simulation duration (e.g., \"60s\", \"1.5m\", \"2000ms\")",
-        long_help = "Total duration to run the motion simulation. Accepts human-readable \
-            duration strings like \"60s\" (60 seconds), \"1.5m\" (1.5 minutes), or \
-            \"2000ms\" (2000 milliseconds)."
+        value_parser = parse_ra_dec,
+        help = "Start pointing in 'ra,dec' degrees (e.g., '56.75,24.12')"
+    )]
+    start: Equatorial,
+
+    #[arg(
+        long,
+        value_parser = parse_ra_dec,
+        help = "End pointing in 'ra,dec' degrees (e.g., '57.0,24.5')"
+    )]
+    end: Equatorial,
+
+    #[arg(
+        long,
+        default_value = "10s",
+        help = "Total trajectory duration (e.g., '10s', '1m')"
     )]
     duration: DurationArg,
 
     #[arg(
         long,
-        default_value = "100ms",
-        help = "Simulation time step (e.g., \"100ms\", \"0.1s\")",
-        long_help = "Time step for the simulation integration. Smaller steps provide \
-            higher accuracy but increase computation time. Accepts human-readable \
-            duration strings."
+        default_value = "1s",
+        help = "Time between frames (e.g., '1s', '500ms')"
     )]
     timestep: DurationArg,
 
     #[arg(
         long,
-        default_value = "motion_results.csv",
-        help = "Output CSV file for motion data",
-        long_help = "Path to the output CSV file containing motion simulation results. \
-            The file will contain timestamped attitude and position data."
+        default_value = "trajectory_output",
+        help = "Output directory for PNG frame sequence"
     )]
-    output_csv: String,
+    output_dir: String,
+
+    #[arg(long, default_value_t = 42, help = "Random seed for noise generation")]
+    seed: u64,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize logging from environment variables
     env_logger::init();
 
     let args = Args::parse();
+    let wallclock = Instant::now();
 
-    let telescope = args.telescope.to_config();
+    let telescope = args.shared.telescope.to_config();
     let sensor = args.sensor.to_config();
 
-    println!("Motion Simulator");
-    println!("================");
-    println!("Shared parameters:");
-    println!("  Exposure: {}", args.shared.exposure);
-    println!("  Temperature: {} °C", args.shared.temperature);
-    println!(
-        "  Coordinates: {:.1}°,{:.1}°",
-        args.shared.coordinates.elongation(),
-        args.shared.coordinates.latitude()
+    info!(
+        "Telescope: {} (aperture={:.3}m, f/{:.1})",
+        telescope.name,
+        telescope.aperture.as_meters(),
+        telescope.f_number()
     );
-    println!("  Catalog: {}", args.shared.catalog.display());
-    println!();
-    println!("Telescope configuration:");
-    println!("  Model: {:?}", args.telescope);
-    println!("  Name: {}", telescope.name);
-    println!("  Aperture: {:.1} m", telescope.aperture.as_meters());
-    println!(
-        "  Focal length: {:.1} m",
-        telescope.focal_length.as_meters()
-    );
-    println!(
-        "  Light efficiency: {:.1}%",
-        telescope
-            .quantum_efficiency
-            .at(Wavelength::from_nanometers(550.0))
-            * 100.0
-    );
-    println!();
-    println!("Sensor configuration:");
-    println!("  Model: {:?}", args.sensor);
-    println!("  Name: {}", sensor.name);
-    println!("  Dimensions: {}", sensor.dimensions);
-    // Get read noise estimate at operating temperature with exposure time
-    let read_noise = sensor
-        .read_noise_estimator
-        .estimate(
-            Temperature::from_celsius(args.shared.temperature).as_celsius(),
-            args.shared.exposure.0,
-        )
-        .unwrap_or(0.0);
-    println!(
-        "  Read noise: {:.1} e⁻ @ {}°C",
-        read_noise, args.shared.temperature
-    );
-    println!(
-        "  Dark current: {:.3} e⁻/px/s @ {}°C",
-        sensor.dark_current_at_temperature(Temperature::from_celsius(args.shared.temperature)),
-        args.shared.temperature
-    );
-    println!("  Max frame rate: {:.1} fps", sensor.max_frame_rate_fps);
-    println!();
-    println!("Motion parameters:");
-    println!("  Duration: {}", args.duration);
-    println!("  Timestep: {}", args.timestep);
-    println!("  Output file: {}", args.output_csv);
+    info!("Sensor: {}", sensor.name);
 
-    let timestep = args.timestep.0;
-    let duration = args.duration.0;
-    let total_steps = (duration.as_millis() / timestep.as_millis()) as usize;
+    let satellite = SatelliteConfig::new(
+        telescope.clone(),
+        sensor.clone(),
+        simulator::units::Temperature::from_celsius(args.shared.temperature),
+    );
+    let focal_plane = FocalPlaneConfig::from_satellite(&satellite);
 
-    println!("\nSimulation will run for {total_steps} steps");
-    println!("Each step represents {}", args.timestep);
+    let trajectory = Trajectory::from_endpoints(args.start, args.end, args.duration.0)?;
 
-    // Example of loading catalog using shared helper function
-    debug!("Attempting to load catalog for demonstration...");
-    match args.shared.load_catalog() {
-        Ok(catalog) => {
-            debug!("Successfully loaded catalog with {} stars", catalog.len());
-        }
-        Err(e) => {
-            debug!("Note: Could not load catalog ({e})");
-            debug!("This is not required for motion simulation");
-        }
+    let base_fov_deg = field_diameter_for_array(&focal_plane)
+        .map(|a| a.as_degrees())
+        .ok_or("Empty focal plane")?;
+
+    let (envelope_center, envelope_diameter) = fov_envelope(&trajectory, base_fov_deg);
+
+    info!(
+        "Trajectory: RA {:.4}° Dec {:.4}° → RA {:.4}° Dec {:.4}° over {:.1}s",
+        args.start.ra_degrees(),
+        args.start.dec_degrees(),
+        args.end.ra_degrees(),
+        args.end.dec_degrees(),
+        args.duration.0.as_secs_f64()
+    );
+    info!(
+        "FOV envelope: center RA {:.4}° Dec {:.4}°, diameter {:.4}°",
+        envelope_center.ra_degrees(),
+        envelope_center.dec_degrees(),
+        envelope_diameter
+    );
+
+    info!("Loading catalog...");
+    let catalog = args.shared.load_catalog()?;
+
+    let stars = catalog.stars_in_field(
+        envelope_center.ra_degrees(),
+        envelope_center.dec_degrees(),
+        envelope_diameter,
+    );
+    info!("Cached {} stars for trajectory envelope", stars.len());
+
+    let output_path = Path::new(&args.output_dir);
+    if !output_path.exists() {
+        std::fs::create_dir_all(output_path)?;
     }
 
-    println!("\n[STUB] Motion simulation not yet implemented");
-    println!("This is a placeholder for future development");
+    let render_config = TrajectoryRenderConfig {
+        trajectory: &trajectory,
+        timestep: args.timestep.0,
+        exposure: args.shared.exposure.0,
+        focal_plane: &focal_plane,
+        catalog_stars: &stars,
+        zodiacal: args.shared.coordinates,
+        output_dir: output_path,
+        base_seed: Some(args.seed),
+    };
+    let frame_count = render_trajectory(&render_config)?;
+
+    let elapsed = wallclock.elapsed();
+    info!(
+        "Rendered {} frames in {:.2}s ({:.1} fps)",
+        frame_count,
+        elapsed.as_secs_f64(),
+        frame_count as f64 / elapsed.as_secs_f64()
+    );
+    info!("Output: {}", args.output_dir);
 
     Ok(())
 }

--- a/simulator/src/hardware/mod.rs
+++ b/simulator/src/hardware/mod.rs
@@ -35,7 +35,7 @@ pub mod sensor_noise;
 pub mod telescope;
 
 pub use gyro::GyroModel;
-pub use satellite::SatelliteConfig;
+pub use satellite::{FocalPlaneConfig, SatelliteConfig};
 pub use sensor::SensorConfig;
 pub use sensor_array::SensorArray;
 pub use telescope::TelescopeConfig;

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -87,9 +87,9 @@ pub use hardware::telescope::TelescopeConfig;
 pub use photometry::quantum_efficiency::QuantumEfficiency;
 pub use photometry::spectrum::{Spectrum, CGS};
 pub use photometry::trapezoid::trap_integrate;
-pub use scene::Scene;
+pub use scene::{ArrayScene, Scene};
 pub use shared::image_proc::histogram_stretch::stretch_histogram;
-pub use star_math::{field_diameter, pixel_scale, star_data_to_fluxes};
+pub use star_math::{field_diameter, field_diameter_for_array, pixel_scale, star_data_to_fluxes};
 pub use starfield::catalogs::StarPosition;
 
 #[cfg(test)]

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -87,7 +87,7 @@ pub use hardware::telescope::TelescopeConfig;
 pub use photometry::quantum_efficiency::QuantumEfficiency;
 pub use photometry::spectrum::{Spectrum, CGS};
 pub use photometry::trapezoid::trap_integrate;
-pub use scene::{ArrayScene, Scene};
+pub use scene::Scene;
 pub use shared::image_proc::histogram_stretch::stretch_histogram;
 pub use star_math::{field_diameter, field_diameter_for_array, pixel_scale, star_data_to_fluxes};
 pub use starfield::catalogs::StarPosition;

--- a/simulator/src/scene.rs
+++ b/simulator/src/scene.rs
@@ -87,10 +87,8 @@
 //! - **Diagnostic data**: Background levels, noise contributions
 
 use crate::hardware::satellite::FocalPlaneConfig;
-use crate::hardware::SatelliteConfig;
 use crate::image_proc::render::{
-    project_stars_to_focal_plane, project_stars_to_pixels, route_stars_to_sensors, Renderer,
-    RenderingResult, StarInFrame,
+    project_stars_to_focal_plane, route_stars_to_sensors, Renderer, RenderingResult, StarInFrame,
 };
 use crate::photometry::zodiacal::SolarAngularCoordinates;
 use shared::units::LengthExt;
@@ -98,269 +96,29 @@ use starfield::catalogs::StarData;
 use starfield::Equatorial;
 use std::time::Duration;
 
-/// Complete astronomical observation scene with instrument and target configuration.
+/// Complete astronomical observation scene for single or multi-sensor focal planes.
 ///
-/// Represents a fully-specified astronomical observation combining instrument
-/// hardware, stellar targets, pointing direction, and exposure parameters.
-/// Provides unified interface for realistic telescope simulations including
-/// coordinate projections, photometric calculations, and detector modeling.
-///
-/// # Scene Components
-/// - **Instrument Model**: Complete telescope + detector characterization
-/// - **Stellar Field**: Catalog stars with positions, magnitudes, and colors
-/// - **Pointing**: Celestial coordinates defining observation center
-/// - **Timing**: Exposure duration and observing epoch
-/// - **Environment**: Background conditions (zodiacal light, thermal)
-///
-/// # Coordinate System Integration
-/// The scene handles complex astronomical coordinate transformations:
-/// - **Input**: Catalog coordinates (RA, Dec in degrees)
-/// - **Projection**: Gnomonic tangent-plane mapping to focal plane
-/// - **Distortion**: Optical aberrations and field curvature
-/// - **Output**: Pixel coordinates with sub-pixel accuracy
-///
-/// # Performance Characteristics
-/// - **Initialization**: O(N) star projection and flux calculation
-/// - **Rendering**: O(N) PSF convolution and noise generation  
-/// - **Memory**: Minimal duplication of catalog data
-/// - **Thread safety**: Immutable scene allows concurrent rendering
-///
-/// # Simulation Workflow
-/// 1. **Scene Creation**: Project stars from catalog to detector coordinates
-/// 2. **Flux Calculation**: Compute realistic photoelectron rates
-/// 3. **Image Rendering**: Generate detector images with noise models
-/// 4. **Analysis**: Extract photometry and astrometry from simulated data
-///
-/// # Usage
-/// The Scene struct represents a complete astronomical observation, combining instrument hardware,
-/// stellar targets, pointing direction, and exposure parameters. Create a scene from a star catalog
-/// using `Scene::from_catalog()`, or from pre-computed stars using `Scene::from_stars()`.
-#[derive(Debug, Clone)]
-pub struct Scene {
-    /// Complete satellite hardware configuration defining the observation system.
-    ///
-    /// Includes telescope optics (aperture, focal length, efficiency), detector
-    /// characteristics (QE, noise, pixel scale), and environmental conditions
-    /// (operating temperature, background radiation levels).
-    pub satellite_config: SatelliteConfig,
-
-    /// Stellar targets projected to detector pixel coordinates.
-    ///
-    /// Contains stars from the input catalog that fall within the field of view,
-    /// with pre-computed pixel positions and expected photoelectron fluxes.
-    /// Includes proper handling of field edge effects and PSF truncation.
-    pub stars: Vec<StarInFrame>,
-
-    /// Celestial pointing center for the observation.
-    ///
-    /// Defines the RA/Dec coordinates of the detector center, used as the
-    /// reference point for all coordinate transformations and field geometry
-    /// calculations. Typically the optical axis direction.
-    pub pointing_center: Equatorial,
-
-    /// Solar angular coordinates for zodiacal light calculation.
-    ///
-    /// Defines the angular position of the observation relative to the Sun,
-    /// used to calculate the intensity of zodiacal light background which
-    /// varies significantly based on solar elongation and ecliptic latitude.
-    pub zodiacal_coordinates: SolarAngularCoordinates,
-}
-
-impl Scene {
-    /// Create astronomical scene from star catalog with automatic coordinate projection.
-    ///
-    /// Constructs a complete observation scene by projecting catalog stars onto
-    /// the detector plane and calculating realistic photoelectron fluxes. Handles
-    /// all coordinate transformations, field geometry, and photometric scaling
-    /// automatically based on the instrument configuration.
-    ///
-    /// # Projection Pipeline
-    /// 1. **Field calculation**: Determine FOV boundaries with PSF padding
-    /// 2. **Coordinate transformation**: RA/Dec → tangent plane → pixel coordinates
-    /// 3. **Flux calculation**: Magnitude → photoelectrons using QE curves
-    /// 4. **Field filtering**: Retain only stars within detector boundaries
-    /// 5. **Edge handling**: Proper PSF truncation for partially-visible stars
-    ///
-    /// # Photometric Accuracy
-    /// - **Magnitude system**: Standard astronomical photometry (Johnson UBV)
-    /// - **Color conversion**: B-V color indices to spectral energy distributions
-    /// - **Quantum efficiency**: Wavelength-dependent detector response
-    /// - **Aperture scaling**: Flux proportional to telescope collecting area
-    ///
-    /// # Arguments
-    /// * `satellite_config` - Complete instrument configuration
-    /// * `catalog_stars` - Input star catalog with positions and photometry
-    /// * `pointing_center` - RA/Dec coordinates of field center
-    /// * `exposure_time` - Integration time as Duration
-    ///
-    /// # Returns
-    /// Complete Scene with projected stars ready for rendering
-    ///
-    /// # Usage
-    /// Create a scene from a star catalog by projecting catalog stars onto the detector plane.
-    /// The scene automatically handles coordinate transformations, field-of-view calculations,
-    /// and flux computations based on the instrument configuration.
-    pub fn from_catalog(
-        satellite_config: SatelliteConfig,
-        catalog_stars: Vec<StarData>,
-        pointing_center: Equatorial,
-        zodiacal_coordinates: SolarAngularCoordinates,
-    ) -> Self {
-        // Calculate PSF padding for edge handling (same as render_star_field)
-        let airy_pix = satellite_config.airy_disk_pixel_space();
-        let padding = airy_pix.first_zero() * 2.0;
-
-        // Convert stars to references (required by project_stars_to_pixels)
-        let star_refs: Vec<&StarData> = catalog_stars.iter().collect();
-
-        // Use shared projection function
-        let projected_stars =
-            project_stars_to_pixels(&star_refs, &pointing_center, &satellite_config, padding);
-
-        Self {
-            satellite_config,
-            stars: projected_stars,
-            pointing_center,
-            zodiacal_coordinates,
-        }
-    }
-
-    /// Create astronomical scene from pre-computed stars with known pixel positions.
-    ///
-    /// Constructs a scene directly from pre-projected stars, bypassing the catalog
-    /// projection pipeline. This is useful for testing scenarios where stars are
-    /// placed at specific pixel locations with known fluxes, such as PSF analysis,
-    /// detector characterization, or controlled experiments.
-    ///
-    /// # Use Cases
-    /// - **Detector testing**: Place stars at known positions for centroid accuracy
-    /// - **PSF characterization**: Test star detection with controlled placement
-    /// - **Noise floor analysis**: Single star detection threshold experiments
-    /// - **Algorithm validation**: Known ground truth for detection algorithms
-    ///
-    /// # Arguments
-    /// * `satellite_config` - Complete instrument configuration
-    /// * `stars` - Pre-computed stars with pixel positions and fluxes
-    /// * `pointing_center` - Nominal field center (for metadata/compatibility)
-    /// * `exposure_time` - Integration time for scaling and noise models
-    /// * `zodiacal_coordinates` - Solar position for background calculation
-    ///
-    /// # Returns
-    /// Complete Scene ready for rendering with the provided stars
-    ///
-    /// # Examples
-    /// # Usage
-    /// Create a scene with pre-computed stars at specific pixel positions. This is useful for
-    /// testing scenarios where you need precise control over star placement, such as detector
-    /// characterization, PSF analysis, or algorithm validation with known ground truth.
-    pub fn from_stars(
-        satellite_config: SatelliteConfig,
-        stars: Vec<StarInFrame>,
-        pointing_center: Equatorial,
-        zodiacal_coordinates: SolarAngularCoordinates,
-    ) -> Self {
-        Self {
-            satellite_config,
-            stars,
-            pointing_center,
-            zodiacal_coordinates,
-        }
-    }
-
-    /// Render complete astronomical image with realistic detector effects.
-    ///
-    /// Generates a fully realistic detector image from the pre-projected stellar
-    /// field, including accurate PSF modeling, background contributions, noise
-    /// statistics, and detector artifacts. Produces both the raw floating-point
-    /// image and quantized detector output.
-    ///
-    /// # Rendering Pipeline
-    /// 1. **PSF Convolution**: Apply Airy disk pattern to each star
-    /// 2. **Background Addition**: Zodiacal light + thermal backgrounds
-    /// 3. **Noise Generation**: Shot noise, read noise, dark current
-    /// 4. **Detector Effects**: Quantum efficiency, linearity, saturation
-    /// 5. **Quantization**: ADU conversion with realistic bit depth
-    ///
-    /// # Physical Accuracy
-    /// - **PSF modeling**: Diffraction-limited Airy disks with optical aberrations
-    /// - **Background scaling**: Position-dependent zodiacal light brightness
-    /// - **Noise statistics**: Poisson photon noise + Gaussian detector noise
-    /// - **Saturation handling**: Well depth limits with realistic overflow
-    ///
-    /// # Output Components
-    /// - **Quantized image**: Realistic detector output in ADU units
-    /// - **Float image**: High-precision electron image before quantization
-    /// - **Background map**: Spatial background distribution
-    /// - **Metadata**: Exposure parameters, noise levels, saturation statistics
-    ///
-    /// # Arguments
-    /// Uses the zodiacal coordinates stored in the scene for background calculation.
-    ///
-    /// # Returns
-    /// Complete RenderingResult with image data and diagnostic information
-    ///
-    /// # Examples
-    /// # Usage
-    /// Render the scene to produce a complete astronomical image with realistic detector effects.
-    /// The output includes the quantized detector image, zodiacal background map, and metadata
-    /// about rendered stars. Use the stored zodiacal coordinates for background calculation.
-    pub fn render(&self, exposure: &Duration) -> RenderingResult {
-        self.render_with_seed(exposure, None)
-    }
-
-    /// Render the scene with a specific RNG seed for reproducible results
-    pub fn render_with_seed(&self, exposure: &Duration, seed: Option<u64>) -> RenderingResult {
-        // Use the new Renderer for the actual work
-        let renderer = Renderer::from_stars(&self.stars, self.satellite_config.clone());
-        let rendered = renderer.render_with_seed(exposure, &self.zodiacal_coordinates, seed);
-
-        // Convert back to RenderingResult for backwards compatibility
-        RenderingResult {
-            quantized_image: rendered.quantized_image,
-            star_image: rendered.star_image,
-            zodiacal_image: rendered.zodiacal_image,
-            sensor_noise_image: rendered.sensor_noise_image,
-            rendered_stars: rendered.rendered_stars,
-            sensor_config: self.satellite_config.sensor.clone(),
-        }
-    }
-
-    /// Create a renderer for efficient multi-exposure rendering.
-    ///
-    /// Returns a `Renderer` that caches star projections and base images,
-    /// enabling efficient generation of multiple exposures without re-calculating
-    /// star positions and fluxes. This is particularly useful for:
-    /// - Time series observations with varying exposure times
-    /// - Detector characterization across different integration periods
-    /// - Monte Carlo simulations with consistent star fields
-    ///
-    /// # Performance Benefits
-    /// - **One-time star projection**: O(N) computation done once
-    /// - **Cached base image**: 1-second star field pre-rendered
-    /// - **Fast exposure scaling**: O(1) linear scaling per exposure
-    /// - **Fresh noise generation**: Maintains statistical independence
-    pub fn create_renderer(&self) -> Renderer {
-        Renderer::from_stars(&self.stars, self.satellite_config.clone())
-    }
-}
-
-/// Multi-sensor observation scene for focal plane arrays.
-///
-/// Like [`Scene`] but operates across a full sensor array. One catalog query
-/// and one gnomonic projection covers the entire focal plane, then stars are
-/// routed to individual sensors for rendering.
+/// Handles the full pipeline from star catalog to rendered detector images.
+/// A single sensor is treated as a 1-element array, so the same code path
+/// handles both single-sensor and multi-sensor (e.g. SPENCER) configurations.
 ///
 /// # Architecture
 ///
 /// ```text
-/// Catalog → projection to focal plane mm → route to sensors → per-sensor render
+/// Catalog → focal plane mm projection → route to sensors → per-sensor render
 /// ```
 ///
 /// Each sensor gets its own `SatelliteConfig` (QE, noise, pixel scale) and
 /// produces an independent `RenderingResult`.
+///
+/// # Usage
+///
+/// For a single sensor, wrap your `SatelliteConfig` via
+/// `FocalPlaneConfig::from_satellite()`. For multi-sensor arrays, construct
+/// a `FocalPlaneConfig` directly with a `SensorArray`.
 #[derive(Debug, Clone)]
-pub struct ArrayScene {
-    /// Focal plane array configuration (telescope + sensor array + temperature)
+pub struct Scene {
+    /// Focal plane configuration (telescope + sensor array + temperature)
     pub focal_plane: FocalPlaneConfig,
 
     /// Stars projected and routed to each sensor's pixel coordinates.
@@ -374,15 +132,15 @@ pub struct ArrayScene {
     pub zodiacal_coordinates: SolarAngularCoordinates,
 }
 
-impl ArrayScene {
-    /// Create an array scene from a star catalog.
+impl Scene {
+    /// Create scene from a star catalog with automatic projection and routing.
     ///
     /// Projects all catalog stars onto the focal plane with one pass, then
     /// routes them to individual sensors. PSF padding is computed from the
     /// telescope's Airy disk at the first sensor's pixel scale.
     ///
     /// # Arguments
-    /// * `focal_plane` - Complete focal plane array configuration
+    /// * `focal_plane` - Focal plane configuration (single or multi-sensor)
     /// * `catalog_stars` - Star catalog covering the full array field
     /// * `pointing_center` - Telescope pointing direction
     /// * `zodiacal_coordinates` - Solar position for background calculation
@@ -392,7 +150,6 @@ impl ArrayScene {
         pointing_center: Equatorial,
         zodiacal_coordinates: SolarAngularCoordinates,
     ) -> Self {
-        // Compute PSF padding in mm from the first sensor's Airy disk
         let first_sat = focal_plane
             .satellite_for_sensor(0)
             .expect("Array must have at least one sensor");
@@ -405,6 +162,25 @@ impl ArrayScene {
             project_stars_to_focal_plane(&star_refs, &pointing_center, &focal_plane, padding_mm);
         let per_sensor_stars = route_stars_to_sensors(&fp_stars, &focal_plane, padding_mm);
 
+        Self {
+            focal_plane,
+            per_sensor_stars,
+            pointing_center,
+            zodiacal_coordinates,
+        }
+    }
+
+    /// Create scene from pre-computed stars with known pixel positions.
+    ///
+    /// Bypasses catalog projection. Each inner `Vec<StarInFrame>` corresponds
+    /// to one sensor in the array. For a single-sensor scene, pass
+    /// `vec![stars]`.
+    pub fn from_stars(
+        focal_plane: FocalPlaneConfig,
+        per_sensor_stars: Vec<Vec<StarInFrame>>,
+        pointing_center: Equatorial,
+        zodiacal_coordinates: SolarAngularCoordinates,
+    ) -> Self {
         Self {
             focal_plane,
             per_sensor_stars,

--- a/simulator/src/sims/mod.rs
+++ b/simulator/src/sims/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod scene_runner;
 pub mod single_detection;
+pub mod trajectory;

--- a/simulator/src/sims/trajectory.rs
+++ b/simulator/src/sims/trajectory.rs
@@ -1,0 +1,534 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::Duration;
+
+use image::{ImageBuffer, Luma};
+use log::info;
+use starfield::catalogs::StarData;
+use starfield::Equatorial;
+use thiserror::Error;
+
+use crate::hardware::satellite::FocalPlaneConfig;
+use crate::image_proc::render::{project_stars_to_focal_plane, StarInFocalPlane, StarInFrame};
+use crate::photometry::photoconversion::SourceFlux;
+use crate::photometry::zodiacal::SolarAngularCoordinates;
+use crate::scene::Scene;
+use crate::star_math::star_data_to_fluxes;
+use shared::units::LengthExt;
+
+#[derive(Debug, Error)]
+pub enum TrajectoryError {
+    #[error("trajectory must have at least 2 waypoints, got {0}")]
+    TooFewWaypoints(usize),
+
+    #[error("waypoint times must be strictly monotonically increasing (index {index}: {earlier:?} >= {later:?})")]
+    NonMonotonicTimes {
+        index: usize,
+        earlier: Duration,
+        later: Duration,
+    },
+
+    #[error("time {0:?} is outside trajectory range [{1:?}, {2:?}]")]
+    TimeOutOfRange(Duration, Duration, Duration),
+
+    #[error("focal plane has no sensors")]
+    NoSensors,
+
+    #[error("image write error: {0}")]
+    ImageWrite(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct Waypoint {
+    pub time: Duration,
+    pub pointing: Equatorial,
+}
+
+#[derive(Debug, Clone)]
+pub struct Trajectory {
+    waypoints: Vec<Waypoint>,
+}
+
+impl Trajectory {
+    pub fn new(waypoints: Vec<Waypoint>) -> Result<Self, TrajectoryError> {
+        if waypoints.len() < 2 {
+            return Err(TrajectoryError::TooFewWaypoints(waypoints.len()));
+        }
+        for i in 1..waypoints.len() {
+            if waypoints[i].time <= waypoints[i - 1].time {
+                return Err(TrajectoryError::NonMonotonicTimes {
+                    index: i,
+                    earlier: waypoints[i - 1].time,
+                    later: waypoints[i].time,
+                });
+            }
+        }
+        Ok(Self { waypoints })
+    }
+
+    pub fn from_endpoints(
+        start: Equatorial,
+        end: Equatorial,
+        duration: Duration,
+    ) -> Result<Self, TrajectoryError> {
+        Self::new(vec![
+            Waypoint {
+                time: Duration::ZERO,
+                pointing: start,
+            },
+            Waypoint {
+                time: duration,
+                pointing: end,
+            },
+        ])
+    }
+
+    pub fn start_time(&self) -> Duration {
+        self.waypoints.first().unwrap().time
+    }
+
+    pub fn end_time(&self) -> Duration {
+        self.waypoints.last().unwrap().time
+    }
+
+    pub fn waypoints(&self) -> &[Waypoint] {
+        &self.waypoints
+    }
+
+    /// Interpolate pointing at a given time using SLERP on the celestial sphere.
+    pub fn pointing_at(&self, t: Duration) -> Result<Equatorial, TrajectoryError> {
+        let start = self.start_time();
+        let end = self.end_time();
+        if t < start || t > end {
+            return Err(TrajectoryError::TimeOutOfRange(t, start, end));
+        }
+
+        // Find bracketing segment
+        let seg_idx = self
+            .waypoints
+            .windows(2)
+            .position(|w| t >= w[0].time && t <= w[1].time)
+            .unwrap_or(self.waypoints.len() - 2);
+
+        let w0 = &self.waypoints[seg_idx];
+        let w1 = &self.waypoints[seg_idx + 1];
+
+        let seg_duration = (w1.time - w0.time).as_secs_f64();
+        if seg_duration == 0.0 {
+            return Ok(w0.pointing);
+        }
+        let frac = (t - w0.time).as_secs_f64() / seg_duration;
+
+        Ok(slerp_equatorial(&w0.pointing, &w1.pointing, frac))
+    }
+
+    /// Generate evenly spaced frame times from start to end (inclusive of start).
+    pub fn frame_times(&self, timestep: Duration) -> Vec<Duration> {
+        let mut times = Vec::new();
+        let mut t = self.start_time();
+        let end = self.end_time();
+        while t <= end {
+            times.push(t);
+            t += timestep;
+        }
+        times
+    }
+}
+
+/// Convert Equatorial (ra, dec in radians) to unit 3D vector.
+fn equatorial_to_xyz(eq: &Equatorial) -> [f64; 3] {
+    let cos_dec = eq.dec.cos();
+    [cos_dec * eq.ra.cos(), cos_dec * eq.ra.sin(), eq.dec.sin()]
+}
+
+/// Convert unit 3D vector back to Equatorial.
+fn xyz_to_equatorial(xyz: [f64; 3]) -> Equatorial {
+    let [x, y, z] = xyz;
+    let ra = y.atan2(x);
+    let dec = z.atan2((x * x + y * y).sqrt());
+    // Normalize RA to [0, 2pi)
+    let ra = if ra < 0.0 {
+        ra + 2.0 * std::f64::consts::PI
+    } else {
+        ra
+    };
+    Equatorial::new(ra, dec)
+}
+
+/// Spherical linear interpolation between two Equatorial pointings.
+fn slerp_equatorial(a: &Equatorial, b: &Equatorial, t: f64) -> Equatorial {
+    let va = equatorial_to_xyz(a);
+    let vb = equatorial_to_xyz(b);
+
+    let dot = (va[0] * vb[0] + va[1] * vb[1] + va[2] * vb[2]).clamp(-1.0, 1.0);
+    let omega = dot.acos();
+
+    if omega.abs() < 1e-12 {
+        return *a;
+    }
+
+    let sin_omega = omega.sin();
+    let sa = ((1.0 - t) * omega).sin() / sin_omega;
+    let sb = (t * omega).sin() / sin_omega;
+
+    let result = [
+        sa * va[0] + sb * vb[0],
+        sa * va[1] + sb * vb[1],
+        sa * va[2] + sb * vb[2],
+    ];
+
+    xyz_to_equatorial(result)
+}
+
+/// Angular distance in degrees between two Equatorial pointings (haversine).
+fn angular_distance_deg(a: &Equatorial, b: &Equatorial) -> f64 {
+    let va = equatorial_to_xyz(a);
+    let vb = equatorial_to_xyz(b);
+    let dot = (va[0] * vb[0] + va[1] * vb[1] + va[2] * vb[2]).clamp(-1.0, 1.0);
+    dot.acos().to_degrees()
+}
+
+/// Compute the FOV envelope for a trajectory: a single (center, diameter_deg) that
+/// encompasses all pointings plus the base instrument FOV.
+pub fn fov_envelope(trajectory: &Trajectory, base_fov_deg: f64) -> (Equatorial, f64) {
+    // Average unit vectors to find centroid
+    let mut cx = 0.0;
+    let mut cy = 0.0;
+    let mut cz = 0.0;
+    let n = trajectory.waypoints.len() as f64;
+    for wp in &trajectory.waypoints {
+        let [x, y, z] = equatorial_to_xyz(&wp.pointing);
+        cx += x;
+        cy += y;
+        cz += z;
+    }
+    cx /= n;
+    cy /= n;
+    cz /= n;
+
+    // Normalize
+    let mag = (cx * cx + cy * cy + cz * cz).sqrt();
+    if mag < 1e-15 {
+        // Degenerate: pointings span a half-sphere. Use first waypoint as center.
+        let center = trajectory.waypoints[0].pointing;
+        let max_dist = trajectory
+            .waypoints
+            .iter()
+            .map(|wp| angular_distance_deg(&center, &wp.pointing))
+            .fold(0.0f64, f64::max);
+        return (center, 2.0 * max_dist + base_fov_deg);
+    }
+
+    let center = xyz_to_equatorial([cx / mag, cy / mag, cz / mag]);
+    let max_dist = trajectory
+        .waypoints
+        .iter()
+        .map(|wp| angular_distance_deg(&center, &wp.pointing))
+        .fold(0.0f64, f64::max);
+
+    (center, 2.0 * max_dist + base_fov_deg)
+}
+
+/// Route focal-plane stars to sensors with a flux cache to avoid redundant computation.
+///
+/// Identical to `route_stars_to_sensors` in render.rs but caches `star_data_to_fluxes()`
+/// results keyed by (star_id, sensor_index). For trajectory rendering where the same
+/// stars appear across many frames on the same sensors, this eliminates repeated
+/// Simpson's rule integration.
+pub fn route_stars_to_sensors_cached(
+    fp_stars: &[StarInFocalPlane],
+    focal_plane: &FocalPlaneConfig,
+    padding_mm: f64,
+    flux_cache: &mut HashMap<(u64, usize), SourceFlux>,
+) -> Vec<Vec<StarInFrame>> {
+    let sensor_count = focal_plane.array.sensor_count();
+    let mut per_sensor_stars: Vec<Vec<StarInFrame>> =
+        (0..sensor_count).map(|_| Vec::new()).collect();
+
+    let satellites: Vec<_> = (0..sensor_count)
+        .filter_map(|i| focal_plane.satellite_for_sensor(i))
+        .collect();
+
+    for fp_star in fp_stars {
+        let hits = focal_plane
+            .array
+            .mm_to_pixels_padded(fp_star.x_mm, fp_star.y_mm, padding_mm);
+        for (pixel_x, pixel_y, sensor_idx) in hits {
+            let key = (fp_star.star.id, sensor_idx);
+            let flux = flux_cache
+                .entry(key)
+                .or_insert_with(|| star_data_to_fluxes(&fp_star.star, &satellites[sensor_idx]))
+                .clone();
+            per_sensor_stars[sensor_idx].push(StarInFrame {
+                x: pixel_x,
+                y: pixel_y,
+                spot: flux,
+                star: fp_star.star,
+            });
+        }
+    }
+
+    for stars in &mut per_sensor_stars {
+        stars.sort_by(|a, b| {
+            a.spot
+                .electrons
+                .flux
+                .partial_cmp(&b.spot.electrons.flux)
+                .unwrap()
+        });
+    }
+
+    per_sensor_stars
+}
+
+/// Save a single-sensor u16 image as 16-bit grayscale PNG.
+fn save_u16_png(image: &ndarray::Array2<u16>, path: &Path) -> Result<(), TrajectoryError> {
+    let (height, width) = image.dim();
+    let raw: Vec<u16> = image.iter().copied().collect();
+    let img: ImageBuffer<Luma<u16>, Vec<u16>> =
+        ImageBuffer::from_raw(width as u32, height as u32, raw)
+            .ok_or_else(|| TrajectoryError::ImageWrite("buffer size mismatch".into()))?;
+    img.save(path)
+        .map_err(|e| TrajectoryError::ImageWrite(e.to_string()))
+}
+
+/// Configuration for rendering a trajectory sequence.
+pub struct TrajectoryRenderConfig<'a> {
+    /// Trajectory defining the pointing over time.
+    pub trajectory: &'a Trajectory,
+    /// Time between frames.
+    pub timestep: Duration,
+    /// Exposure duration per frame.
+    pub exposure: Duration,
+    /// Focal plane hardware configuration.
+    pub focal_plane: &'a FocalPlaneConfig,
+    /// Pre-fetched catalog stars covering the full trajectory envelope.
+    pub catalog_stars: &'a [StarData],
+    /// Solar angular coordinates for zodiacal background.
+    pub zodiacal: SolarAngularCoordinates,
+    /// Directory to write 16-bit PNG output frames.
+    pub output_dir: &'a Path,
+    /// Optional RNG seed for reproducible noise.
+    pub base_seed: Option<u64>,
+}
+
+/// Render a sequence of frames along a trajectory, writing 16-bit PNG files.
+///
+/// Queries the star catalog conceptually "once" (caller provides pre-fetched stars),
+/// then for each frame along the trajectory: re-projects, routes to sensors, renders,
+/// and writes 16-bit PNG output.
+///
+/// Returns the total number of frames rendered.
+pub fn render_trajectory(config: &TrajectoryRenderConfig) -> Result<usize, TrajectoryError> {
+    let TrajectoryRenderConfig {
+        trajectory,
+        timestep,
+        exposure,
+        focal_plane,
+        catalog_stars,
+        zodiacal,
+        output_dir,
+        base_seed,
+    } = config;
+    let sensor_count = focal_plane.array.sensor_count();
+    if sensor_count == 0 {
+        return Err(TrajectoryError::NoSensors);
+    }
+
+    let first_sat = focal_plane
+        .satellite_for_sensor(0)
+        .ok_or(TrajectoryError::NoSensors)?;
+    let airy_pix = first_sat.airy_disk_pixel_space();
+    let pixel_size_mm = first_sat.sensor.pixel_size().as_millimeters();
+    let padding_mm = airy_pix.first_zero() * 2.0 * pixel_size_mm;
+
+    let star_refs: Vec<&StarData> = catalog_stars.iter().collect();
+    let frame_times = trajectory.frame_times(*timestep);
+    let total_frames = frame_times.len();
+
+    info!("Rendering {total_frames} frames across {sensor_count} sensors");
+
+    let mut flux_cache: HashMap<(u64, usize), SourceFlux> = HashMap::new();
+    let single_sensor = sensor_count == 1;
+
+    for (frame_idx, &t) in frame_times.iter().enumerate() {
+        let pointing = trajectory.pointing_at(t)?;
+
+        let fp_stars = project_stars_to_focal_plane(&star_refs, &pointing, focal_plane, padding_mm);
+        let per_sensor_stars =
+            route_stars_to_sensors_cached(&fp_stars, focal_plane, padding_mm, &mut flux_cache);
+
+        let scene = Scene::from_stars(
+            (*focal_plane).clone(),
+            per_sensor_stars,
+            pointing,
+            *zodiacal,
+        );
+
+        let seed = base_seed.map(|s| s + frame_idx as u64);
+        let results = scene.render_with_seed(exposure, seed);
+
+        for (sensor_idx, result) in results.iter().enumerate() {
+            let filename = if single_sensor {
+                format!("frame_{frame_idx:06}.png")
+            } else {
+                format!("frame_{frame_idx:06}_sensor_{sensor_idx:02}.png")
+            };
+            let path = output_dir.join(&filename);
+            save_u16_png(&result.quantized_image, &path)?;
+        }
+
+        if (frame_idx + 1) % 10 == 0 || frame_idx + 1 == total_frames {
+            info!(
+                "Rendered frame {}/{} (t={:.3}s)",
+                frame_idx + 1,
+                total_frames,
+                t.as_secs_f64()
+            );
+        }
+    }
+
+    info!(
+        "Flux cache: {} entries ({} cache-eligible lookups saved)",
+        flux_cache.len(),
+        flux_cache.len()
+    );
+
+    Ok(total_frames)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn make_pointing(ra_deg: f64, dec_deg: f64) -> Equatorial {
+        Equatorial::from_degrees(ra_deg, dec_deg)
+    }
+
+    #[test]
+    fn test_trajectory_requires_two_waypoints() {
+        let result = Trajectory::new(vec![Waypoint {
+            time: Duration::ZERO,
+            pointing: make_pointing(0.0, 0.0),
+        }]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_trajectory_rejects_non_monotonic() {
+        let result = Trajectory::new(vec![
+            Waypoint {
+                time: Duration::from_secs(5),
+                pointing: make_pointing(0.0, 0.0),
+            },
+            Waypoint {
+                time: Duration::from_secs(3),
+                pointing: make_pointing(10.0, 10.0),
+            },
+        ]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_slerp_endpoints() {
+        let a = make_pointing(10.0, 20.0);
+        let b = make_pointing(20.0, 30.0);
+
+        let at_start = slerp_equatorial(&a, &b, 0.0);
+        let at_end = slerp_equatorial(&a, &b, 1.0);
+
+        assert!((at_start.ra_degrees() - a.ra_degrees()).abs() < 1e-10);
+        assert!((at_start.dec_degrees() - a.dec_degrees()).abs() < 1e-10);
+        assert!((at_end.ra_degrees() - b.ra_degrees()).abs() < 1e-10);
+        assert!((at_end.dec_degrees() - b.dec_degrees()).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_slerp_midpoint_is_between() {
+        let a = make_pointing(10.0, 20.0);
+        let b = make_pointing(20.0, 20.0);
+        let mid = slerp_equatorial(&a, &b, 0.5);
+
+        assert!(mid.ra_degrees() > 10.0 && mid.ra_degrees() < 20.0);
+        assert!((mid.dec_degrees() - 20.0).abs() < 0.5);
+    }
+
+    #[test]
+    fn test_pointing_at_returns_endpoints() {
+        let traj = Trajectory::from_endpoints(
+            make_pointing(10.0, 20.0),
+            make_pointing(20.0, 30.0),
+            Duration::from_secs(10),
+        )
+        .unwrap();
+
+        let start = traj.pointing_at(Duration::ZERO).unwrap();
+        assert!((start.ra_degrees() - 10.0).abs() < 1e-10);
+
+        let end = traj.pointing_at(Duration::from_secs(10)).unwrap();
+        assert!((end.ra_degrees() - 20.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_pointing_at_rejects_out_of_range() {
+        let traj = Trajectory::from_endpoints(
+            make_pointing(10.0, 20.0),
+            make_pointing(20.0, 30.0),
+            Duration::from_secs(10),
+        )
+        .unwrap();
+
+        assert!(traj.pointing_at(Duration::from_secs(11)).is_err());
+    }
+
+    #[test]
+    fn test_frame_times() {
+        let traj = Trajectory::from_endpoints(
+            make_pointing(0.0, 0.0),
+            make_pointing(10.0, 0.0),
+            Duration::from_secs(10),
+        )
+        .unwrap();
+
+        let times = traj.frame_times(Duration::from_secs(2));
+        assert_eq!(times.len(), 6); // 0, 2, 4, 6, 8, 10
+        assert_eq!(times[0], Duration::ZERO);
+        assert_eq!(times[5], Duration::from_secs(10));
+    }
+
+    #[test]
+    fn test_fov_envelope_covers_trajectory() {
+        let traj = Trajectory::from_endpoints(
+            make_pointing(10.0, 0.0),
+            make_pointing(20.0, 0.0),
+            Duration::from_secs(10),
+        )
+        .unwrap();
+
+        let base_fov = 1.0;
+        let (center, diameter) = fov_envelope(&traj, base_fov);
+
+        // Center should be near RA=15, Dec=0
+        assert!((center.ra_degrees() - 15.0).abs() < 1.0);
+        assert!(center.dec_degrees().abs() < 1.0);
+
+        // Diameter should cover the 10 degree span plus the base FOV
+        assert!(diameter >= 10.0 + base_fov);
+    }
+
+    #[test]
+    fn test_angular_distance() {
+        let a = make_pointing(0.0, 0.0);
+        let b = make_pointing(90.0, 0.0);
+        let dist = angular_distance_deg(&a, &b);
+        assert!((dist - 90.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_angular_distance_same_point() {
+        let a = make_pointing(45.0, 30.0);
+        let dist = angular_distance_deg(&a, &a);
+        assert!(dist.abs() < 1e-10);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds complete rendering pipeline for multi-sensor focal plane arrays (e.g. 4-sensor SPENCER layout)
- Single catalog query and gnomonic projection covers the full array, then stars are routed to individual sensors for per-sensor rendering
- Architecture: `Catalog → focal plane mm projection → sensor routing → per-sensor pixel render`

### New types and functions

| Component | File | Purpose |
|-----------|------|---------|
| `mm_to_pixels_padded` | `sensor_array.rs` | Route mm-space points to sensor(s) with PSF bleed padding |
| `FocalPlaneConfig` | `satellite.rs` | Array-level analog of `SatelliteConfig` (telescope + array + temp) |
| `StarInFocalPlane` | `render.rs` | Intermediate mm-space star representation |
| `project_stars_to_focal_plane` | `render.rs` | Gnomonic projection to focal plane mm via `StarProjector` trick |
| `route_stars_to_sensors` | `render.rs` | Route focal plane stars to per-sensor pixel coords with flux |
| `ArrayScene` | `scene.rs` | High-level multi-sensor scene: `from_catalog()` → `render()` |
| `field_diameter_for_array` | `star_math.rs` | Angular diameter enclosing full array for catalog queries |

### Key design decisions

- **StarProjector reuse**: Sets `radians_per_pixel = rad_per_mm * mm_per_virtual_pixel` so output coordinates are in mm, avoiding changes to the shared crate
- **PSF bleed handling**: `mm_to_pixels_padded` expands sensor bounds so stars near gaps can contribute to multiple sensors
- **Independent noise**: Each sensor gets a unique RNG seed (base + sensor_index) for reproducible but independent noise
- **Backward compatible**: Existing `Scene` and `SatelliteConfig` unchanged

## Test plan

- [x] `mm_to_pixels_padded`: 4 tests covering no-padding, outside bounds, with padding, gap between sensors
- [x] `FocalPlaneConfig`: 4 tests covering creation, satellite_for_sensor, from_satellite roundtrip, plate_scale
- [x] `project_stars_to_focal_plane`: center star maps to (0,0) mm
- [x] `route_stars_to_sensors`: center star routes to sensor pixel center
- [x] All 195 existing tests pass
- [x] `cargo clippy -- -W clippy::all` clean