### PR TITLE
Remove stale starfield branch pins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,7 @@ dependencies = [
 [[package]]
 name = "meter-math"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?branch=meawoppl%2Fupdate-starfield-0.9.1#a2288fe4a3f03e801905d463245d46f3478f8deb"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations#77e2d2dca8bc15cbd8825fe1a22cf1a1d56cc6a1"
 dependencies = [
  "log",
  "nalgebra",
@@ -2962,7 +2962,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?branch=meawoppl%2Fupdate-starfield-0.9.1#a2288fe4a3f03e801905d463245d46f3478f8deb"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations#77e2d2dca8bc15cbd8825fe1a22cf1a1d56cc6a1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3003,7 +3003,7 @@ dependencies = [
 [[package]]
 name = "shared-wasm"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?branch=meawoppl%2Fupdate-starfield-0.9.1#a2288fe4a3f03e801905d463245d46f3478f8deb"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations#77e2d2dca8bc15cbd8825fe1a22cf1a1d56cc6a1"
 dependencies = [
  "gloo-net",
  "num-traits",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -25,9 +25,9 @@ log = "0.4"                   # Logging facade
 env_logger = "0.11"           # Environment-based logger
 url = "2.5"                   # URL parsing and manipulation
 # Foundation crates from cfl-foundations
-shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", branch = "meawoppl/update-starfield-0.9.1", default-features = false, features = ["frame-writer"] }
-meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", branch = "meawoppl/update-starfield-0.9.1" }
-shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", branch = "meawoppl/update-starfield-0.9.1" }
+shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", default-features = false, features = ["frame-writer"] }
+meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations" }
+shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations" }
 
 rand = "0.9"
 rand_distr = "0.5"


### PR DESCRIPTION
Remove branch = "meawoppl/update-starfield-0.9.1" pins from simulator/Cargo.toml now that the upstream branches have been merged to main.