### PR TITLE
Use prebuilt cargo-tarpaulin binary in CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,9 @@ jobs:
       uses: ./.github/actions/setup
 
     - name: Install cargo-tarpaulin
-      run: cargo install cargo-tarpaulin
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-tarpaulin
 
     - name: Generate coverage
       run: cargo tarpaulin --out xml --output-dir coverage/


### PR DESCRIPTION
## Summary

\`cargo install cargo-tarpaulin\` without \`--locked\` re-resolves tarpaulin's deps on every CI run, so any transitive MSRV bump immediately breaks coverage. Last week \`cargo-platform@0.3.3\` raised MSRV to rustc 1.91 while our CI is on 1.88, which is why coverage has been failing on every PR (#29, #35, …).

Switching to [taiki-e/install-action](https://github.com/taiki-e/install-action)'s prebuilt binary makes coverage immune to this class of failure and drops install time from ~5 min to ~2 s.

## Test plan

- [ ] Coverage job installs cargo-tarpaulin via prebuilt binary
- [ ] Coverage job completes end-to-end (xml generated, Codecov upload attempted)