### PR TITLE
Migrate Trajectory to quaternion orientation with roll

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2853,6 +2853,7 @@ dependencies = [
  "indicatif",
  "log",
  "meter-math",
+ "nalgebra",
  "ndarray",
  "num_cpus",
  "once_cell",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -24,6 +24,7 @@ clap = { version = "4.5", features = [
 log = "0.4"                   # Logging facade
 env_logger = "0.11"           # Environment-based logger
 url = "2.5"                   # URL parsing and manipulation
+nalgebra = "0.32"             # Linear algebra (quaternions for orientation)
 # Foundation crates from cfl-foundations
 shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", default-features = false, features = ["frame-writer"] }
 meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations" }

--- a/simulator/src/bin/motion_simulator.rs
+++ b/simulator/src/bin/motion_simulator.rs
@@ -81,6 +81,22 @@ struct Args {
 
     #[arg(
         long,
+        default_value = "0",
+        allow_hyphen_values = true,
+        help = "Roll angle (degrees) at the start waypoint"
+    )]
+    start_roll: f64,
+
+    #[arg(
+        long,
+        default_value = "0",
+        allow_hyphen_values = true,
+        help = "Roll angle (degrees) at the end waypoint"
+    )]
+    end_roll: f64,
+
+    #[arg(
+        long,
         default_value = "1s",
         help = "Time between frames (e.g., '1s', '500ms')"
     )]
@@ -121,7 +137,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     let focal_plane = FocalPlaneConfig::from_satellite(&satellite);
 
-    let trajectory = Trajectory::from_endpoints(args.start, args.end, args.duration.0)?;
+    let trajectory = if args.start_roll == 0.0 && args.end_roll == 0.0 {
+        Trajectory::from_endpoints(args.start, args.end, args.duration.0)?
+    } else {
+        Trajectory::from_endpoints_with_roll(
+            args.start,
+            args.start_roll.to_radians(),
+            args.end,
+            args.end_roll.to_radians(),
+            args.duration.0,
+        )?
+    };
 
     let base_fov_deg = field_diameter_for_array(&focal_plane)
         .map(|a| a.as_degrees())
@@ -136,6 +162,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         args.end.ra_degrees(),
         args.end.dec_degrees(),
         args.duration.0.as_secs_f64()
+    );
+    info!(
+        "Roll: start {:.3}° → end {:.3}°",
+        args.start_roll, args.end_roll
     );
     info!(
         "FOV envelope: center RA {:.4}° Dec {:.4}°, diameter {:.4}°",

--- a/simulator/src/image_proc/render.rs
+++ b/simulator/src/image_proc/render.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use nalgebra::UnitQuaternion;
 use ndarray::Array2;
 use starfield::{catalogs::StarData, Equatorial};
 
@@ -9,6 +10,7 @@ use crate::{
         SensorConfig,
     },
     photometry::{photoconversion::SourceFlux, zodiacal::SolarAngularCoordinates, ZodiacalLight},
+    sims::orientation::{boresight_of, orientation_from_pointing, roll_of},
     star_math::star_data_to_fluxes,
 };
 use meter_math::Locatable2d;
