### PR TITLE
Update starfield to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -1836,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "meter-math"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations#f05be50dfdc975faece267747647503474a041a9"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?branch=meawoppl%2Fupdate-starfield-0.9.1#a2288fe4a3f03e801905d463245d46f3478f8deb"
 dependencies = [
  "log",
  "nalgebra",
@@ -2948,9 +2949,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sgp4"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9467b9a7be8485ed8be0f336d399c8f32c0fcd60686e7dd2ed3dab75c9a73eb3"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations#f05be50dfdc975faece267747647503474a041a9"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?branch=meawoppl%2Fupdate-starfield-0.9.1#a2288fe4a3f03e801905d463245d46f3478f8deb"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2991,7 +3003,7 @@ dependencies = [
 [[package]]
 name = "shared-wasm"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations#f05be50dfdc975faece267747647503474a041a9"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?branch=meawoppl%2Fupdate-starfield-0.9.1#a2288fe4a3f03e801905d463245d46f3478f8deb"
 dependencies = [
  "gloo-net",
  "num-traits",
@@ -3129,9 +3141,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "starfield"
-version = "0.2.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1da925e5d997bbfc1f019c7f9b3a7b70c395b9bd4909f9a113514ec4bc9bd4"
+checksum = "e158470f36d5b9842de2cce6d602890a5d95a3c6f0afbbd669a20756a6ad6413"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -3139,9 +3151,11 @@ dependencies = [
  "clap",
  "flate2",
  "image 0.24.9",
+ "indicatif",
  "lazy_static",
  "log",
  "md5",
+ "memmap2",
  "nalgebra",
  "ndarray",
  "num",
@@ -3151,9 +3165,11 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
+ "sgp4",
  "term_size",
  "thiserror 1.0.69",
  "time",
+ "uom",
 ]
 
 [[package]]

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-starfield = "0.2.3" # Star catalog functionality
+starfield = "0.9.1" # Star catalog functionality
 image = "0.25" # Image processing
 ndarray = { version = "0.16", features = [
     "rayon",
@@ -25,9 +25,9 @@ log = "0.4"                   # Logging facade
 env_logger = "0.11"           # Environment-based logger
 url = "2.5"                   # URL parsing and manipulation
 # Foundation crates from cfl-foundations
-shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", default-features = false, features = ["frame-writer"] }
-meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations" }
-shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations" }
+shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", branch = "meawoppl/update-starfield-0.9.1", default-features = false, features = ["frame-writer"] }
+meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", branch = "meawoppl/update-starfield-0.9.1" }
+shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", branch = "meawoppl/update-starfield-0.9.1" }
 
 rand = "0.9"
 rand_distr = "0.5"

--- a/simulator/src/bin/sensor-view-stats.rs
+++ b/simulator/src/bin/sensor-view-stats.rs
@@ -31,7 +31,7 @@ use shared::units::{Angle, AngleExt, LengthExt, Temperature, TemperatureExt};
 use simulator::hardware::SatelliteConfig;
 use simulator::shared_args::{parse_additional_stars, SensorModel, TelescopeModel};
 use simulator::star_math::field_diameter;
-use starfield::catalogs::binary_catalog::BinaryCatalog;
+use starfield::catalogs::minimal_catalog::MinimalCatalog;
 use starfield::catalogs::StarPosition;
 use starfield::framelib::random::RandomEquatorial;
 use starfield::Equatorial;
@@ -111,7 +111,7 @@ struct Args {
 
 /// Efficiently process all stars once for all projector configurations
 fn process_all_stars_efficiently(
-    catalog: &BinaryCatalog,
+    catalog: &MinimalCatalog,
     projector_configs: &[ProjectorConfig],
 ) -> Vec<ProjectorResult> {
     let num_configs = projector_configs.len();
@@ -318,7 +318,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Loading binary star catalog from: {}",
         args.catalog.display()
     );
-    let catalog = BinaryCatalog::load(&args.catalog)?;
+    let catalog = MinimalCatalog::load(&args.catalog)?;
 
     let additional_stars = parse_additional_stars()?;
     info!(
@@ -334,7 +334,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         catalog.description(),
         all_stars.len() - catalog.len()
     );
-    let catalog = BinaryCatalog::from_stars(all_stars, &updated_description);
+    let catalog = MinimalCatalog::from_stars(all_stars, &updated_description);
 
     info!("Setting up {} random sky pointings...", args.pointings);
 

--- a/simulator/src/shared_args.rs
+++ b/simulator/src/shared_args.rs
@@ -91,7 +91,7 @@
 //! Demonstrates how to use the automatic bright star augmentation feature:
 //! - Use SharedSimulationArgs::parse() to parse command-line arguments
 //! - Call args.load_catalog() to load the catalog with embedded bright stars included
-//! - The returned catalog combines the specified binary catalog with additional bright stars
+//! - The returned catalog combines the specified minimal catalog with additional bright stars
 //!
 //! # Error Handling and Validation
 //!
@@ -156,7 +156,7 @@ use crate::hardware::telescope::TelescopeConfig;
 use crate::photometry::zodiacal::SolarAngularCoordinates;
 use clap::{Parser, ValueEnum};
 use log::info;
-use starfield::catalogs::binary_catalog::{BinaryCatalog, MinimalStar};
+use starfield::catalogs::minimal_catalog::{MinimalCatalog, MinimalStar};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -601,25 +601,25 @@ pub struct SharedSimulationArgs {
 impl SharedSimulationArgs {
     /// Load a binary star catalog from the configured path and union with additional bright stars
     ///
-    /// This method loads a BinaryCatalog and adds additional bright stars from embedded CSV data.
+    /// This method loads a MinimalCatalog and adds additional bright stars from embedded CSV data.
     ///
     /// # Returns
-    /// * `Result<BinaryCatalog, Box<dyn std::error::Error>>` - The loaded catalog with additional stars or error
+    /// * `Result<MinimalCatalog, Box<dyn std::error::Error>>` - The loaded catalog with additional stars or error
     ///
     /// # Usage
     /// Load a catalog with automatic bright star augmentation:
-    /// - Loads the binary catalog from the specified path
+    /// - Loads the minimal catalog from the specified path
     /// - Automatically adds embedded bright stars from CSV data
     /// - Returns a combined catalog with collision-free star IDs
     /// - Reports clear error messages if catalog loading fails
-    pub fn load_catalog(&self) -> Result<BinaryCatalog, Box<dyn std::error::Error>> {
+    pub fn load_catalog(&self) -> Result<MinimalCatalog, Box<dyn std::error::Error>> {
         info!(
             "Loading binary star catalog from: {}",
             self.catalog.display()
         );
         let start_time = Instant::now();
 
-        let mut catalog = BinaryCatalog::load(&self.catalog).map_err(|e| {
+        let mut catalog = MinimalCatalog::load(&self.catalog).map_err(|e| {
             format!(
                 "Failed to load catalog from '{}': {}",
                 self.catalog.display(),
@@ -655,7 +655,7 @@ impl SharedSimulationArgs {
             catalog.description(),
             all_stars.len() - catalog.len()
         );
-        catalog = BinaryCatalog::from_stars(all_stars, &updated_description);
+        catalog = MinimalCatalog::from_stars(all_stars, &updated_description);
 
         Ok(catalog)
     }


### PR DESCRIPTION
## Summary
- Bump starfield dependency from 0.2.3 to 0.9.1 in `simulator/Cargo.toml`
- Rename `BinaryCatalog` to `MinimalCatalog` (API rename in starfield 0.9.1)
- Updated 3 source files: `catalog_stats.rs`, `sensor-view-stats.rs`, `shared_args.rs`

Part of coordinated update across cfl-foundations, focalplane, and meter-sim.

## Test plan
- [x] All tests pass
- [x] Clippy clean