### PR TITLE
Add multi-sensor focal plane array rendering

### DIFF
--- a/simulator/src/hardware/mod.rs
+++ b/simulator/src/hardware/mod.rs
@@ -35,7 +35,7 @@ pub mod sensor_noise;
 pub mod telescope;
 
 pub use gyro::GyroModel;
-pub use satellite::SatelliteConfig;
+pub use satellite::{FocalPlaneConfig, SatelliteConfig};
 pub use sensor::SensorConfig;
 pub use sensor_array::SensorArray;
 pub use telescope::TelescopeConfig;

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -87,9 +87,9 @@ pub use hardware::telescope::TelescopeConfig;
 pub use photometry::quantum_efficiency::QuantumEfficiency;
 pub use photometry::spectrum::{Spectrum, CGS};
 pub use photometry::trapezoid::trap_integrate;
-pub use scene::Scene;
+pub use scene::{ArrayScene, Scene};
 pub use shared::image_proc::histogram_stretch::stretch_histogram;
-pub use star_math::{field_diameter, pixel_scale, star_data_to_fluxes};
+pub use star_math::{field_diameter, field_diameter_for_array, pixel_scale, star_data_to_fluxes};
 pub use starfield::catalogs::StarPosition;
 
 #[cfg(test)]


### PR DESCRIPTION
Part 1 of 3 in the multi-sensor rendering stack.

Stacks on: `main`

## Changes

- Add `mm_to_pixels_padded` to `SensorArray` for PSF bleed routing
- Add `FocalPlaneConfig` combining telescope + sensor array + temp
- Add `project_stars_to_focal_plane` using mm-space projection
- Add `route_stars_to_sensors` for per-sensor pixel routing
- Add `ArrayScene` for one-query multi-sensor rendering
- Add `field_diameter_for_array` for catalog query sizing
- Re-export new types from `hardware/mod.rs` and `lib.rs`

## Test plan

Local pre-push checks all green:

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (195 passed)
- [x] `cargo clippy --workspace -- -W clippy::all`
- [x] `cargo fmt --check`