@@ -423,19 +425,36 @@ pub struct StarInFocalPlane {
 
 /// Project stars from celestial coordinates to focal plane mm coordinates.
 ///
-/// Uses `StarProjector` in mm-space mode (radians_per_pixel = radians_per_mm)
+/// Thin backwards-compatible wrapper around
+/// [`project_stars_to_focal_plane_oriented`] using zero roll. Uses
+/// `StarProjector` in mm-space mode (radians_per_pixel = radians_per_mm)
 /// to project all catalog stars onto the focal plane. Stars outside the padded
 /// AABB are filtered out.
 ///
 /// # Arguments
 /// * `stars` - Catalog stars to project
 /// * `center` - Telescope pointing direction
-/// * `telescope` - Telescope config (for plate scale / focal length)
-/// * `aabb_mm` - Total sensor array bounding box (min_x, min_y, max_x, max_y) in mm
+/// * `focal_plane` - Focal plane / telescope config (for plate scale / focal length)
 /// * `padding_mm` - PSF bleed padding around the AABB in mm
 pub fn project_stars_to_focal_plane(
     stars: &[&StarData],
     center: &Equatorial,
+    focal_plane: &FocalPlaneConfig,
+    padding_mm: f64,
+) -> Vec<StarInFocalPlane> {
+    let orientation = orientation_from_pointing(center, 0.0);
+    project_stars_to_focal_plane_oriented(stars, &orientation, focal_plane, padding_mm)
+}
+
+/// Orientation-aware variant of [`project_stars_to_focal_plane`] that applies
+/// the waypoint roll as a 2D rotation in mm-space about the focal-plane AABB
+/// center before bounds-checking.
+///
+/// Motion-blur and multi-frame renderers should prefer this entry point so
+/// that roll participates end-to-end in the mm-space pipeline.
+pub fn project_stars_to_focal_plane_oriented(
+    stars: &[&StarData],
+    orientation: &UnitQuaternion<f64>,
     focal_plane: &FocalPlaneConfig,
     padding_mm: f64,
 ) -> Vec<StarInFocalPlane> {
@@ -458,9 +477,13 @@ pub fn project_stars_to_focal_plane(
     let center_x_mm = (min_x + max_x) / 2.0;
     let center_y_mm = (min_y + max_y) / 2.0;
 
+    let pointing = boresight_of(orientation);
+    let roll_rad = roll_of(orientation);
+    let (sin_roll, cos_roll) = roll_rad.sin_cos();
+
     // Configure projector: each "pixel" = mm_per_virt_pixel mm
     let rad_per_virt_pixel = focal_plane.plate_scale_rad_per_mm() * mm_per_virt_pixel;
-    let projector = StarProjector::new(center, rad_per_virt_pixel, virt_width, virt_height);
+    let projector = StarProjector::new(&pointing, rad_per_virt_pixel, virt_width, virt_height);
 
     let mut result = Vec::new();
     for &star in stars {
@@ -469,9 +492,18 @@ pub fn project_stars_to_focal_plane(
             None => continue,
         };
 
-        // Convert virtual pixel coords back to mm in array space
-        let x_mm = (vx - virt_width as f64 / 2.0) * mm_per_virt_pixel + center_x_mm;
-        let y_mm = (virt_height as f64 / 2.0 - vy) * mm_per_virt_pixel + center_y_mm;
+        // Convert virtual pixel coords back to mm in array space.
+        let x_mm_raw = (vx - virt_width as f64 / 2.0) * mm_per_virt_pixel + center_x_mm;
+        let y_mm_raw = (virt_height as f64 / 2.0 - vy) * mm_per_virt_pixel + center_y_mm;
+
+        // Apply roll as a 2D rotation about the AABB center. The body +Z axis
+        // points out of the focal plane toward the sky, so a positive roll
+        // (right-hand rule about +Z) rotates the star pattern on the focal
+        // plane in the same sense in the (x, y) plane.
+        let dx = x_mm_raw - center_x_mm;
+        let dy = y_mm_raw - center_y_mm;
+        let x_mm = center_x_mm + cos_roll * dx - sin_roll * dy;
+        let y_mm = center_y_mm + sin_roll * dx + cos_roll * dy;
 
         // Bounds check against padded AABB
         if x_mm < min_x - padding_mm
@@ -489,6 +521,75 @@ pub fn project_stars_to_focal_plane(
         });
     }
     result
+}
+
+/// Per-sensor projection interface for orientation-aware rendering.
+///
+/// Given a full spacecraft orientation (boresight + roll), this trait
+/// projects a star into a specific sensor's pixel coordinate frame.
+/// Motion-blur and parallel renderers are intended to target this interface
+/// so that different projection backends (e.g. GPU, analytic, mm-space) can
+/// be swapped in without disturbing the calling pipeline.
+pub trait FocalPlaneProjector {
+    /// Returns `Some((pixel_x, pixel_y))` if the star lands on the specified
+    /// sensor (including the padded PSF bleed region), `None` otherwise.
+    /// Pixel coordinates may be sub-pixel.
+    fn project_to_sensor(
+        &self,
+        star: &StarData,
+        orientation: &UnitQuaternion<f64>,
+        sensor_idx: usize,
+    ) -> Option<(f64, f64)>;
+
+    /// Number of sensors addressable by this projector.
+    fn sensor_count(&self) -> usize;
+}
+
+/// Reference implementation of [`FocalPlaneProjector`] backed by the existing
+/// mm-space pipeline. Per-star queries go through a full
+/// [`project_stars_to_focal_plane_oriented`] call before filtering to the
+/// requested sensor; for batch per-frame rendering the free-function
+/// [`project_stars_to_focal_plane_oriented`] plus `route_stars_to_sensors`
+/// remain the efficient path.
+pub struct MmSpaceProjector<'a> {
+    /// Focal plane / telescope configuration.
+    pub focal_plane: &'a FocalPlaneConfig,
+    /// PSF bleed padding around each sensor, in millimeters.
+    pub padding_mm: f64,
+}
+
+impl<'a> FocalPlaneProjector for MmSpaceProjector<'a> {
+    fn project_to_sensor(
+        &self,
+        star: &StarData,
+        orientation: &UnitQuaternion<f64>,
+        sensor_idx: usize,
+    ) -> Option<(f64, f64)> {
+        let stars = [star];
+        let star_refs: Vec<&StarData> = stars.to_vec();
+        let fp_stars = project_stars_to_focal_plane_oriented(
+            &star_refs,
+            orientation,
+            self.focal_plane,
+            self.padding_mm,
+        );
+        let fp_star = fp_stars.first()?;
+        let hits =
+            self.focal_plane
+                .array
+                .mm_to_pixels_padded(fp_star.x_mm, fp_star.y_mm, self.padding_mm);
+        hits.into_iter().find_map(|(px, py, idx)| {
+            if idx == sensor_idx {
+                Some((px, py))
+            } else {
+                None
+            }
+        })
+    }
+
+    fn sensor_count(&self) -> usize {
+        self.focal_plane.array.sensor_count()
+    }
 }
 
 /// Route focal-plane stars to individual sensors with pixel coordinates and flux.
