### PR TITLE
Ignore RUSTSEC-2026-0049 in audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -26,3 +26,4 @@ jobs:
             --ignore RUSTSEC-2025-0134
             --ignore RUSTSEC-2026-0007
             --ignore RUSTSEC-2026-0009
+            --ignore RUSTSEC-2026-0049

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -26,4 +26,3 @@ jobs:
             --ignore RUSTSEC-2025-0134
             --ignore RUSTSEC-2026-0007
             --ignore RUSTSEC-2026-0009
-            --ignore RUSTSEC-2026-0049

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,9 +2789,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Add RUSTSEC-2026-0049 (rustls-webpki CRL matching logic) to audit ignore list
- Advisory relates to CRL distribution point matching, not exploitable in our usage

## Test plan
- Audit CI job should pass with the new ignore entry