### PR TITLE
Triage audit ignore list

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -17,6 +17,9 @@ jobs:
     - name: Install cargo-audit
       run: cargo install cargo-audit --locked
 
+    # Ignored advisories are all transitive-only warnings blocked by upstream
+    # pins in CosmicFrontierLabs/cfl-foundations. Tracking:
+    # https://github.com/CosmicFrontierLabs/cfl-foundations/issues/7
     - name: Run security audit
       run: >
             cargo audit
@@ -24,5 +27,3 @@ jobs:
             --ignore RUSTSEC-2024-0436
             --ignore RUSTSEC-2025-0119
             --ignore RUSTSEC-2025-0134
-            --ignore RUSTSEC-2026-0007
-            --ignore RUSTSEC-2026-0009

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,9 +279,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"
@@ -2409,9 +2409,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2420,9 +2420,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2473,7 +2473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -2503,7 +2503,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -2789,9 +2789,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2979,7 +2979,7 @@ dependencies = [
  "num-complex",
  "num-traits",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_distr",
  "rayon",
@@ -3075,7 +3075,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "plotters",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_distr",
  "rayon",
  "shared",
@@ -3160,7 +3160,7 @@ dependencies = [
  "ndarray",
  "num",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "reqwest 0.11.27",
  "serde",
@@ -3378,9 +3378,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -3399,9 +3399,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
## Summary

Triaged the 6 advisories previously `--ignore`d in `.github/workflows/audit.yml` per the policy: prefer upgrade, else file upstream issue, else justify with a comment.

Net: 2 direct fixes via `cargo update`, 4 kept with an issue-linking comment pointing at `cfl-foundations`. (Also picked up 4 incidental patch-level bumps for advisories that had appeared since the last ignore-list refresh — `rustls-webpki` x3 and `rand` x1 — so the workflow is actually green, not just less red.)

## Per-advisory outcomes

| Advisory | Crate | Outcome | Reference |
|----------|-------|---------|-----------|
| RUSTSEC-2026-0007 | `bytes 1.11.0` | Upgraded to `1.11.1` via `cargo update`, ignore removed | patched in-range |
| RUSTSEC-2026-0009 | `time 0.3.46` | Upgraded to `0.3.47` via `cargo update`, ignore removed | patched in-range |
| RUSTSEC-2020-0163 | `term_size` (unmaintained) | Ignore kept; upstream fix tracked | `starfield 0.9.1` is pinned by `cfl-foundations/shared`; `starfield >= 0.10` drops `term_size`. See [cfl-foundations#7](https://github.com/CosmicFrontierLabs/cfl-foundations/issues/7) |
| RUSTSEC-2025-0134 | `rustls-pemfile 1.x` (unmaintained) | Ignore kept; same upstream fix | Enters via `reqwest 0.11` through `starfield 0.9.1`; `starfield >= 0.10` moves to `reqwest 0.12`. Same [cfl-foundations#7](https://github.com/CosmicFrontierLabs/cfl-foundations/issues/7) |
| RUSTSEC-2025-0119 | `number_prefix` (unmaintained) | Ignore kept; upstream fix tracked | `indicatif = "0.17"` pinned in `cfl-foundations/shared`; `indicatif >= 0.18` switches to `unit-prefix`. Same [cfl-foundations#7](https://github.com/CosmicFrontierLabs/cfl-foundations/issues/7) |
| RUSTSEC-2024-0436 | `paste` (unmaintained) | Ignore kept; upstream fix tracked | `nalgebra = "0.32"` pinned in `cfl-foundations/shared` and `meter-math`; pulls `simba 0.8` which uses `paste`. `nalgebra >= 0.34` drops `paste`. Same [cfl-foundations#7](https://github.com/CosmicFrontierLabs/cfl-foundations/issues/7) |

Also incidentally fixed (not in the original 6, but the last scheduled audit on `main` was already failing on these):

| Advisory | Crate | Outcome |
|----------|-------|---------|
| RUSTSEC-2026-0097 | `rand 0.8.5` / `0.9.2` (unsound) | Upgraded to `0.8.6` / `0.9.4` |
| RUSTSEC-2026-0098, -0099, -0104 | `rustls-webpki 0.103.10` | Upgraded to `0.103.13` |

## Upstream tracking

Filed [CosmicFrontierLabs/cfl-foundations#7](https://github.com/CosmicFrontierLabs/cfl-foundations/issues/7) requesting the 3 upstream bumps (starfield, indicatif, nalgebra) that would clear the remaining 4 ignores.

## Test plan

- [x] `cargo build` on the resulting lock
- [x] `cargo test --lib` (185 passed, 0 failed)
- [x] `cargo audit` with only the 4 remaining ignores reports 0 vulnerabilities and 1 allowed warning (yanked `core2`, which is the flip-side of the kept `paste` transitive chain and noted upstream)
- [ ] CI `Security Audit` run green on this PR