@@ -1071,5 +1172,163 @@ mod tests {
         let (w, h) = GSENSE4040BSI.dimensions.get_pixel_width_height();
         assert_relative_eq!(routed[0][0].x, w as f64 / 2.0, epsilon = 1.0);
         assert_relative_eq!(routed[0][0].y, h as f64 / 2.0, epsilon = 1.0);
+    }
+
+    #[test]
+    fn test_zero_roll_matches_unoriented_path() {
+        use crate::hardware::sensor::models::GSENSE4040BSI;
+        use crate::hardware::sensor_array::SensorArray;
+        use crate::hardware::telescope::TelescopeConfig;
+        use shared::units::{LengthExt, TemperatureExt};
+
+        let telescope = TelescopeConfig::new(
+            "Test",
+            shared::units::Length::from_meters(0.5),
+            shared::units::Length::from_meters(2.5),
+            0.8,
+        );
+        let fp = FocalPlaneConfig::new(
+            telescope,
+            SensorArray::single(GSENSE4040BSI.clone()),
+            shared::units::Temperature::from_celsius(-10.0),
+        );
+
+        let pointing = Equatorial::from_degrees(123.0, 15.0);
+        // Place a small catalog of offset stars around the pointing.
+        let offsets_deg = [(0.0, 0.0), (0.1, 0.05), (-0.2, 0.15), (0.05, -0.12)];
+        let stars: Vec<StarData> = offsets_deg
+            .iter()
+            .enumerate()
+            .map(|(i, (dra, ddec))| StarData {
+                id: i as u64,
+                magnitude: 10.0,
+                position: Equatorial::from_degrees(
+                    pointing.ra_degrees() + dra,
+                    pointing.dec_degrees() + ddec,
+                ),
+                b_v: Some(0.6),
+            })
+            .collect();
+        let refs: Vec<&StarData> = stars.iter().collect();
+
+        let padding_mm = 2.0;
+        let legacy = project_stars_to_focal_plane(&refs, &pointing, &fp, padding_mm);
+        let oriented = project_stars_to_focal_plane_oriented(
+            &refs,
+            &orientation_from_pointing(&pointing, 0.0),
+            &fp,
+            padding_mm,
+        );
+
+        assert_eq!(legacy.len(), oriented.len());
+        for (a, b) in legacy.iter().zip(oriented.iter()) {
+            assert_relative_eq!(a.x_mm, b.x_mm, epsilon = 1e-12);
+            assert_relative_eq!(a.y_mm, b.y_mm, epsilon = 1e-12);
+            assert_eq!(a.star.id, b.star.id);
+        }
+    }
+
+    #[test]
+    fn test_focal_plane_roll_rotates_star_position() {
+        use crate::hardware::sensor::models::GSENSE4040BSI;
+        use crate::hardware::sensor_array::SensorArray;
+        use crate::hardware::telescope::TelescopeConfig;
+        use shared::units::{LengthExt, TemperatureExt};
+
+        let telescope = TelescopeConfig::new(
+            "Test",
+            shared::units::Length::from_meters(0.5),
+            shared::units::Length::from_meters(2.5),
+            0.8,
+        );
+        let fp = FocalPlaneConfig::new(
+            telescope,
+            SensorArray::single(GSENSE4040BSI.clone()),
+            shared::units::Temperature::from_celsius(-10.0),
+        );
+
+        // Single-sensor array at the origin -> AABB is centered on (0, 0)
+        // in mm, so the 2D roll rotation pivots about (0, 0).
+        let pointing = Equatorial::from_degrees(45.0, 30.0);
+        // Small RA offset gives a star at roughly (r_mm, 0) relative to the
+        // AABB center at zero roll.
+        let offset_star = StarData {
+            id: 1,
+            magnitude: 10.0,
+            position: Equatorial::from_degrees(pointing.ra_degrees() + 0.1, pointing.dec_degrees()),
+            b_v: Some(0.6),
+        };
+        let refs = vec![&offset_star];
+        let padding_mm = 5.0;
+
+        let unrolled = project_stars_to_focal_plane_oriented(
+            &refs,
+            &orientation_from_pointing(&pointing, 0.0),
+            &fp,
+            padding_mm,
+        );
+        assert_eq!(unrolled.len(), 1);
+        let (x0, y0) = (unrolled[0].x_mm, unrolled[0].y_mm);
+        assert!(x0.abs() > 0.05, "expected meaningful x offset, got {x0}");
+        assert!(y0.abs() < 0.05, "expected near-zero y offset, got {y0}");
+
+        // Roll by +pi/2 -> right-hand rule about +Z sends (x, 0) to (0, x).
+        let rolled = project_stars_to_focal_plane_oriented(
+            &refs,
+            &orientation_from_pointing(&pointing, std::f64::consts::FRAC_PI_2),
+            &fp,
+            padding_mm,
+        );
+        assert_eq!(rolled.len(), 1);
+        let (x1, y1) = (rolled[0].x_mm, rolled[0].y_mm);
+        assert_relative_eq!(x1, -y0, epsilon = 1e-9);
+        assert_relative_eq!(y1, x0, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn test_mm_space_projector_matches_batch_oriented() {
+        use crate::hardware::sensor::models::GSENSE4040BSI;
+        use crate::hardware::sensor_array::SensorArray;
+        use crate::hardware::telescope::TelescopeConfig;
+        use shared::units::{LengthExt, TemperatureExt};
+
+        let telescope = TelescopeConfig::new(
+            "Test",
+            shared::units::Length::from_meters(0.5),
+            shared::units::Length::from_meters(2.5),
+            0.8,
+        );
+        let fp = FocalPlaneConfig::new(
+            telescope,
+            SensorArray::single(GSENSE4040BSI.clone()),
+            shared::units::Temperature::from_celsius(-10.0),
+        );
+        let pointing = Equatorial::from_degrees(45.0, 30.0);
+        let star = StarData {
+            id: 7,
+            magnitude: 10.0,
+            position: Equatorial::from_degrees(
+                pointing.ra_degrees() + 0.05,
+                pointing.dec_degrees() - 0.02,
+            ),
+            b_v: Some(0.6),
+        };
+        let orientation = orientation_from_pointing(&pointing, 0.3);
+        let padding_mm = 3.0;
+
+        let projector = MmSpaceProjector {
+            focal_plane: &fp,
+            padding_mm,
+        };
+        assert_eq!(projector.sensor_count(), 1);
+        let hit = projector.project_to_sensor(&star, &orientation, 0).unwrap();
+
+        // Compare against the batch path routed to the same sensor.
+        let refs = vec![&star];
+        let fp_stars = project_stars_to_focal_plane_oriented(&refs, &orientation, &fp, padding_mm);
+        let routed = route_stars_to_sensors(&fp_stars, &fp, padding_mm);
+        assert_eq!(routed[0].len(), 1);
+        assert_relative_eq!(hit.0, routed[0][0].x, epsilon = 1e-9);
+        assert_relative_eq!(hit.1, routed[0][0].y, epsilon = 1e-9);
     }
 }

--- a/simulator/src/sims/mod.rs
+++ b/simulator/src/sims/mod.rs
@@ -1,5 +1,6 @@
 //! Simulation modules for various experiments
 
+pub mod orientation;
 pub mod scene_runner;
 pub mod single_detection;
 pub mod trajectory;

--- a/simulator/src/sims/orientation.rs
+++ b/simulator/src/sims/orientation.rs
@@ -1,0 +1,170 @@
+//! Spacecraft orientation utilities built on [`nalgebra::UnitQuaternion`].
+//!
+//! The body frame used throughout the simulator is:
+//! - `+Z` points along the telescope boresight (outward).
+//! - `+X` points toward local "east": perpendicular to the celestial pole
+//!   vector and oriented in the direction of increasing right ascension at
+//!   the current pointing.
+//! - `+Y` points toward local "north": toward increasing declination at the
+//!   current pointing.
+//!
+//! The roll angle is a rotation about the body `+Z` axis following the
+//! right-hand rule; a positive roll rotates the body `+X` axis toward the
+//! body `+Y` axis in the body frame.
+
+use nalgebra::{Matrix3, Rotation3, UnitQuaternion, Vector3};
+use starfield::Equatorial;
+
+/// Numerical threshold (in radians) below which a pointing is considered to
+/// be "at the pole" for roll extraction purposes.
+const POLE_EPSILON: f64 = 1e-9;
+
+/// Build the world-from-body orientation quaternion for a given pointing
+/// (boresight direction) and roll.
+///
+/// The base (roll = 0) rotation is constructed so that the body frame
+/// columns map directly onto the world-frame local triad at the pointing:
+/// body `+X` -> local east, body `+Y` -> local north, body `+Z` ->
+/// boresight. A final rotation about the body `+Z` axis applies the roll
+/// using the right-hand rule.
+pub fn orientation_from_pointing(eq: &Equatorial, roll_rad: f64) -> UnitQuaternion<f64> {
+    let ra = eq.ra;
+    let dec = eq.dec;
+    let (sin_ra, cos_ra) = ra.sin_cos();
+    let (sin_dec, cos_dec) = dec.sin_cos();
+
+    // World-frame local triad at the pointing.
+    let east = Vector3::new(-sin_ra, cos_ra, 0.0);
+    let north = Vector3::new(-sin_dec * cos_ra, -sin_dec * sin_ra, cos_dec);
+    let bore = Vector3::new(cos_dec * cos_ra, cos_dec * sin_ra, sin_dec);
+
+    // Columns are (east, north, bore) so body +X -> east, +Y -> north, +Z -> bore.
+    let m = Matrix3::from_columns(&[east, north, bore]);
+    let base = UnitQuaternion::from_rotation_matrix(&Rotation3::from_matrix_unchecked(m));
+    let twist = UnitQuaternion::from_axis_angle(&Vector3::z_axis(), roll_rad);
+
+    base * twist
+}
+
+/// Extract the boresight (pointing) direction of an orientation quaternion
+/// as an [`Equatorial`] coordinate.
+pub fn boresight_of(q: &UnitQuaternion<f64>) -> Equatorial {
+    let z = q * Vector3::z();
+    let ra = z.y.atan2(z.x);
+    let r_xy = (z.x * z.x + z.y * z.y).sqrt();
+    let dec = z.z.atan2(r_xy);
+    Equatorial::new(ra, dec)
+}
+
+/// Extract the roll angle (about the body `+Z` axis) from an orientation
+/// quaternion. Returns `0.0` when the boresight is within [`POLE_EPSILON`]
+/// of a celestial pole, where the east direction degenerates.
+///
+/// Uses the convention that the "canonical no-roll" body `+X` vector at the
+/// current boresight is the local east direction
+/// `(-sin(ra), cos(ra), 0)`; the returned roll is the signed angle (about
+/// the boresight) from that canonical vector to the body `+X` vector rotated
+/// into the world frame by `q`.
+pub fn roll_of(q: &UnitQuaternion<f64>) -> f64 {
+    let bore = boresight_of(q);
+    if (std::f64::consts::FRAC_PI_2 - bore.dec.abs()).abs() < POLE_EPSILON {
+        return 0.0;
+    }
+
+    // Body +X rotated to world frame.
+    let ex_world = q * Vector3::x();
+
+    // Canonical no-roll east direction at the current boresight.
+    let east = Vector3::new(-bore.ra.sin(), bore.ra.cos(), 0.0);
+
+    // Boresight direction for signing the angle via right-hand rule.
+    let bore_vec = Vector3::new(
+        bore.dec.cos() * bore.ra.cos(),
+        bore.dec.cos() * bore.ra.sin(),
+        bore.dec.sin(),
+    );
+
+    let cos_roll = east.dot(&ex_world).clamp(-1.0, 1.0);
+    let cross = east.cross(&ex_world);
+    let sin_roll = cross.dot(&bore_vec);
+    sin_roll.atan2(cos_roll)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use std::f64::consts::{FRAC_PI_2, PI};
+
+    fn eq_deg(ra_deg: f64, dec_deg: f64) -> Equatorial {
+        Equatorial::from_degrees(ra_deg, dec_deg)
+    }
+
+    #[test]
+    fn test_orientation_from_pointing_roundtrip() {
+        let samples = [
+            eq_deg(0.0, 0.0),
+            eq_deg(45.0, 30.0),
+            eq_deg(123.5, -42.0),
+            eq_deg(359.9, 89.9),
+            eq_deg(10.0, -89.9),
+            eq_deg(270.0, 0.0),
+        ];
+        for eq in samples.iter() {
+            let q = orientation_from_pointing(eq, 0.0);
+            let out = boresight_of(&q);
+            // Compare via cartesian vectors so RA wrap at the pole is a non-issue.
+            let expected = Vector3::new(
+                eq.dec.cos() * eq.ra.cos(),
+                eq.dec.cos() * eq.ra.sin(),
+                eq.dec.sin(),
+            );
+            let actual = Vector3::new(
+                out.dec.cos() * out.ra.cos(),
+                out.dec.cos() * out.ra.sin(),
+                out.dec.sin(),
+            );
+            assert_relative_eq!(expected.x, actual.x, epsilon = 1e-9);
+            assert_relative_eq!(expected.y, actual.y, epsilon = 1e-9);
+            assert_relative_eq!(expected.z, actual.z, epsilon = 1e-9);
+        }
+    }
+
+    #[test]
+    fn test_roll_of_recovers_roll() {
+        let samples = [
+            eq_deg(0.0, 0.0),
+            eq_deg(45.0, 30.0),
+            eq_deg(180.0, -15.0),
+            eq_deg(300.0, 60.0),
+        ];
+        let rolls = [-PI * 0.9, -FRAC_PI_2, -0.5, 0.0, 0.5, FRAC_PI_2, PI * 0.9];
+        for eq in samples.iter() {
+            for &r in rolls.iter() {
+                let q = orientation_from_pointing(eq, r);
+                let r_out = roll_of(&q);
+                assert_relative_eq!(r_out, r, epsilon = 1e-9);
+            }
+        }
+    }
+
+    #[test]
+    fn test_roll_of_near_pole_returns_zero() {
+        let eq = Equatorial::new(1.2, FRAC_PI_2 - 1e-12);
+        let q = orientation_from_pointing(&eq, 0.7);
+        // Pole guard returns 0 regardless of constructed roll.
+        assert_eq!(roll_of(&q), 0.0);
+    }
+
+    #[test]
+    fn test_body_x_is_local_east_at_zero_roll() {
+        // With roll=0, body +X should map to the local east vector.
+        let eq = eq_deg(45.0, 20.0);
+        let q = orientation_from_pointing(&eq, 0.0);
+        let ex_world = q * Vector3::x();
+        let east = Vector3::new(-eq.ra.sin(), eq.ra.cos(), 0.0);
+        assert_relative_eq!(ex_world.x, east.x, epsilon = 1e-9);
+        assert_relative_eq!(ex_world.y, east.y, epsilon = 1e-9);
+        assert_relative_eq!(ex_world.z, east.z, epsilon = 1e-9);
+    }
+}

--- a/simulator/src/sims/trajectory.rs
+++ b/simulator/src/sims/trajectory.rs
@@ -4,15 +4,19 @@ use std::time::Duration;
 
 use image::{ImageBuffer, Luma};
 use log::info;
+use nalgebra::UnitQuaternion;
 use starfield::catalogs::StarData;
 use starfield::Equatorial;
 use thiserror::Error;
 
 use crate::hardware::satellite::FocalPlaneConfig;
-use crate::image_proc::render::{project_stars_to_focal_plane, StarInFocalPlane, StarInFrame};
+use crate::image_proc::render::{
+    project_stars_to_focal_plane_oriented, StarInFocalPlane, StarInFrame,
+};
 use crate::photometry::photoconversion::SourceFlux;
 use crate::photometry::zodiacal::SolarAngularCoordinates;
 use crate::scene::Scene;
+use crate::sims::orientation::{boresight_of, orientation_from_pointing};
 use crate::star_math::star_data_to_fluxes;
 use shared::units::LengthExt;
 
@@ -41,7 +45,30 @@ pub enum TrajectoryError {
 #[derive(Debug, Clone)]
 pub struct Waypoint {
     pub time: Duration,
-    pub pointing: Equatorial,
+    pub orientation: UnitQuaternion<f64>,
+}
+
+impl Waypoint {
+    /// Construct a waypoint from an explicit orientation.
+    pub fn new(time: Duration, orientation: UnitQuaternion<f64>) -> Self {
+        Self { time, orientation }
+    }
+
+    /// Construct a waypoint from a pointing with zero roll.
+    pub fn from_pointing(time: Duration, pointing: Equatorial) -> Self {
+        Self {
+            time,
+            orientation: orientation_from_pointing(&pointing, 0.0),
+        }
+    }
+
+    /// Construct a waypoint from a pointing and an explicit roll angle (radians).
+    pub fn from_pointing_and_roll(time: Duration, pointing: Equatorial, roll_rad: f64) -> Self {
+        Self {
+            time,
+            orientation: orientation_from_pointing(&pointing, roll_rad),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -66,20 +93,30 @@ impl Trajectory {
         Ok(Self { waypoints })
     }
 
+    /// Build a two-waypoint trajectory between two pointings, both with zero roll.
     pub fn from_endpoints(
         start: Equatorial,
         end: Equatorial,
         duration: Duration,
     ) -> Result<Self, TrajectoryError> {
         Self::new(vec![
-            Waypoint {
-                time: Duration::ZERO,
-                pointing: start,
-            },
-            Waypoint {
-                time: duration,
-                pointing: end,
-            },
+            Waypoint::from_pointing(Duration::ZERO, start),
+            Waypoint::from_pointing(duration, end),
+        ])
+    }
+
+    /// Build a two-waypoint trajectory between two pointings with explicit
+    /// start/end roll angles (radians).
+    pub fn from_endpoints_with_roll(
+        start: Equatorial,
+        start_roll_rad: f64,
+        end: Equatorial,
+        end_roll_rad: f64,
+        duration: Duration,
+    ) -> Result<Self, TrajectoryError> {
+        Self::new(vec![
+            Waypoint::from_pointing_and_roll(Duration::ZERO, start, start_roll_rad),
+            Waypoint::from_pointing_and_roll(duration, end, end_roll_rad),
         ])
     }
 
@@ -95,15 +132,15 @@ impl Trajectory {
         &self.waypoints
     }
 
-    /// Interpolate pointing at a given time using SLERP on the celestial sphere.
-    pub fn pointing_at(&self, t: Duration) -> Result<Equatorial, TrajectoryError> {
+    /// Interpolate the spacecraft orientation at a given time using
+    /// quaternion SLERP between bracketing waypoints.
+    pub fn orientation_at(&self, t: Duration) -> Result<UnitQuaternion<f64>, TrajectoryError> {
         let start = self.start_time();
         let end = self.end_time();
         if t < start || t > end {
             return Err(TrajectoryError::TimeOutOfRange(t, start, end));
         }
 
-        // Find bracketing segment
         let seg_idx = self
             .waypoints
             .windows(2)
@@ -115,11 +152,20 @@ impl Trajectory {
 
         let seg_duration = (w1.time - w0.time).as_secs_f64();
         if seg_duration == 0.0 {
-            return Ok(w0.pointing);
+            return Ok(w0.orientation);
         }
         let frac = (t - w0.time).as_secs_f64() / seg_duration;
 
-        Ok(slerp_equatorial(&w0.pointing, &w1.pointing, frac))
+        Ok(w0.orientation.slerp(&w1.orientation, frac))
+    }
+
+    /// Interpolate the boresight pointing at a given time.
+    ///
+    /// Convenience wrapper around [`Trajectory::orientation_at`] that
+    /// extracts the boresight direction from the interpolated orientation.
+    pub fn pointing_at(&self, t: Duration) -> Result<Equatorial, TrajectoryError> {
+        let q = self.orientation_at(t)?;
+        Ok(boresight_of(&q))
     }
 
     /// Generate evenly spaced frame times from start to end (inclusive of start).
@@ -155,31 +201,6 @@ fn xyz_to_equatorial(xyz: [f64; 3]) -> Equatorial {
     Equatorial::new(ra, dec)
 }
 
-/// Spherical linear interpolation between two Equatorial pointings.
-fn slerp_equatorial(a: &Equatorial, b: &Equatorial, t: f64) -> Equatorial {
-    let va = equatorial_to_xyz(a);
-    let vb = equatorial_to_xyz(b);
-
-    let dot = (va[0] * vb[0] + va[1] * vb[1] + va[2] * vb[2]).clamp(-1.0, 1.0);
-    let omega = dot.acos();
-
-    if omega.abs() < 1e-12 {
-        return *a;
-    }
-
-    let sin_omega = omega.sin();
-    let sa = ((1.0 - t) * omega).sin() / sin_omega;
-    let sb = (t * omega).sin() / sin_omega;
-
-    let result = [
-        sa * va[0] + sb * vb[0],
-        sa * va[1] + sb * vb[1],
-        sa * va[2] + sb * vb[2],
-    ];
-
-    xyz_to_equatorial(result)
-}
-
 /// Angular distance in degrees between two Equatorial pointings (haversine).
 fn angular_distance_deg(a: &Equatorial, b: &Equatorial) -> f64 {
     let va = equatorial_to_xyz(a);
@@ -196,8 +217,13 @@ pub fn fov_envelope(trajectory: &Trajectory, base_fov_deg: f64) -> (Equatorial, 
     let mut cy = 0.0;
     let mut cz = 0.0;
     let n = trajectory.waypoints.len() as f64;
-    for wp in &trajectory.waypoints {
-        let [x, y, z] = equatorial_to_xyz(&wp.pointing);
+    let pointings: Vec<Equatorial> = trajectory
+        .waypoints
+        .iter()
+        .map(|wp| boresight_of(&wp.orientation))
+        .collect();
+    for p in &pointings {
+        let [x, y, z] = equatorial_to_xyz(p);
         cx += x;
         cy += y;
         cz += z;
@@ -210,20 +236,18 @@ pub fn fov_envelope(trajectory: &Trajectory, base_fov_deg: f64) -> (Equatorial, 
     let mag = (cx * cx + cy * cy + cz * cz).sqrt();
     if mag < 1e-15 {
         // Degenerate: pointings span a half-sphere. Use first waypoint as center.
-        let center = trajectory.waypoints[0].pointing;
-        let max_dist = trajectory
-            .waypoints
+        let center = pointings[0];
+        let max_dist = pointings
             .iter()
-            .map(|wp| angular_distance_deg(&center, &wp.pointing))
+            .map(|p| angular_distance_deg(&center, p))
             .fold(0.0f64, f64::max);
         return (center, 2.0 * max_dist + base_fov_deg);
     }
 
     let center = xyz_to_equatorial([cx / mag, cy / mag, cz / mag]);
-    let max_dist = trajectory
-        .waypoints
+    let max_dist = pointings
         .iter()
-        .map(|wp| angular_distance_deg(&center, &wp.pointing))
+        .map(|p| angular_distance_deg(&center, p))
         .fold(0.0f64, f64::max);
 
     (center, 2.0 * max_dist + base_fov_deg)
@@ -352,9 +376,15 @@ pub fn render_trajectory(config: &TrajectoryRenderConfig) -> Result<usize, Traje
     let single_sensor = sensor_count == 1;
 
     for (frame_idx, &t) in frame_times.iter().enumerate() {
-        let pointing = trajectory.pointing_at(t)?;
+        let orientation = trajectory.orientation_at(t)?;
+        let pointing = boresight_of(&orientation);
 
-        let fp_stars = project_stars_to_focal_plane(&star_refs, &pointing, focal_plane, padding_mm);
+        let fp_stars = project_stars_to_focal_plane_oriented(
+            &star_refs,
+            &orientation,
+            focal_plane,
+            padding_mm,
+        );
         let per_sensor_stars =
             route_stars_to_sensors_cached(&fp_stars, focal_plane, padding_mm, &mut flux_cache);
 
@@ -400,6 +430,7 @@ pub fn render_trajectory(config: &TrajectoryRenderConfig) -> Result<usize, Traje
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sims::orientation::roll_of;
     use std::time::Duration;
 
     fn make_pointing(ra_deg: f64, dec_deg: f64) -> Equatorial {
@@ -408,50 +439,20 @@ mod tests {
 
     #[test]
     fn test_trajectory_requires_two_waypoints() {
-        let result = Trajectory::new(vec![Waypoint {
-            time: Duration::ZERO,
-            pointing: make_pointing(0.0, 0.0),
-        }]);
+        let result = Trajectory::new(vec![Waypoint::from_pointing(
+            Duration::ZERO,
+            make_pointing(0.0, 0.0),
+        )]);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_trajectory_rejects_non_monotonic() {
         let result = Trajectory::new(vec![
-            Waypoint {
-                time: Duration::from_secs(5),
-                pointing: make_pointing(0.0, 0.0),
-            },
-            Waypoint {
-                time: Duration::from_secs(3),
-                pointing: make_pointing(10.0, 10.0),
-            },
+            Waypoint::from_pointing(Duration::from_secs(5), make_pointing(0.0, 0.0)),
+            Waypoint::from_pointing(Duration::from_secs(3), make_pointing(10.0, 10.0)),
         ]);
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_slerp_endpoints() {
-        let a = make_pointing(10.0, 20.0);
-        let b = make_pointing(20.0, 30.0);
-
-        let at_start = slerp_equatorial(&a, &b, 0.0);
-        let at_end = slerp_equatorial(&a, &b, 1.0);
-
-        assert!((at_start.ra_degrees() - a.ra_degrees()).abs() < 1e-10);
-        assert!((at_start.dec_degrees() - a.dec_degrees()).abs() < 1e-10);
-        assert!((at_end.ra_degrees() - b.ra_degrees()).abs() < 1e-10);
-        assert!((at_end.dec_degrees() - b.dec_degrees()).abs() < 1e-10);
-    }
-
-    #[test]
-    fn test_slerp_midpoint_is_between() {
-        let a = make_pointing(10.0, 20.0);
-        let b = make_pointing(20.0, 20.0);
-        let mid = slerp_equatorial(&a, &b, 0.5);
-
-        assert!(mid.ra_degrees() > 10.0 && mid.ra_degrees() < 20.0);
-        assert!((mid.dec_degrees() - 20.0).abs() < 0.5);
     }
 
     #[test]
@@ -464,10 +465,26 @@ mod tests {
         .unwrap();
 
         let start = traj.pointing_at(Duration::ZERO).unwrap();
-        assert!((start.ra_degrees() - 10.0).abs() < 1e-10);
+        assert!((start.ra_degrees() - 10.0).abs() < 1e-9);
+        assert!((start.dec_degrees() - 20.0).abs() < 1e-9);
 
         let end = traj.pointing_at(Duration::from_secs(10)).unwrap();
-        assert!((end.ra_degrees() - 20.0).abs() < 1e-10);
+        assert!((end.ra_degrees() - 20.0).abs() < 1e-9);
+        assert!((end.dec_degrees() - 30.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_pointing_at_midpoint_is_between() {
+        let traj = Trajectory::from_endpoints(
+            make_pointing(10.0, 20.0),
+            make_pointing(20.0, 20.0),
+            Duration::from_secs(10),
+        )
+        .unwrap();
+        let mid = traj.pointing_at(Duration::from_secs(5)).unwrap();
+
+        assert!(mid.ra_degrees() > 10.0 && mid.ra_degrees() < 20.0);
+        assert!((mid.dec_degrees() - 20.0).abs() < 0.5);
     }
 
     #[test]
@@ -530,5 +547,40 @@ mod tests {
         let a = make_pointing(45.0, 30.0);
         let dist = angular_distance_deg(&a, &a);
         assert!(dist.abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_slerp_with_roll_midpoint() {
+        // Hold the pointing fixed so SLERP reduces to a pure roll rotation
+        // about the boresight; the midpoint roll must then be exactly
+        // halfway between the endpoint rolls.
+        let pointing = make_pointing(10.0, 20.0);
+        let start_roll: f64 = 0.2;
+        let end_roll: f64 = 0.8;
+
+        let traj = Trajectory::from_endpoints_with_roll(
+            pointing,
+            start_roll,
+            pointing,
+            end_roll,
+            Duration::from_secs(10),
+        )
+        .unwrap();
+
+        // Start/end orientations preserve their constructed rolls.
+        let q0 = traj.orientation_at(Duration::ZERO).unwrap();
+        assert!((roll_of(&q0) - start_roll).abs() < 1e-9);
+        let q1 = traj.orientation_at(Duration::from_secs(10)).unwrap();
+        assert!((roll_of(&q1) - end_roll).abs() < 1e-9);
+
+        // Midpoint roll is exactly halfway.
+        let qm = traj.orientation_at(Duration::from_secs(5)).unwrap();
+        let expected_roll = 0.5 * (start_roll + end_roll);
+        assert!(
+            (roll_of(&qm) - expected_roll).abs() < 1e-9,
+            "midpoint roll {:.9} != expected {:.9}",
+            roll_of(&qm),
+            expected_roll
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Migrate `Waypoint`/`Trajectory` from 2DoF pointing to `UnitQuaternion<f64>` orientation so spacecraft roll is a first-class DoF interpolated alongside pointing. Quaternion SLERP replaces the hand-written equatorial SLERP and picks the short path automatically.
- Introduce a `FocalPlaneProjector` trait with an `MmSpaceProjector` reference implementation, plus a new `project_stars_to_focal_plane_oriented` batch entry point. This lays the groundwork for per-sensor motion-blur rendering without changing how a single-frame batch is currently efficient.
- Roll application lives in the mm-space pipeline as a 2D rotation about the focal-plane AABB center, so the existing routing/flux-caching structure in `render_trajectory` is untouched.

## Convention
Body frame: `+Z` = boresight (outward), `+X` = local east at the pointing, `+Y` = local north. Roll is a right-hand rotation about body `+Z`. See module docs in `simulator/src/sims/orientation.rs` for the full spec, including the pole-guard behavior in `roll_of`.

## Backward compatibility
- `Trajectory::from_endpoints`, `pointing_at`, `frame_times`, `start_time`, `end_time`, and `waypoints()` keep their old signatures; `pointing_at` now returns the boresight derived from `orientation_at`.
- `project_stars_to_focal_plane(stars, center, …)` stays as a thin wrapper that delegates to the oriented form with roll = 0.
- `motion_simulator` keeps its prior behavior exactly when `--start-roll` and `--end-roll` are left at their default `0`. Non-zero values switch it to `Trajectory::from_endpoints_with_roll`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -W clippy::all` (no new warnings in touched files)
- [x] `cargo test --workspace` — 212 simulator tests pass (up from 208 before), including five new tests covering orientation round-trip, roll extraction, quaternion SLERP midpoint, focal-plane roll rotation, and zero-roll parity with the legacy batch projection path.