### PR TITLE
Dedup image crate by trimming plotters features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,7 +531,6 @@ dependencies = [
  "num-traits",
  "once_cell",
  "oorandom",
- "plotters",
  "rayon",
  "regex",
  "serde",
@@ -1035,16 +1034,6 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
-name = "gif"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
@@ -1358,20 +1347,6 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
-dependencies = [
- "bytemuck",
- "byteorder",
- "color_quant",
- "jpeg-decoder",
- "num-traits",
- "png 0.17.16",
-]
-
-[[package]]
-name = "image"
 version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
@@ -1549,12 +1524,6 @@ dependencies = [
  "getrandom 0.3.4",
  "libc",
 ]
-
-[[package]]
-name = "jpeg-decoder"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"
@@ -2089,7 +2058,6 @@ checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
 dependencies = [
  "chrono",
  "font-kit",
- "image 0.24.9",
  "lazy_static",
  "num-traits",
  "pathfinder_geometry",
@@ -2113,8 +2081,6 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ce181e3f6bf82d6c1dc569103ca7b1bd964c60ba03d7e6cdfbb3e3eb7f7405"
 dependencies = [
- "gif 0.12.0",
- "image 0.24.9",
  "plotters-backend",
 ]
 
@@ -2754,7 +2720,7 @@ dependencies = [
  "crossbeam-channel",
  "fitsio-pure",
  "float-cmp",
- "image 0.25.9",
+ "image",
  "indicatif",
  "itertools 0.11.0",
  "log",
@@ -2849,7 +2815,7 @@ dependencies = [
  "env_logger",
  "fitsio-pure",
  "float-cmp",
- "image 0.25.9",
+ "image",
  "indicatif",
  "log",
  "meter-math",
@@ -2922,7 +2888,7 @@ dependencies = [
  "chrono",
  "clap",
  "flate2",
- "image 0.25.9",
+ "image",
  "indicatif",
  "lazy_static",
  "log",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -34,12 +34,25 @@ rand_distr = "0.5"
 indicatif = "0.17"
 num_cpus = "1.16"
 
-plotters = "0.3"
+plotters = { version = "0.3", default-features = false, features = [
+    "bitmap_backend",
+    "svg_backend",
+    "chrono",
+    "ttf",
+    "all_series",
+    "all_elements",
+    "full_palette",
+    "colormaps",
+] }
 chrono = "0.4.41"
 fitsio = { version = "0.9.2", package = "fitsio-pure", features = ["compat"] }
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] } # Benchmarking
+criterion = { version = "0.5", default-features = false, features = [
+    "rayon",
+    "cargo_bench_support",
+    "html_reports",
+] } # Benchmarking (no plotters: criterion's plotters feature pulls image 0.24)
 approx = "0.5"                                               # Approximate floating point comparisons
 tempfile = "3.10"                                            # Temporary file handling
 

--- a/simulator/examples/airy_disk_demo.rs
+++ b/simulator/examples/airy_disk_demo.rs
@@ -18,6 +18,7 @@
 
 use plotters::prelude::*;
 use shared::image_proc::AiryDisk;
+use simulator::plotting::save_plot_png;
 use std::path::Path;
 
 /// Type of Airy disk approximation to render in 2D images.
@@ -258,126 +259,111 @@ fn create_airy_comparison_plot(
     let max_r_normalized = 2.0;
     let normalized_radii: Vec<f64> = radii.iter().map(|&r| r / airy_disk.first_zero).collect();
 
-    // Set up the plot with 4:3 aspect ratio
-    let root = BitMapBackend::new(save_path, (1200, 900)).into_drawing_area();
-    root.fill(&WHITE)?;
-    let root = root.margin(20, 20, 20, 20);
+    save_plot_png(save_path, (1200, 900), |root| {
+        root.fill(&WHITE)?;
+        let root = root.margin(20, 20, 20, 20);
 
-    // Single panel: Function comparison
-    let mut chart = ChartBuilder::on(&root)
-        .caption(
-            "Airy Disk vs Approximations",
-            ("sans-serif", 32).into_font().color(&BLACK),
-        )
-        .margin(15)
-        .x_label_area_size(50)
-        .y_label_area_size(80)
-        .build_cartesian_2d(-max_r_normalized..max_r_normalized, 0.0..1.0)?;
+        let mut chart = ChartBuilder::on(&root)
+            .caption(
+                "Airy Disk vs Approximations",
+                ("sans-serif", 32).into_font().color(&BLACK),
+            )
+            .margin(15)
+            .x_label_area_size(50)
+            .y_label_area_size(80)
+            .build_cartesian_2d(-max_r_normalized..max_r_normalized, 0.0..1.0)?;
 
-    chart
-        .configure_mesh()
-        .x_desc("Normalized Radius (r/r₀)")
-        .y_desc("Normalized Intensity")
-        .axis_desc_style(("sans-serif", 20))
-        .label_style(("sans-serif", 16))
-        .y_max_light_lines(10)
-        .draw()?;
+        chart
+            .configure_mesh()
+            .x_desc("Normalized Radius (r/r₀)")
+            .y_desc("Normalized Intensity")
+            .axis_desc_style(("sans-serif", 20))
+            .label_style(("sans-serif", 16))
+            .y_max_light_lines(10)
+            .draw()?;
 
-    // Create symmetric data points (positive and negative r)
-    let symmetric_points = |data: &[f64]| {
-        let mut points = Vec::new();
-        // Add negative side (reversed order for proper line drawing)
-        for (i, &r) in normalized_radii.iter().enumerate().rev() {
-            if r > 0.0 {
-                points.push((-r, data[i]));
+        let symmetric_points = |data: &[f64]| {
+            let mut points = Vec::new();
+            for (i, &r) in normalized_radii.iter().enumerate().rev() {
+                if r > 0.0 {
+                    points.push((-r, data[i]));
+                }
             }
-        }
-        // Add positive side
-        for (i, &r) in normalized_radii.iter().enumerate() {
-            points.push((r, data[i]));
-        }
-        points
-    };
+            for (i, &r) in normalized_radii.iter().enumerate() {
+                points.push((r, data[i]));
+            }
+            points
+        };
 
-    // Plot the exact Airy disk function
-    chart
-        .draw_series(LineSeries::new(symmetric_points(exact), BLUE))?
-        .label("Exact Airy Disk")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], BLUE.stroke_width(2)));
+        chart
+            .draw_series(LineSeries::new(symmetric_points(exact), BLUE))?
+            .label("Exact Airy Disk")
+            .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], BLUE.stroke_width(2)));
 
-    // Plot the Gaussian approximation
-    chart
-        .draw_series(LineSeries::new(symmetric_points(gaussian), RED))?
-        .label("Gaussian Approximation")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], RED.stroke_width(2)));
+        chart
+            .draw_series(LineSeries::new(symmetric_points(gaussian), RED))?
+            .label("Gaussian Approximation")
+            .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], RED.stroke_width(2)));
 
-    // Plot the Triangle approximation
-    chart
-        .draw_series(LineSeries::new(symmetric_points(triangle), GREEN))?
-        .label("Triangle Approximation")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], GREEN.stroke_width(2)));
+        chart
+            .draw_series(LineSeries::new(symmetric_points(triangle), GREEN))?
+            .label("Triangle Approximation")
+            .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], GREEN.stroke_width(2)));
 
-    // Add dotted vertical lines at first zero (r₀) - light blue to match 2D rings
-    let first_zero_color = RGBColor(173, 216, 230); // Light blue
-    chart.draw_series(std::iter::once(PathElement::new(
-        vec![(1.0, 0.0), (1.0, 1.0)],
-        first_zero_color.stroke_width(2),
-    )))?;
-    chart.draw_series(std::iter::once(PathElement::new(
-        vec![(-1.0, 0.0), (-1.0, 1.0)],
-        first_zero_color.stroke_width(2),
-    )))?;
+        let first_zero_color = RGBColor(173, 216, 230);
+        chart.draw_series(std::iter::once(PathElement::new(
+            vec![(1.0, 0.0), (1.0, 1.0)],
+            first_zero_color.stroke_width(2),
+        )))?;
+        chart.draw_series(std::iter::once(PathElement::new(
+            vec![(-1.0, 0.0), (-1.0, 1.0)],
+            first_zero_color.stroke_width(2),
+        )))?;
 
-    // Add FWHM annotation lines and axvlines
-    let fwhm_half_normalized = airy_disk.fwhm / 2.0 / airy_disk.first_zero;
-    let fwhm_intensity = 0.5; // Half maximum by definition
-    let fwhm_color = RGBColor(255, 182, 193); // Light pink/red to match 2D rings
+        let fwhm_half_normalized = airy_disk.fwhm / 2.0 / airy_disk.first_zero;
+        let fwhm_intensity = 0.5;
+        let fwhm_color = RGBColor(255, 182, 193);
 
-    // Keep the grey spanning bar (horizontal line across full FWHM)
-    chart.draw_series(std::iter::once(PathElement::new(
-        vec![
-            (-fwhm_half_normalized, fwhm_intensity),
-            (fwhm_half_normalized, fwhm_intensity),
-        ],
-        RGBColor(128, 128, 128).stroke_width(2),
-    )))?;
+        chart.draw_series(std::iter::once(PathElement::new(
+            vec![
+                (-fwhm_half_normalized, fwhm_intensity),
+                (fwhm_half_normalized, fwhm_intensity),
+            ],
+            RGBColor(128, 128, 128).stroke_width(2),
+        )))?;
 
-    // Add dotted vertical axvlines at FWHM points - light red to match 2D rings
-    chart.draw_series(std::iter::once(PathElement::new(
-        vec![(fwhm_half_normalized, 0.0), (fwhm_half_normalized, 1.0)],
-        fwhm_color.stroke_width(2),
-    )))?;
-    chart.draw_series(std::iter::once(PathElement::new(
-        vec![(-fwhm_half_normalized, 0.0), (-fwhm_half_normalized, 1.0)],
-        fwhm_color.stroke_width(2),
-    )))?;
+        chart.draw_series(std::iter::once(PathElement::new(
+            vec![(fwhm_half_normalized, 0.0), (fwhm_half_normalized, 1.0)],
+            fwhm_color.stroke_width(2),
+        )))?;
+        chart.draw_series(std::iter::once(PathElement::new(
+            vec![(-fwhm_half_normalized, 0.0), (-fwhm_half_normalized, 1.0)],
+            fwhm_color.stroke_width(2),
+        )))?;
 
-    // Add text annotation for first zero
-    chart.draw_series(std::iter::once(Text::new(
-        format!("r₀ = {:.3}", airy_disk.first_zero),
-        (1.05, 0.9),
-        ("sans-serif", 18).into_font().color(&BLACK),
-    )))?;
+        chart.draw_series(std::iter::once(Text::new(
+            format!("r₀ = {:.3}", airy_disk.first_zero),
+            (1.05, 0.9),
+            ("sans-serif", 18).into_font().color(&BLACK),
+        )))?;
 
-    // Add text annotation for FWHM
-    chart.draw_series(std::iter::once(Text::new(
-        "FWHM",
-        (0.05, 0.55),
-        ("sans-serif", 18)
-            .into_font()
-            .color(&RGBColor(128, 128, 128)),
-    )))?;
+        chart.draw_series(std::iter::once(Text::new(
+            "FWHM",
+            (0.05, 0.55),
+            ("sans-serif", 18)
+                .into_font()
+                .color(&RGBColor(128, 128, 128)),
+        )))?;
 
-    chart
-        .configure_series_labels()
-        .background_style(WHITE.mix(0.9))
-        .border_style(BLACK)
-        .label_font(("sans-serif", 18))
-        .draw()?;
+        chart
+            .configure_series_labels()
+            .background_style(WHITE.mix(0.9))
+            .border_style(BLACK)
+            .label_font(("sans-serif", 18))
+            .draw()?;
 
-    root.present()?;
-
-    Ok(())
+        Ok(())
+    })
 }
 
 /// Creates a 512×512 grayscale 2D image of an Airy disk pattern with colored rings.
@@ -426,48 +412,40 @@ fn create_airy_disk_image(
     let first_zero_radius = airy_disk.first_zero / scale_factor;
     let fwhm_radius = (airy_disk.fwhm / 2.0) / scale_factor;
 
-    let root = BitMapBackend::new(save_path, (size as u32, size as u32)).into_drawing_area();
-    root.fill(&WHITE)?;
+    save_plot_png(save_path, (size as u32, size as u32), |root| {
+        root.fill(&WHITE)?;
 
-    // Create pixel buffer
-    for y in 0..size {
-        for x in 0..size {
-            let dx = x as f64 - center;
-            let dy = y as f64 - center;
-            let pixel_radius = (dx * dx + dy * dy).sqrt();
+        for y in 0..size {
+            for x in 0..size {
+                let dx = x as f64 - center;
+                let dy = y as f64 - center;
+                let pixel_radius = (dx * dx + dy * dy).sqrt();
 
-            // Convert pixel radius to angular radius
-            let angular_radius = pixel_radius * scale_factor;
+                let angular_radius = pixel_radius * scale_factor;
 
-            // Calculate intensity based on image type (0 to 1)
-            let intensity = match image_type {
-                ImageType::Exact => airy_disk.intensity(angular_radius),
-                ImageType::Gaussian => airy_disk.gaussian_approximation(angular_radius),
-                ImageType::Triangle => airy_disk.triangle_approximation(angular_radius),
-            };
+                let intensity = match image_type {
+                    ImageType::Exact => airy_disk.intensity(angular_radius),
+                    ImageType::Gaussian => airy_disk.gaussian_approximation(angular_radius),
+                    ImageType::Triangle => airy_disk.triangle_approximation(angular_radius),
+                };
 
-            // Convert to greyscale (0-255)
-            let grey_value = (intensity * 255.0) as u8;
+                let grey_value = (intensity * 255.0) as u8;
 
-            // Check if we're near the ring positions
-            let is_first_zero_ring = (pixel_radius - first_zero_radius).abs() < 0.8;
-            let is_fwhm_ring = (pixel_radius - fwhm_radius).abs() < 0.8;
+                let is_first_zero_ring = (pixel_radius - first_zero_radius).abs() < 0.8;
+                let is_fwhm_ring = (pixel_radius - fwhm_radius).abs() < 0.8;
 
-            let color = if is_first_zero_ring {
-                // Light blue ring at first zero
-                RGBColor(173, 216, 230) // Light blue
-            } else if is_fwhm_ring {
-                // Light red ring at FWHM
-                RGBColor(255, 182, 193) // Light pink/red
-            } else {
-                // Greyscale based on intensity
-                RGBColor(grey_value, grey_value, grey_value)
-            };
+                let color = if is_first_zero_ring {
+                    RGBColor(173, 216, 230)
+                } else if is_fwhm_ring {
+                    RGBColor(255, 182, 193)
+                } else {
+                    RGBColor(grey_value, grey_value, grey_value)
+                };
 
-            root.draw_pixel((x, y), &color)?;
+                root.draw_pixel((x, y), &color)?;
+            }
         }
-    }
 
-    root.present()?;
-    Ok(())
+        Ok(())
+    })
 }

--- a/simulator/examples/chromatic_airy_demo.rs
+++ b/simulator/examples/chromatic_airy_demo.rs
@@ -16,6 +16,7 @@ use simulator::photometry::{
     stellar::{temperature_from_bv, BlackbodyStellarSpectrum},
     QuantumEfficiency,
 };
+use simulator::plotting::save_plot_png;
 use simulator::star_math::DEFAULT_BV;
 use simulator::units::{Area, AreaExt, LengthExt, Wavelength};
 use std::error::Error;
@@ -185,103 +186,98 @@ fn create_sensor_plot(
 
     let mono_color = RGBColor(0, 255, 0); // Laser green for monochromatic
 
-    // Create plot
     let filename = format!("plots/chromatic_airy_{}.png", sensor_name.to_lowercase());
-    let root = BitMapBackend::new(&filename, (2048, 1536)).into_drawing_area();
-    root.fill(&BLACK)?;
+    save_plot_png(&filename, (2048, 1536), |root| {
+        root.fill(&BLACK)?;
 
-    let mut chart = ChartBuilder::on(&root)
-        .caption(
-            format!("{sensor_name}: Chromatic vs Monochromatic Airy Disk Profiles"),
-            ("sans-serif", 50).into_font().color(&WHITE),
-        )
-        .margin(40)
-        .x_label_area_size(80)
-        .y_label_area_size(100)
-        .build_cartesian_2d(0.0..max_radius, 0.0001f64..1.1f64)?;
-
-    chart
-        .configure_mesh()
-        .x_desc("Radius (normalized units)")
-        .y_desc("Normalized Intensity")
-        .y_label_formatter(&|y| {
-            if *y >= 0.1 {
-                format!("{y:.1}")
-            } else {
-                format!("{y:.0e}")
-            }
-        })
-        .y_labels(11)
-        .label_style(("sans-serif", 24).into_font().color(&WHITE))
-        .axis_style(WHITE)
-        .draw()?;
-
-    // Plot monochromatic profiles
-    chart
-        .draw_series(LineSeries::new(
-            radii.iter().cloned().zip(mono_profile.iter().cloned()),
-            ShapeStyle::from(&mono_color).stroke_width(2),
-        ))?
-        .label("Monochromatic (550nm)")
-        .legend(move |(x, y)| {
-            PathElement::new(
-                vec![(x, y), (x + 20, y)],
-                ShapeStyle::from(&mono_color).stroke_width(2),
+        let mut chart = ChartBuilder::on(root)
+            .caption(
+                format!("{sensor_name}: Chromatic vs Monochromatic Airy Disk Profiles"),
+                ("sans-serif", 50).into_font().color(&WHITE),
             )
-        });
+            .margin(40)
+            .x_label_area_size(80)
+            .y_label_area_size(100)
+            .build_cartesian_2d(0.0..max_radius, 0.0001f64..1.1f64)?;
 
-    chart
-        .draw_series(
-            LineSeries::new(
-                radii
-                    .iter()
-                    .cloned()
-                    .zip(mono_gauss_profile.iter().cloned()),
-                ShapeStyle::from(&mono_color).stroke_width(1),
-            )
-            .point_size(0),
-        )?
-        .label("Mono Gaussian approx")
-        .legend(move |(x, y)| {
-            PathElement::new(
-                vec![(x, y), (x + 20, y)],
-                ShapeStyle::from(&mono_color).stroke_width(1),
-            )
-        });
-
-    // Plot star profiles
-    for (i, ((_, star_type, temp), profile)) in stars.iter().zip(star_profiles.iter()).enumerate() {
-        let color = &star_colors[i];
-        let eff_wavelength = star_psfs[i].disk.reference_wavelength.as_nanometers();
-        let label = if star_type.contains("B-V") {
-            format!("{star_type} ({temp:.0}K, {eff_wavelength:.0}nm)")
-        } else {
-            format!("{star_type} ({temp:.0}K, {eff_wavelength:.0}nm)")
-        };
+        chart
+            .configure_mesh()
+            .x_desc("Radius (normalized units)")
+            .y_desc("Normalized Intensity")
+            .y_label_formatter(&|y| {
+                if *y >= 0.1 {
+                    format!("{y:.1}")
+                } else {
+                    format!("{y:.0e}")
+                }
+            })
+            .y_labels(11)
+            .label_style(("sans-serif", 24).into_font().color(&WHITE))
+            .axis_style(WHITE)
+            .draw()?;
 
         chart
             .draw_series(LineSeries::new(
-                radii.iter().cloned().zip(profile.iter().cloned()),
-                ShapeStyle::from(color).stroke_width(1),
+                radii.iter().cloned().zip(mono_profile.iter().cloned()),
+                ShapeStyle::from(&mono_color).stroke_width(2),
             ))?
-            .label(&label)
+            .label("Monochromatic (550nm)")
             .legend(move |(x, y)| {
                 PathElement::new(
                     vec![(x, y), (x + 20, y)],
-                    ShapeStyle::from(color).stroke_width(1),
+                    ShapeStyle::from(&mono_color).stroke_width(2),
                 )
             });
-    }
 
-    chart
-        .configure_series_labels()
-        .background_style(BLACK.mix(0.8))
-        .border_style(WHITE)
-        .label_font(("sans-serif", 20).into_font().color(&WHITE))
-        .draw()?;
+        chart
+            .draw_series(
+                LineSeries::new(
+                    radii
+                        .iter()
+                        .cloned()
+                        .zip(mono_gauss_profile.iter().cloned()),
+                    ShapeStyle::from(&mono_color).stroke_width(1),
+                )
+                .point_size(0),
+            )?
+            .label("Mono Gaussian approx")
+            .legend(move |(x, y)| {
+                PathElement::new(
+                    vec![(x, y), (x + 20, y)],
+                    ShapeStyle::from(&mono_color).stroke_width(1),
+                )
+            });
 
-    root.present()?;
-    Ok(())
+        for (i, ((_, star_type, temp), profile)) in
+            stars.iter().zip(star_profiles.iter()).enumerate()
+        {
+            let color = &star_colors[i];
+            let eff_wavelength = star_psfs[i].disk.reference_wavelength.as_nanometers();
+            let label = format!("{star_type} ({temp:.0}K, {eff_wavelength:.0}nm)");
+
+            chart
+                .draw_series(LineSeries::new(
+                    radii.iter().cloned().zip(profile.iter().cloned()),
+                    ShapeStyle::from(color).stroke_width(1),
+                ))?
+                .label(&label)
+                .legend(move |(x, y)| {
+                    PathElement::new(
+                        vec![(x, y), (x + 20, y)],
+                        ShapeStyle::from(color).stroke_width(1),
+                    )
+                });
+        }
+
+        chart
+            .configure_series_labels()
+            .background_style(BLACK.mix(0.8))
+            .border_style(WHITE)
+            .label_font(("sans-serif", 20).into_font().color(&WHITE))
+            .draw()?;
+
+        Ok(())
+    })
 }
 
 /// Creates 2D PSF comparison images showing monochromatic vs chromatic PSFs.
@@ -351,43 +347,40 @@ fn create_2d_psf_comparison(
         }
     };
 
-    // Save 2D PSF comparison
-    let root2d = BitMapBackend::new("plots/chromatic_psf_2d.png", (768, 384)).into_drawing_area();
-    root2d.fill(&WHITE)?;
+    save_plot_png("plots/chromatic_psf_2d.png", (768, 384), |root2d| {
+        root2d.fill(&WHITE)?;
 
-    let (left, right) = root2d.split_horizontally(384);
+        let (left, right) = root2d.split_horizontally(384);
 
-    // Plot monochromatic PSF
-    let mut mono_chart = ChartBuilder::on(&left)
-        .caption("Monochromatic PSF", ("sans-serif", 20))
-        .margin(10)
-        .build_cartesian_2d(0..image_size, 0..image_size)?;
+        let mut mono_chart = ChartBuilder::on(&left)
+            .caption("Monochromatic PSF", ("sans-serif", 20))
+            .margin(10)
+            .build_cartesian_2d(0..image_size, 0..image_size)?;
 
-    mono_chart.draw_series(mono_image.indexed_iter().map(|((y, x), &v)| {
-        Rectangle::new(
-            [(x, y), (x + 1, y + 1)],
-            HSLColor(0.0, 0.0, 1.0 - log_scale(v)).filled(),
-        )
-    }))?;
+        mono_chart.draw_series(mono_image.indexed_iter().map(|((y, x), &v)| {
+            Rectangle::new(
+                [(x, y), (x + 1, y + 1)],
+                HSLColor(0.0, 0.0, 1.0 - log_scale(v)).filled(),
+            )
+        }))?;
 
-    // Plot chromatic PSF
-    let mut chrom_chart = ChartBuilder::on(&right)
-        .caption(
-            format!("Chromatic PSF (Sun-like star, {sensor_name})"),
-            ("sans-serif", 20),
-        )
-        .margin(10)
-        .build_cartesian_2d(0..image_size, 0..image_size)?;
+        let mut chrom_chart = ChartBuilder::on(&right)
+            .caption(
+                format!("Chromatic PSF (Sun-like star, {sensor_name})"),
+                ("sans-serif", 20),
+            )
+            .margin(10)
+            .build_cartesian_2d(0..image_size, 0..image_size)?;
 
-    chrom_chart.draw_series(sun_image.indexed_iter().map(|((y, x), &v)| {
-        Rectangle::new(
-            [(x, y), (x + 1, y + 1)],
-            HSLColor(0.0, 0.0, 1.0 - log_scale(v)).filled(),
-        )
-    }))?;
+        chrom_chart.draw_series(sun_image.indexed_iter().map(|((y, x), &v)| {
+            Rectangle::new(
+                [(x, y), (x + 1, y + 1)],
+                HSLColor(0.0, 0.0, 1.0 - log_scale(v)).filled(),
+            )
+        }))?;
 
-    root2d.present()?;
-    Ok(())
+        Ok(())
+    })
 }
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/simulator/examples/noise_dump.rs
+++ b/simulator/examples/noise_dump.rs
@@ -18,97 +18,90 @@
 use plotters::prelude::*;
 use simulator::hardware::dark_current::{MAX_TEMP_C, MIN_TEMP_C};
 use simulator::hardware::sensor::models::ALL_SENSORS;
+use simulator::plotting::save_plot_png;
 use simulator::units::{Temperature, TemperatureExt};
 
 fn plot_dark_current_curves() -> Result<(), Box<dyn std::error::Error>> {
-    // Create plot
-    let root = BitMapBackend::new("dark_current_curves.png", (1200, 800)).into_drawing_area();
-    root.fill(&WHITE)?;
+    save_plot_png("dark_current_curves.png", (1200, 800), |root| {
+        root.fill(&WHITE)?;
 
-    let mut chart = ChartBuilder::on(&root)
-        .caption(
-            "Dark Current vs Temperature for All Sensors",
-            ("sans-serif", 40),
-        )
-        .margin(10)
-        .x_label_area_size(40)
-        .y_label_area_size(80)
-        .build_cartesian_2d(MIN_TEMP_C..MAX_TEMP_C, (0.001f64..10f64).log_scale())?;
+        let mut chart = ChartBuilder::on(root)
+            .caption(
+                "Dark Current vs Temperature for All Sensors",
+                ("sans-serif", 40),
+            )
+            .margin(10)
+            .x_label_area_size(40)
+            .y_label_area_size(80)
+            .build_cartesian_2d(MIN_TEMP_C..MAX_TEMP_C, (0.001f64..10f64).log_scale())?;
 
-    chart
-        .configure_mesh()
-        .x_desc("Temperature (°C)")
-        .y_desc("Dark Current (e⁻/pixel/second)")
-        .y_label_formatter(&|y| format!("{y:.0e}"))
-        .axis_desc_style(("sans-serif", 20))
-        .draw()?;
+        chart
+            .configure_mesh()
+            .x_desc("Temperature (°C)")
+            .y_desc("Dark Current (e⁻/pixel/second)")
+            .y_label_formatter(&|y| format!("{y:.0e}"))
+            .axis_desc_style(("sans-serif", 20))
+            .draw()?;
 
-    // Plot each sensor's dark current curve
-    let sensors = &*ALL_SENSORS;
-    let colors = [&RED, &BLUE, &GREEN, &MAGENTA, &CYAN, &BLACK, &YELLOW];
+        let sensors = &*ALL_SENSORS;
+        let colors = [&RED, &BLUE, &GREEN, &MAGENTA, &CYAN, &BLACK, &YELLOW];
 
-    for (idx, sensor) in sensors.iter().enumerate() {
-        let color = colors[idx % colors.len()];
+        for (idx, sensor) in sensors.iter().enumerate() {
+            let color = colors[idx % colors.len()];
 
-        // Generate temperature points for smooth curve
-        let min_temp_int = (MIN_TEMP_C * 10.0) as i32;
-        let max_temp_int = (MAX_TEMP_C * 10.0) as i32;
-        let temps: Vec<f64> = (min_temp_int..=max_temp_int)
-            .map(|t| t as f64 / 10.0)
-            .collect();
-        let mut curve_points = Vec::new();
+            let min_temp_int = (MIN_TEMP_C * 10.0) as i32;
+            let max_temp_int = (MAX_TEMP_C * 10.0) as i32;
+            let temps: Vec<f64> = (min_temp_int..=max_temp_int)
+                .map(|t| t as f64 / 10.0)
+                .collect();
+            let mut curve_points = Vec::new();
 
-        for temp in &temps {
-            // Only plot points within the valid range
-            let temperature = Temperature::from_celsius(*temp);
-            if let Ok(dark_current) = sensor
-                .dark_current_estimator
-                .estimate_at_temperature(temperature)
-            {
-                curve_points.push((*temp, dark_current));
+            for temp in &temps {
+                let temperature = Temperature::from_celsius(*temp);
+                if let Ok(dark_current) = sensor
+                    .dark_current_estimator
+                    .estimate_at_temperature(temperature)
+                {
+                    curve_points.push((*temp, dark_current));
+                }
+            }
+
+            if !curve_points.is_empty() {
+                let doubling_temp = sensor
+                    .dark_current_estimator
+                    .calculate_doubling_temperature();
+
+                chart
+                    .draw_series(LineSeries::new(curve_points.clone(), color.stroke_width(1)))?
+                    .label(&sensor.name)
+                    .legend(move |(x, y)| {
+                        PathElement::new(vec![(x, y), (x + 20, y)], color.stroke_width(3))
+                    });
+
+                let annotation_temp = 10.0;
+                if let Ok(dark_current) = sensor
+                    .dark_current_estimator
+                    .estimate_at_temperature(Temperature::from_celsius(annotation_temp))
+                {
+                    let annotation_text = format!("{doubling_temp:.1}°C/2×");
+                    chart.draw_series(std::iter::once(Text::new(
+                        annotation_text,
+                        (annotation_temp, dark_current),
+                        ("sans-serif", 20).into_font().color(color),
+                    )))?;
+                }
             }
         }
 
-        // Draw the curve
-        if !curve_points.is_empty() {
-            // Calculate doubling temperature for this sensor
-            let doubling_temp = sensor
-                .dark_current_estimator
-                .calculate_doubling_temperature();
+        chart
+            .configure_series_labels()
+            .label_font(("sans-serif", 16))
+            .border_style(BLACK)
+            .background_style(WHITE.mix(0.8))
+            .draw()?;
 
-            chart
-                .draw_series(LineSeries::new(curve_points.clone(), color.stroke_width(1)))?
-                .label(&sensor.name)
-                .legend(move |(x, y)| {
-                    PathElement::new(vec![(x, y), (x + 20, y)], color.stroke_width(3))
-                });
-
-            // Add annotation on the curve
-            // Find a good position around the middle of the temperature range
-            let annotation_temp = 10.0; // Place annotation at 10°C
-            if let Ok(dark_current) = sensor
-                .dark_current_estimator
-                .estimate_at_temperature(Temperature::from_celsius(annotation_temp))
-            {
-                let annotation_text = format!("{doubling_temp:.1}°C/2×");
-                chart.draw_series(std::iter::once(Text::new(
-                    annotation_text,
-                    (annotation_temp, dark_current),
-                    ("sans-serif", 20).into_font().color(color),
-                )))?;
-            }
-        }
-    }
-
-    // Configure and draw legend
-    chart
-        .configure_series_labels()
-        .label_font(("sans-serif", 16))
-        .border_style(BLACK)
-        .background_style(WHITE.mix(0.8))
-        .draw()?;
-
-    root.present()?;
+        Ok(())
+    })?;
     println!("\nDark current curves saved to: dark_current_curves.png");
 
     Ok(())

--- a/simulator/examples/undersampled_psf_bias.rs
+++ b/simulator/examples/undersampled_psf_bias.rs
@@ -16,6 +16,7 @@ use simulator::hardware::telescope::models::IDEAL_50CM;
 use simulator::hardware::SatelliteConfig;
 use simulator::image_proc::render::StarInFrame;
 use simulator::photometry::zodiacal::SolarAngularCoordinates;
+use simulator::plotting::save_plot_png;
 use simulator::scene::Scene;
 use simulator::star_data_to_fluxes;
 use starfield::catalogs::StarData;
@@ -335,83 +336,77 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Create visualization
     println!("Creating visualization...");
 
-    let root =
-        BitMapBackend::new("plots/undersampled_psf_bias.png", (1200, 800)).into_drawing_area();
-    root.fill(&WHITE)?;
+    save_plot_png("plots/undersampled_psf_bias.png", (1200, 800), |root| {
+        root.fill(&WHITE)?;
 
-    // Find maximum error across all results for Y-axis scaling
-    let max_error = all_results
-        .iter()
-        .flat_map(|(_, results, _, _)| results.iter())
-        .cloned()
-        .fold(0.0f64, f64::max);
+        let max_error = all_results
+            .iter()
+            .flat_map(|(_, results, _, _)| results.iter())
+            .cloned()
+            .fold(0.0f64, f64::max);
 
-    let y_max = max_error + 0.01; // Pad by 0.01 above maximum
+        let y_max = max_error + 0.01;
 
-    let mut chart = ChartBuilder::on(&root)
-        .caption(
-            "Centroid Error vs Sub-pixel Position for Different PSF Sampling",
-            ("sans-serif", 30),
-        )
-        .margin(20)
-        .x_label_area_size(40)
-        .y_label_area_size(50)
-        .build_cartesian_2d(0.0..1.0, 0.0..y_max)?;
+        let mut chart = ChartBuilder::on(root)
+            .caption(
+                "Centroid Error vs Sub-pixel Position for Different PSF Sampling",
+                ("sans-serif", 30),
+            )
+            .margin(20)
+            .x_label_area_size(40)
+            .y_label_area_size(50)
+            .build_cartesian_2d(0.0..1.0, 0.0..y_max)?;
 
-    chart
-        .configure_mesh()
-        .x_desc("Sub-pixel X Position")
-        .y_desc("Mean Centroid Error (pixels)")
-        .draw()?;
+        chart
+            .configure_mesh()
+            .x_desc("Sub-pixel X Position")
+            .y_desc("Mean Centroid Error (pixels)")
+            .draw()?;
 
-    // Plot results for different sampling values
-    // Create color interpolation from red (undersampled) to green (well-sampled)
-    let mut colors = Vec::new();
-    for i in 0..psf_sampling_values.len() {
-        let t = i as f64 / (psf_sampling_values.len() - 1) as f64;
-        // Interpolate from red to green
-        let r = (255.0 * (1.0 - t)) as u8;
-        let g = (255.0 * t) as u8;
-        let b = 0u8;
-        colors.push(RGBColor(r, g, b));
-    }
-
-    for (idx, &(psf_sampling, ref results, _, _)) in all_results.iter().enumerate() {
-        let color = &colors[idx];
-
-        // Extract center row for plotting
-        let center_row = grid_size / 2;
-        let mut plot_data = Vec::new();
-
-        for x in 0..grid_size {
-            let x_pos = x as f64 / (grid_size - 1) as f64;
-            let error = results[[center_row, x]];
-            plot_data.push((x_pos, error));
+        let mut colors = Vec::new();
+        for i in 0..psf_sampling_values.len() {
+            let t = i as f64 / (psf_sampling_values.len() - 1) as f64;
+            let r = (255.0 * (1.0 - t)) as u8;
+            let g = (255.0 * t) as u8;
+            let b = 0u8;
+            colors.push(RGBColor(r, g, b));
         }
 
-        let color_clone = *color;
+        for (idx, &(psf_sampling, ref results, _, _)) in all_results.iter().enumerate() {
+            let color = &colors[idx];
+
+            let center_row = grid_size / 2;
+            let mut plot_data = Vec::new();
+
+            for x in 0..grid_size {
+                let x_pos = x as f64 / (grid_size - 1) as f64;
+                let error = results[[center_row, x]];
+                plot_data.push((x_pos, error));
+            }
+
+            let color_clone = *color;
+            chart
+                .draw_series(LineSeries::new(plot_data.clone(), *color))?
+                .label(format!("PSF = {psf_sampling:.2} FWHM/px"))
+                .legend(move |(x, y)| PathElement::new(vec![(x, y), (x + 10, y)], color_clone));
+
+            chart.draw_series(PointSeries::of_element(
+                plot_data,
+                3,
+                color.filled(),
+                &|c, s, st| EmptyElement::at(c) + Circle::new((0, 0), s, st),
+            ))?;
+        }
+
         chart
-            .draw_series(LineSeries::new(plot_data.clone(), *color))?
-            .label(format!("PSF = {psf_sampling:.2} FWHM/px"))
-            .legend(move |(x, y)| PathElement::new(vec![(x, y), (x + 10, y)], color_clone));
+            .configure_series_labels()
+            .position(SeriesLabelPosition::UpperRight)
+            .background_style(WHITE.mix(0.8))
+            .border_style(BLACK)
+            .draw()?;
 
-        // Add points
-        chart.draw_series(PointSeries::of_element(
-            plot_data,
-            3,
-            color.filled(),
-            &|c, s, st| EmptyElement::at(c) + Circle::new((0, 0), s, st),
-        ))?;
-    }
-
-    chart
-        .configure_series_labels()
-        .position(SeriesLabelPosition::UpperRight)
-        .background_style(WHITE.mix(0.8))
-        .border_style(BLACK)
-        .draw()?;
-
-    root.present()?;
+        Ok(())
+    })?;
 
     println!("\nVisualization saved to 'plots/undersampled_psf_bias.png'");
 
@@ -421,88 +416,83 @@ fn main() -> Result<(), Box<dyn Error>> {
     for (psf_sampling, _, x_bias, y_bias) in all_results.iter() {
         let filename = format!("plots/psf_bias_heatmap_{psf_sampling:.2}_fwhm_per_pixel.png");
 
-        let root_heatmap = BitMapBackend::new(&filename, (1000, 400)).into_drawing_area();
-        root_heatmap.fill(&WHITE)?;
+        save_plot_png(&filename, (1000, 400), |root_heatmap| {
+            root_heatmap.fill(&WHITE)?;
 
-        let areas = root_heatmap.split_evenly((1, 2));
-        let areas_x = &areas[0];
-        let areas_y = &areas[1];
+            let areas = root_heatmap.split_evenly((1, 2));
+            let areas_x = &areas[0];
+            let areas_y = &areas[1];
 
-        // X bias heatmap
-        let mut chart_x = ChartBuilder::on(areas_x)
-            .caption(
-                format!("X Centroid Bias (PSF = {psf_sampling:.2} FWHM/px)"),
-                ("sans-serif", 20),
-            )
-            .margin(10)
-            .x_label_area_size(30)
-            .y_label_area_size(30)
-            .build_cartesian_2d(0..grid_size, 0..grid_size)?;
+            let mut chart_x = ChartBuilder::on(areas_x)
+                .caption(
+                    format!("X Centroid Bias (PSF = {psf_sampling:.2} FWHM/px)"),
+                    ("sans-serif", 20),
+                )
+                .margin(10)
+                .x_label_area_size(30)
+                .y_label_area_size(30)
+                .build_cartesian_2d(0..grid_size, 0..grid_size)?;
 
-        chart_x
-            .configure_mesh()
-            .x_desc("Sub-pixel X (grid)")
-            .y_desc("Sub-pixel Y (grid)")
-            .draw()?;
+            chart_x
+                .configure_mesh()
+                .x_desc("Sub-pixel X (grid)")
+                .y_desc("Sub-pixel Y (grid)")
+                .draw()?;
 
-        // Find max bias for adaptive scaling, but keep minimum scale for visibility
-        let max_abs_bias = x_bias.iter().cloned().map(f64::abs).fold(0.0f64, f64::max);
-        let scale_limit = max_abs_bias.max(0.05); // Minimum scale of 0.05 for visibility
+            let max_abs_bias = x_bias.iter().cloned().map(f64::abs).fold(0.0f64, f64::max);
+            let scale_limit = max_abs_bias.max(0.05);
 
-        chart_x.draw_series(x_bias.indexed_iter().map(|((y, x), &value)| {
-            // Blue for negative, red for positive, white at zero
-            let color = if value < 0.0 {
-                let intensity = (value.abs() / scale_limit).min(1.0);
-                let blue_val = (intensity * 200.0 + 55.0) as u8; // Range 55-255 for better visibility
-                RGBColor(255 - blue_val, 255 - blue_val, 255)
-            } else if value > 0.0 {
-                let intensity = (value.abs() / scale_limit).min(1.0);
-                let red_val = (intensity * 200.0 + 55.0) as u8; // Range 55-255 for better visibility
-                RGBColor(255, 255 - red_val, 255 - red_val)
-            } else {
-                RGBColor(255, 255, 255) // White for zero
-            };
-            Rectangle::new([(x, y), (x + 1, y + 1)], color.filled())
-        }))?;
+            chart_x.draw_series(x_bias.indexed_iter().map(|((y, x), &value)| {
+                let color = if value < 0.0 {
+                    let intensity = (value.abs() / scale_limit).min(1.0);
+                    let blue_val = (intensity * 200.0 + 55.0) as u8;
+                    RGBColor(255 - blue_val, 255 - blue_val, 255)
+                } else if value > 0.0 {
+                    let intensity = (value.abs() / scale_limit).min(1.0);
+                    let red_val = (intensity * 200.0 + 55.0) as u8;
+                    RGBColor(255, 255 - red_val, 255 - red_val)
+                } else {
+                    RGBColor(255, 255, 255)
+                };
+                Rectangle::new([(x, y), (x + 1, y + 1)], color.filled())
+            }))?;
 
-        // Y bias heatmap
-        let mut chart_y = ChartBuilder::on(areas_y)
-            .caption(
-                format!("Y Centroid Bias (PSF = {psf_sampling:.2} FWHM/px)"),
-                ("sans-serif", 20),
-            )
-            .margin(10)
-            .x_label_area_size(30)
-            .y_label_area_size(30)
-            .build_cartesian_2d(0..grid_size, 0..grid_size)?;
+            let mut chart_y = ChartBuilder::on(areas_y)
+                .caption(
+                    format!("Y Centroid Bias (PSF = {psf_sampling:.2} FWHM/px)"),
+                    ("sans-serif", 20),
+                )
+                .margin(10)
+                .x_label_area_size(30)
+                .y_label_area_size(30)
+                .build_cartesian_2d(0..grid_size, 0..grid_size)?;
 
-        chart_y
-            .configure_mesh()
-            .x_desc("Sub-pixel X (grid)")
-            .y_desc("Sub-pixel Y (grid)")
-            .draw()?;
+            chart_y
+                .configure_mesh()
+                .x_desc("Sub-pixel X (grid)")
+                .y_desc("Sub-pixel Y (grid)")
+                .draw()?;
 
-        // Find max bias for Y adaptive scaling
-        let max_abs_bias_y = y_bias.iter().cloned().map(f64::abs).fold(0.0f64, f64::max);
-        let scale_limit_y = max_abs_bias_y.max(0.05); // Minimum scale of 0.05 for visibility
+            let max_abs_bias_y = y_bias.iter().cloned().map(f64::abs).fold(0.0f64, f64::max);
+            let scale_limit_y = max_abs_bias_y.max(0.05);
 
-        chart_y.draw_series(y_bias.indexed_iter().map(|((y, x), &value)| {
-            // Blue for negative, red for positive, white at zero
-            let color = if value < 0.0 {
-                let intensity = (value.abs() / scale_limit_y).min(1.0);
-                let blue_val = (intensity * 200.0 + 55.0) as u8; // Range 55-255 for better visibility
-                RGBColor(255 - blue_val, 255 - blue_val, 255)
-            } else if value > 0.0 {
-                let intensity = (value.abs() / scale_limit_y).min(1.0);
-                let red_val = (intensity * 200.0 + 55.0) as u8; // Range 55-255 for better visibility
-                RGBColor(255, 255 - red_val, 255 - red_val)
-            } else {
-                RGBColor(255, 255, 255) // White for zero
-            };
-            Rectangle::new([(x, y), (x + 1, y + 1)], color.filled())
-        }))?;
+            chart_y.draw_series(y_bias.indexed_iter().map(|((y, x), &value)| {
+                let color = if value < 0.0 {
+                    let intensity = (value.abs() / scale_limit_y).min(1.0);
+                    let blue_val = (intensity * 200.0 + 55.0) as u8;
+                    RGBColor(255 - blue_val, 255 - blue_val, 255)
+                } else if value > 0.0 {
+                    let intensity = (value.abs() / scale_limit_y).min(1.0);
+                    let red_val = (intensity * 200.0 + 55.0) as u8;
+                    RGBColor(255, 255 - red_val, 255 - red_val)
+                } else {
+                    RGBColor(255, 255, 255)
+                };
+                Rectangle::new([(x, y), (x + 1, y + 1)], color.filled())
+            }))?;
 
-        root_heatmap.present()?;
+            Ok(())
+        })?;
 
         println!("  Saved heatmap: {filename}");
     }

--- a/simulator/examples/zodiacal_background.rs
+++ b/simulator/examples/zodiacal_background.rs
@@ -16,6 +16,7 @@ use shared_wasm::StatsScan;
 use simulator::hardware::SatelliteConfig;
 use simulator::image_proc::render::quantize_image;
 use simulator::photometry::{spectrum::Spectrum, zodiacal::SolarAngularCoordinates, ZodiacalLight};
+use simulator::plotting::save_plot_png;
 use simulator::shared_args::{DurationArg, SensorModel, TelescopeModel};
 use simulator::units::{LengthExt, TemperatureExt, Wavelength};
 
@@ -179,69 +180,61 @@ fn create_spectrum_plot(
     let min_wavelength = *wavelengths.first().unwrap();
     let max_wavelength = *wavelengths.last().unwrap();
 
-    // Create a new drawing area
-    let root = BitMapBackend::new(output_path, (1024, 768)).into_drawing_area();
+    save_plot_png(output_path, (1024, 768), |root| {
+        root.fill(&WHITE)?;
 
-    // Fill the background with white
-    root.fill(&WHITE)?;
+        let title = format!(
+            "Zodiacal Light Spectrum at {:.1}° elongation, {:.1}° latitude",
+            coords.elongation(),
+            coords.latitude()
+        );
 
-    // Create chart with title including coordinates
-    let title = format!(
-        "Zodiacal Light Spectrum at {:.1}° elongation, {:.1}° latitude",
-        coords.elongation(),
-        coords.latitude()
-    );
+        let mut chart = ChartBuilder::on(root)
+            .caption(&title, ("sans-serif", 30).into_font())
+            .margin(10)
+            .x_label_area_size(40)
+            .y_label_area_size(80)
+            .build_cartesian_2d(
+                min_wavelength..max_wavelength,
+                min_irradiance..max_irradiance,
+            )?;
 
-    let mut chart = ChartBuilder::on(&root)
-        .caption(&title, ("sans-serif", 30).into_font())
-        .margin(10)
-        .x_label_area_size(40)
-        .y_label_area_size(80)
-        .build_cartesian_2d(
-            min_wavelength..max_wavelength,
-            min_irradiance..max_irradiance,
-        )?;
+        chart
+            .configure_mesh()
+            .x_labels(11)
+            .x_label_formatter(&|x| format!("{x:.0}"))
+            .y_labels(6)
+            .y_label_formatter(&|y| format!("{y:.2e}"))
+            .x_desc("Wavelength (nm)")
+            .y_desc("Spectral Irradiance (erg/(cm²·arcsec²·Hz))")
+            .axis_desc_style(("sans-serif", 18))
+            .draw()?;
 
-    // Configure the mesh
-    chart
-        .configure_mesh()
-        .x_labels(11)
-        .x_label_formatter(&|x| format!("{x:.0}"))
-        .y_labels(6)
-        .y_label_formatter(&|y| format!("{y:.2e}"))
-        .x_desc("Wavelength (nm)")
-        .y_desc("Spectral Irradiance (erg/(cm²·arcsec²·Hz))")
-        .axis_desc_style(("sans-serif", 18))
-        .draw()?;
+        let data_points: Vec<(f64, f64)> = wavelengths
+            .iter()
+            .zip(irradiances.iter())
+            .filter_map(|(&wavelength, &irradiance)| {
+                if irradiance > 0.0 && irradiance.is_finite() {
+                    Some((wavelength, irradiance))
+                } else {
+                    None
+                }
+            })
+            .collect();
 
-    // Create data points for plotting
-    let data_points: Vec<(f64, f64)> = wavelengths
-        .iter()
-        .zip(irradiances.iter())
-        .filter_map(|(&wavelength, &irradiance)| {
-            if irradiance > 0.0 && irradiance.is_finite() {
-                Some((wavelength, irradiance))
-            } else {
-                None
-            }
-        })
-        .collect();
+        chart
+            .draw_series(LineSeries::new(data_points, &BLUE))?
+            .label("Zodiacal Light Spectrum")
+            .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], BLUE));
 
-    // Draw the spectrum curve
-    chart
-        .draw_series(LineSeries::new(data_points, &BLUE))?
-        .label("Zodiacal Light Spectrum")
-        .legend(|(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], BLUE));
+        chart
+            .configure_series_labels()
+            .background_style(WHITE.mix(0.8))
+            .border_style(BLACK)
+            .draw()?;
 
-    // Draw the legend
-    chart
-        .configure_series_labels()
-        .background_style(WHITE.mix(0.8))
-        .border_style(BLACK)
-        .draw()?;
-
-    // Save the plot
-    root.present()?;
+        Ok(())
+    })?;
 
     println!("Zodiacal spectrum plot saved to: {output_path}");
 

--- a/simulator/src/bin/camera_qe_plot.rs
+++ b/simulator/src/bin/camera_qe_plot.rs
@@ -10,6 +10,7 @@
 
 use plotters::prelude::*;
 use simulator::hardware::sensor::models::ALL_SENSORS;
+use simulator::plotting::save_plot_png;
 
 const OUTPUT_PATH: &str = "plots/camera_qe_curves.png";
 const WAVELENGTH_MIN: f32 = 150.0;
@@ -32,67 +33,56 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create plots directory if it doesn't exist
     std::fs::create_dir_all("plots")?;
 
-    // Create a new drawing area
-    let root = BitMapBackend::new(OUTPUT_PATH, (1024, 768)).into_drawing_area();
+    save_plot_png(OUTPUT_PATH, (1024, 768), |root| {
+        root.fill(&WHITE)?;
 
-    // Fill the background with white
-    root.fill(&WHITE)?;
+        let mut chart = ChartBuilder::on(root)
+            .caption(TITLE, ("sans-serif", 30).into_font())
+            .margin(10)
+            .x_label_area_size(40)
+            .y_label_area_size(60)
+            .build_cartesian_2d(WAVELENGTH_MIN..WAVELENGTH_MAX, 0.0..1.0)?;
 
-    // Create chart
-    let mut chart = ChartBuilder::on(&root)
-        .caption(TITLE, ("sans-serif", 30).into_font())
-        .margin(10)
-        .x_label_area_size(40)
-        .y_label_area_size(60)
-        .build_cartesian_2d(WAVELENGTH_MIN..WAVELENGTH_MAX, 0.0..1.0)?;
+        chart
+            .configure_mesh()
+            .x_labels(21)
+            .x_label_formatter(&|x| format!("{x:.0}"))
+            .y_labels(11)
+            .y_label_formatter(&|y| format!("{y:.1}"))
+            .x_desc("Wavelength (nm)")
+            .y_desc("Quantum Efficiency")
+            .axis_desc_style(("sans-serif", 18))
+            .draw()?;
 
-    // Configure the mesh with tick marks every 50nm
-    chart
-        .configure_mesh()
-        .x_labels(21) // 150, 200, 250, 300, ... 1050, 1100, 1150
-        .x_label_formatter(&|x| format!("{x:.0}")) // Remove decimal places
-        .y_labels(11) // 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0
-        .y_label_formatter(&|y| format!("{y:.1}")) // One decimal place for y-axis
-        .x_desc("Wavelength (nm)")
-        .y_desc("Quantum Efficiency")
-        .axis_desc_style(("sans-serif", 18))
-        .draw()?;
-
-    // Sample points for the curves
-    let wavelengths: Vec<f32> = (0..SAMPLE_POINTS)
-        .map(|i| {
-            WAVELENGTH_MIN
-                + (WAVELENGTH_MAX - WAVELENGTH_MIN) * (i as f32) / (SAMPLE_POINTS as f32 - 1.0)
-        })
-        .collect();
-
-    // Draw each sensor's QE curve
-    for (sensor, color) in &sensor_color_pairs {
-        // Generate QE points for this sensor
-        let qe_points: Vec<(f32, f64)> = wavelengths
-            .iter()
-            .map(|&wavelength| (wavelength, sensor.qe_at_wavelength(wavelength as u32)))
+        let wavelengths: Vec<f32> = (0..SAMPLE_POINTS)
+            .map(|i| {
+                WAVELENGTH_MIN
+                    + (WAVELENGTH_MAX - WAVELENGTH_MIN) * (i as f32) / (SAMPLE_POINTS as f32 - 1.0)
+            })
             .collect();
 
-        // Capture color for legend closure
-        let legend_color = **color;
+        for (sensor, color) in &sensor_color_pairs {
+            let qe_points: Vec<(f32, f64)> = wavelengths
+                .iter()
+                .map(|&wavelength| (wavelength, sensor.qe_at_wavelength(wavelength as u32)))
+                .collect();
 
-        // Draw the curve
+            let legend_color = **color;
+
+            chart
+                .draw_series(LineSeries::new(qe_points, color))?
+                .label(&sensor.name)
+                .legend(move |(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], legend_color));
+        }
+
         chart
-            .draw_series(LineSeries::new(qe_points, color))?
-            .label(&sensor.name)
-            .legend(move |(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], legend_color));
-    }
+            .configure_series_labels()
+            .background_style(WHITE.mix(0.8))
+            .border_style(BLACK)
+            .draw()?;
 
-    // Draw the legend
-    chart
-        .configure_series_labels()
-        .background_style(WHITE.mix(0.8))
-        .border_style(BLACK)
-        .draw()?;
-
-    // Save the plot
-    root.present()?;
+        Ok(())
+    })?;
 
     println!("Plot saved to: {OUTPUT_PATH}");
     Ok(())

--- a/simulator/src/bin/dc_vs_z.rs
+++ b/simulator/src/bin/dc_vs_z.rs
@@ -20,6 +20,7 @@ use simulator::photometry::zodiacal::{
     SolarAngularCoordinates, ZodiacalLight, ELONG_OF_MIN, LAT_OF_MIN,
 };
 use simulator::photometry::{photoconversion, QuantumEfficiency};
+use simulator::plotting::save_plot_png;
 use simulator::shared_args::{SensorModel, TelescopeModel};
 use simulator::units::{AreaExt, LengthExt, TemperatureExt};
 use std::time::Duration;
@@ -207,131 +208,122 @@ fn create_comparison_plot(
         min_ratios.push(min_ratio);
     }
 
-    // Create the plot
-    let root = BitMapBackend::new(output_path, (1024, 768)).into_drawing_area();
-    root.fill(&WHITE)?;
+    save_plot_png(output_path, (1024, 768), |root| {
+        root.fill(&WHITE)?;
 
-    let title = format!(
-        "Dark Current vs Zodiacal Light Ratio - {} + {} ({}° solar exclusion)",
-        telescope_config.name, sensor_config.name, solar_exclusion
-    );
+        let title = format!(
+            "Dark Current vs Zodiacal Light Ratio - {} + {} ({}° solar exclusion)",
+            telescope_config.name, sensor_config.name, solar_exclusion
+        );
 
-    // Find plot bounds
-    let min_temp = temperatures.iter().cloned().fold(f64::INFINITY, f64::min);
-    let max_temp = temperatures
-        .iter()
-        .cloned()
-        .fold(f64::NEG_INFINITY, f64::max);
-    let min_ratio = max_ratios
-        .iter()
-        .chain(min_ratios.iter())
-        .cloned()
-        .fold(f64::INFINITY, f64::min);
-    let max_ratio = max_ratios
-        .iter()
-        .chain(min_ratios.iter())
-        .cloned()
-        .fold(f64::NEG_INFINITY, f64::max);
+        let min_temp = temperatures.iter().cloned().fold(f64::INFINITY, f64::min);
+        let max_temp = temperatures
+            .iter()
+            .cloned()
+            .fold(f64::NEG_INFINITY, f64::max);
+        let min_ratio = max_ratios
+            .iter()
+            .chain(min_ratios.iter())
+            .cloned()
+            .fold(f64::INFINITY, f64::min);
+        let max_ratio = max_ratios
+            .iter()
+            .chain(min_ratios.iter())
+            .cloned()
+            .fold(f64::NEG_INFINITY, f64::max);
 
-    let mut chart = ChartBuilder::on(&root)
-        .caption(&title, ("sans-serif", 20).into_font())
-        .margin(10)
-        .x_label_area_size(40)
-        .y_label_area_size(80)
-        .build_cartesian_2d(
-            min_temp..max_temp,
-            ((min_ratio * 0.5).max(0.001)..(max_ratio * 2.0)).log_scale(),
-        )?;
+        let mut chart = ChartBuilder::on(root)
+            .caption(&title, ("sans-serif", 20).into_font())
+            .margin(10)
+            .x_label_area_size(40)
+            .y_label_area_size(80)
+            .build_cartesian_2d(
+                min_temp..max_temp,
+                ((min_ratio * 0.5).max(0.001)..(max_ratio * 2.0)).log_scale(),
+            )?;
 
-    chart
-        .configure_mesh()
-        .x_labels(11)
-        .x_label_formatter(&|x| format!("{x:.0}°C"))
-        .y_labels(8)
-        .y_label_formatter(&|y| {
-            if *y >= 1.0 {
-                format!("{y:.1}")
-            } else {
-                format!("{y:.2}")
-            }
-        })
-        .x_desc("Temperature (°C)")
-        .y_desc("Dark Current / Zodiacal Light Ratio (log scale)")
-        .axis_desc_style(("sans-serif", 18))
-        .draw()?;
+        chart
+            .configure_mesh()
+            .x_labels(11)
+            .x_label_formatter(&|x| format!("{x:.0}°C"))
+            .y_labels(8)
+            .y_label_formatter(&|y| {
+                if *y >= 1.0 {
+                    format!("{y:.1}")
+                } else {
+                    format!("{y:.2}")
+                }
+            })
+            .x_desc("Temperature (°C)")
+            .y_desc("Dark Current / Zodiacal Light Ratio (log scale)")
+            .axis_desc_style(("sans-serif", 18))
+            .draw()?;
 
-    // Add horizontal line at ratio = 1 (crossover point)
-    chart.draw_series(std::iter::once(Rectangle::new(
-        [(min_temp, 1.0), (max_temp, 1.0)],
-        BLACK.stroke_width(2),
-    )))?;
+        chart.draw_series(std::iter::once(Rectangle::new(
+            [(min_temp, 1.0), (max_temp, 1.0)],
+            BLACK.stroke_width(2),
+        )))?;
 
-    // Plot max zodiacal ratio
-    let max_data: Vec<(f64, f64)> = temperatures
-        .iter()
-        .zip(max_ratios.iter())
-        .map(|(&t, &r)| (t, r))
-        .collect();
-    chart.draw_series(LineSeries::new(max_data, RED.stroke_width(3)))?;
+        let max_data: Vec<(f64, f64)> = temperatures
+            .iter()
+            .zip(max_ratios.iter())
+            .map(|(&t, &r)| (t, r))
+            .collect();
+        chart.draw_series(LineSeries::new(max_data, RED.stroke_width(3)))?;
 
-    // Plot min zodiacal ratio
-    let min_data: Vec<(f64, f64)> = temperatures
-        .iter()
-        .zip(min_ratios.iter())
-        .map(|(&t, &r)| (t, r))
-        .collect();
-    chart.draw_series(LineSeries::new(min_data, BLUE.stroke_width(3)))?;
+        let min_data: Vec<(f64, f64)> = temperatures
+            .iter()
+            .zip(min_ratios.iter())
+            .map(|(&t, &r)| (t, r))
+            .collect();
+        chart.draw_series(LineSeries::new(min_data, BLUE.stroke_width(3)))?;
 
-    // Add text annotations for key insights
-    chart.draw_series(std::iter::once(Text::new(
-        "Dark current dominates above line",
-        (min_temp + 2.0, 1.2),
-        ("sans-serif", 14).into_font(),
-    )))?;
+        chart.draw_series(std::iter::once(Text::new(
+            "Dark current dominates above line",
+            (min_temp + 2.0, 1.2),
+            ("sans-serif", 14).into_font(),
+        )))?;
 
-    chart.draw_series(std::iter::once(Text::new(
-        "Zodiacal dominates below line",
-        (max_temp - 15.0, 0.8),
-        ("sans-serif", 14).into_font(),
-    )))?;
+        chart.draw_series(std::iter::once(Text::new(
+            "Zodiacal dominates below line",
+            (max_temp - 15.0, 0.8),
+            ("sans-serif", 14).into_font(),
+        )))?;
 
-    // Draw legend in top-left corner manually
-    let legend_x = min_temp + 2.0;
-    let legend_y_base = max_ratio * 0.7;
+        let legend_x = min_temp + 2.0;
+        let legend_y_base = max_ratio * 0.7;
 
-    // Draw legend background
-    chart.draw_series(std::iter::once(Rectangle::new(
-        [
-            (legend_x - 1.0, legend_y_base * 1.5),
-            (legend_x + 12.0, legend_y_base * 0.3),
-        ],
-        WHITE.mix(0.9).filled().stroke_width(1),
-    )))?;
+        chart.draw_series(std::iter::once(Rectangle::new(
+            [
+                (legend_x - 1.0, legend_y_base * 1.5),
+                (legend_x + 12.0, legend_y_base * 0.3),
+            ],
+            WHITE.mix(0.9).filled().stroke_width(1),
+        )))?;
 
-    // Draw legend lines and text
-    chart.draw_series(std::iter::once(PathElement::new(
-        vec![(legend_x, legend_y_base), (legend_x + 3.0, legend_y_base)],
-        RED.stroke_width(3),
-    )))?;
-    chart.draw_series(std::iter::once(Text::new(
-        format!("vs Max Zodiacal ({solar_exclusion}° from Sun)"),
-        (legend_x + 3.5, legend_y_base),
-        ("sans-serif", 12).into_font(),
-    )))?;
+        chart.draw_series(std::iter::once(PathElement::new(
+            vec![(legend_x, legend_y_base), (legend_x + 3.0, legend_y_base)],
+            RED.stroke_width(3),
+        )))?;
+        chart.draw_series(std::iter::once(Text::new(
+            format!("vs Max Zodiacal ({solar_exclusion}° from Sun)"),
+            (legend_x + 3.5, legend_y_base),
+            ("sans-serif", 12).into_font(),
+        )))?;
 
-    chart.draw_series(std::iter::once(PathElement::new(
-        vec![
-            (legend_x, legend_y_base * 0.7),
-            (legend_x + 3.0, legend_y_base * 0.7),
-        ],
-        BLUE.stroke_width(3),
-    )))?;
-    chart.draw_series(std::iter::once(Text::new(
-        "vs Min Zodiacal (165°, 75°)",
-        (legend_x + 3.5, legend_y_base * 0.7),
-        ("sans-serif", 12).into_font(),
-    )))?;
+        chart.draw_series(std::iter::once(PathElement::new(
+            vec![
+                (legend_x, legend_y_base * 0.7),
+                (legend_x + 3.0, legend_y_base * 0.7),
+            ],
+            BLUE.stroke_width(3),
+        )))?;
+        chart.draw_series(std::iter::once(Text::new(
+            "vs Min Zodiacal (165°, 75°)",
+            (legend_x + 3.5, legend_y_base * 0.7),
+            ("sans-serif", 12).into_font(),
+        )))?;
 
-    root.present()?;
-    Ok(())
+        Ok(())
+    })
 }

--- a/simulator/src/bin/mag_to_flux.rs
+++ b/simulator/src/bin/mag_to_flux.rs
@@ -10,6 +10,7 @@ use simulator::hardware::satellite::FocalPlaneConfig;
 use simulator::hardware::SatelliteConfig;
 use simulator::image_proc::render::StarInFrame;
 use simulator::photometry::zodiacal::SolarAngularCoordinates;
+use simulator::plotting::save_plot_png;
 use simulator::shared_args::{SensorModel, TelescopeModel};
 use simulator::star_data_to_fluxes;
 use simulator::Scene;
@@ -75,119 +76,112 @@ fn create_plot(
     all_results: &[DetectorResults],
     output_path: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Create plots directory if it doesn't exist
     std::fs::create_dir_all("plots")?;
 
-    // Create plot with 2x resolution
-    let root = BitMapBackend::new(output_path, (1600, 1200)).into_drawing_area();
-    root.fill(&WHITE)?;
+    save_plot_png(output_path, (1600, 1200), |root| {
+        root.fill(&WHITE)?;
 
-    // Find min/max for scaling across all detectors
-    let min_mag = all_results
-        .iter()
-        .flat_map(|r| r.data_points.iter())
-        .map(|&(m, _)| m)
-        .fold(f64::INFINITY, f64::min);
-    let max_mag = all_results
-        .iter()
-        .flat_map(|r| r.data_points.iter())
-        .map(|&(m, _)| m)
-        .fold(f64::NEG_INFINITY, f64::max);
-    let min_flux = all_results
-        .iter()
-        .flat_map(|r| r.data_points.iter())
-        .map(|&(_, f)| f)
-        .fold(f64::INFINITY, f64::min)
-        .max(1.0);
-    let max_flux = all_results
-        .iter()
-        .flat_map(|r| r.data_points.iter())
-        .map(|&(_, f)| f)
-        .fold(f64::NEG_INFINITY, f64::max);
-
-    let mut chart = ChartBuilder::on(&root)
-        .caption("Magnitude vs Flux (DN)", ("sans-serif", 40))
-        .margin(10)
-        .x_label_area_size(40)
-        .y_label_area_size(60)
-        .build_cartesian_2d(min_mag..max_mag, (min_flux..max_flux).log_scale())?;
-
-    chart
-        .configure_mesh()
-        .x_desc("Magnitude")
-        .y_desc("Flux (DN) - Log Scale")
-        .draw()?;
-
-    // Define colors for each detector
-    let detector_colors = [("Dao", &BLUE), ("Iraf", &GREEN), ("Naive", &RED)];
-
-    // Plot data and fits for each detector
-    for (idx, results) in all_results.iter().enumerate() {
-        let color = detector_colors[idx].1;
-
-        // Plot measured data points
-        chart
-            .draw_series(PointSeries::of_element(
-                results.data_points.iter().map(|&(m, f)| (m, f)),
-                5,
-                color,
-                &|c, s, st| Circle::new(c, s, st.filled()),
-            ))?
-            .label(&results.detector_name)
-            .legend(move |(x, y)| Circle::new((x + 5, y), 3, color.filled()));
-
-        // Calculate linear fit for this detector
-        let fit_points: Vec<(f64, f64)> = results
-            .data_points
+        let min_mag = all_results
             .iter()
-            .filter(|&&(m, f)| m >= results.fit_range.0 && m <= results.fit_range.1 && f > 0.0)
-            .copied()
-            .collect();
+            .flat_map(|r| r.data_points.iter())
+            .map(|&(m, _)| m)
+            .fold(f64::INFINITY, f64::min);
+        let max_mag = all_results
+            .iter()
+            .flat_map(|r| r.data_points.iter())
+            .map(|&(m, _)| m)
+            .fold(f64::NEG_INFINITY, f64::max);
+        let min_flux = all_results
+            .iter()
+            .flat_map(|r| r.data_points.iter())
+            .map(|&(_, f)| f)
+            .fold(f64::INFINITY, f64::min)
+            .max(1.0);
+        let max_flux = all_results
+            .iter()
+            .flat_map(|r| r.data_points.iter())
+            .map(|&(_, f)| f)
+            .fold(f64::NEG_INFINITY, f64::max);
 
-        if !fit_points.is_empty() {
-            // Calculate linear regression in log space
-            let n = fit_points.len() as f64;
-            let sum_x: f64 = fit_points.iter().map(|(m, _)| m).sum();
-            let sum_y: f64 = fit_points.iter().map(|(_, f)| f.log10()).sum();
-            let sum_xy: f64 = fit_points.iter().map(|(m, f)| m * f.log10()).sum();
-            let sum_x2: f64 = fit_points.iter().map(|(m, _)| m * m).sum();
+        let mut chart = ChartBuilder::on(root)
+            .caption("Magnitude vs Flux (DN)", ("sans-serif", 40))
+            .margin(10)
+            .x_label_area_size(40)
+            .y_label_area_size(60)
+            .build_cartesian_2d(min_mag..max_mag, (min_flux..max_flux).log_scale())?;
 
-            // Linear regression formulas
-            let slope = (n * sum_xy - sum_x * sum_y) / (n * sum_x2 - sum_x * sum_x);
-            let intercept = (sum_y - slope * sum_x) / n;
+        chart
+            .configure_mesh()
+            .x_desc("Magnitude")
+            .y_desc("Flux (DN) - Log Scale")
+            .draw()?;
 
-            // Create fitted line endpoints
-            let fit_min_mag = fit_points
-                .iter()
-                .map(|(m, _)| *m)
-                .fold(f64::INFINITY, f64::min);
-            let fit_max_mag = fit_points
-                .iter()
-                .map(|(m, _)| *m)
-                .fold(f64::NEG_INFINITY, f64::max);
+        let detector_colors = [("Dao", &BLUE), ("Iraf", &GREEN), ("Naive", &RED)];
 
-            let pogson_points = vec![
-                (fit_min_mag, 10_f64.powf(slope * fit_min_mag + intercept)),
-                (fit_max_mag, 10_f64.powf(slope * fit_max_mag + intercept)),
-            ];
+        for (idx, results) in all_results.iter().enumerate() {
+            let color = detector_colors[idx].1;
 
             chart
-                .draw_series(LineSeries::new(pogson_points, &color.mix(0.7)))?
-                .label(format!(
-                    "{} fit (slope={:.3})",
-                    results.detector_name, slope
-                ))
-                .legend(move |(x, y)| PathElement::new(vec![(x, y), (x + 10, y)], color.mix(0.7)));
+                .draw_series(PointSeries::of_element(
+                    results.data_points.iter().map(|&(m, f)| (m, f)),
+                    5,
+                    color,
+                    &|c, s, st| Circle::new(c, s, st.filled()),
+                ))?
+                .label(&results.detector_name)
+                .legend(move |(x, y)| Circle::new((x + 5, y), 3, color.filled()));
+
+            let fit_points: Vec<(f64, f64)> = results
+                .data_points
+                .iter()
+                .filter(|&&(m, f)| m >= results.fit_range.0 && m <= results.fit_range.1 && f > 0.0)
+                .copied()
+                .collect();
+
+            if !fit_points.is_empty() {
+                let n = fit_points.len() as f64;
+                let sum_x: f64 = fit_points.iter().map(|(m, _)| m).sum();
+                let sum_y: f64 = fit_points.iter().map(|(_, f)| f.log10()).sum();
+                let sum_xy: f64 = fit_points.iter().map(|(m, f)| m * f.log10()).sum();
+                let sum_x2: f64 = fit_points.iter().map(|(m, _)| m * m).sum();
+
+                let slope = (n * sum_xy - sum_x * sum_y) / (n * sum_x2 - sum_x * sum_x);
+                let intercept = (sum_y - slope * sum_x) / n;
+
+                let fit_min_mag = fit_points
+                    .iter()
+                    .map(|(m, _)| *m)
+                    .fold(f64::INFINITY, f64::min);
+                let fit_max_mag = fit_points
+                    .iter()
+                    .map(|(m, _)| *m)
+                    .fold(f64::NEG_INFINITY, f64::max);
+
+                let pogson_points = vec![
+                    (fit_min_mag, 10_f64.powf(slope * fit_min_mag + intercept)),
+                    (fit_max_mag, 10_f64.powf(slope * fit_max_mag + intercept)),
+                ];
+
+                chart
+                    .draw_series(LineSeries::new(pogson_points, &color.mix(0.7)))?
+                    .label(format!(
+                        "{} fit (slope={:.3})",
+                        results.detector_name, slope
+                    ))
+                    .legend(move |(x, y)| {
+                        PathElement::new(vec![(x, y), (x + 10, y)], color.mix(0.7))
+                    });
+            }
         }
-    }
 
-    chart
-        .configure_series_labels()
-        .background_style(WHITE.mix(0.8))
-        .border_style(BLACK)
-        .draw()?;
+        chart
+            .configure_series_labels()
+            .background_style(WHITE.mix(0.8))
+            .border_style(BLACK)
+            .draw()?;
 
-    root.present()?;
+        Ok(())
+    })?;
     println!("\nPlot saved to {output_path}");
 
     Ok(())

--- a/simulator/src/bin/stellar_color_plot.rs
+++ b/simulator/src/bin/stellar_color_plot.rs
@@ -21,6 +21,7 @@ use simulator::photometry::stellar::BlackbodyStellarSpectrum;
 use simulator::photometry::{
     generate_temperature_sequence, spectrum_to_rgb_values, temperature_to_spectral_class,
 };
+use simulator::plotting::save_plot_png;
 use std::error::Error;
 
 /// Command line arguments for stellar spectrum plotting
@@ -225,106 +226,92 @@ fn generate_stellar_plot(args: &Args) -> Result<(), Box<dyn Error>> {
     // Generate spectral info including human-perceived colors
     let stellar_info = create_stellar_spectra(args);
 
-    // Create drawing area for the plot
-    let root = BitMapBackend::new(&args.output, (1024, 768)).into_drawing_area();
+    save_plot_png(&args.output, (1024, 768), |root| {
+        root.fill(&BLACK)?;
 
-    // Fill the background with black
-    root.fill(&BLACK)?;
+        let mut chart = ChartBuilder::on(root)
+            .caption(
+                "Stellar Spectra by Temperature",
+                ("sans-serif", 30).into_font().color(&WHITE),
+            )
+            .margin(10)
+            .x_label_area_size(40)
+            .y_label_area_size(60)
+            .build_cartesian_2d(args.wavelength_min..args.wavelength_max, 0.0f64..1.0f64)?;
 
-    // Create chart with specified wavelength range
-    let mut chart = ChartBuilder::on(&root)
-        .caption(
-            "Stellar Spectra by Temperature",
-            ("sans-serif", 30).into_font().color(&WHITE),
-        )
-        .margin(10)
-        .x_label_area_size(40)
-        .y_label_area_size(60)
-        .build_cartesian_2d(args.wavelength_min..args.wavelength_max, 0.0f64..1.0f64)?;
+        let x_grid_spacing = 500.0;
+        let y_grid_spacing = 0.25;
 
-    // Configure grid and labels
-    // Calculate grid spacing based on input parameters - much sparser
-    let x_grid_spacing = 500.0; // nm - much wider spacing
-    let y_grid_spacing = 0.25; // normalized irradiance - 4 grid lines total
+        fn ceil_div(a: f64, b: f64) -> usize {
+            (a / b).ceil() as usize
+        }
 
-    // Use explicit function to resolve ambiguous float type
-    fn ceil_div(a: f64, b: f64) -> usize {
-        (a / b).ceil() as usize
-    }
+        let x_label_count = ceil_div(args.wavelength_max - args.wavelength_min, x_grid_spacing) + 1;
+        let y_label_count = ceil_div(1.0, y_grid_spacing) + 1;
 
-    let x_label_count = ceil_div(args.wavelength_max - args.wavelength_min, x_grid_spacing) + 1;
-    let y_label_count = ceil_div(1.0, y_grid_spacing) + 1;
+        chart
+            .configure_mesh()
+            .x_labels(x_label_count)
+            .y_labels(y_label_count)
+            .x_label_formatter(&|x| format!("{}", *x as i32))
+            .y_label_formatter(&|y| format!("{y:.1}"))
+            .axis_desc_style(("sans-serif", 18).into_font().color(&WHITE))
+            .label_style(("sans-serif", 14).into_font().color(&WHITE))
+            .x_desc("Wavelength (nm)")
+            .y_desc("Normalized Spectral Irradiance")
+            .light_line_style(WHITE.mix(0.4))
+            .draw()?;
 
-    chart
-        .configure_mesh()
-        .x_labels(x_label_count) // Compute from wavelength range and desired spacing
-        .y_labels(y_label_count) // Will show 0.0, 0.1, 0.2, ... 1.0
-        .x_label_formatter(&|x| format!("{}", *x as i32)) // Integer labels
-        .y_label_formatter(&|y| format!("{y:.1}")) // One decimal point for y-axis labels
-        .axis_desc_style(("sans-serif", 18).into_font().color(&WHITE))
-        .label_style(("sans-serif", 14).into_font().color(&WHITE))
-        .x_desc("Wavelength (nm)")
-        .y_desc("Normalized Spectral Irradiance")
-        .light_line_style(WHITE.mix(0.4)) // More visible grey grid lines
-        .draw()?;
-
-    // Sample wavelengths for the plot
-    let wavelengths: Vec<f64> = (0..args.sample_points)
-        .map(|i| {
-            args.wavelength_min
-                + (args.wavelength_max - args.wavelength_min) * (i as f64)
-                    / (args.sample_points as f64 - 1.0)
-        })
-        .collect();
-
-    // Get the maximum irradiance value across all spectra for normalization
-    let all_irradiances: Vec<f64> = stellar_info
-        .iter()
-        .flat_map(|info| {
-            wavelengths.iter().map(|&wl| {
-                info.spectrum
-                    .spectral_irradiance(Wavelength::from_nanometers(wl))
-            })
-        })
-        .collect();
-    let irr_scan = StatsScan::new(&all_irradiances);
-    let max_irr = irr_scan.max().unwrap_or(1.0);
-
-    // Draw each spectrum
-    for star in &stellar_info {
-        // Generate normalized data points
-        let data_points: Vec<(f64, f64)> = wavelengths
-            .iter()
-            .map(|&wavelength| {
-                let irradiance = star
-                    .spectrum
-                    .spectral_irradiance(Wavelength::from_nanometers(wavelength));
-                (wavelength, irradiance / max_irr)
+        let wavelengths: Vec<f64> = (0..args.sample_points)
+            .map(|i| {
+                args.wavelength_min
+                    + (args.wavelength_max - args.wavelength_min) * (i as f64)
+                        / (args.sample_points as f64 - 1.0)
             })
             .collect();
 
-        // Create label with temperature and spectral class
-        let label = format!(
-            "{}K (Class {})",
-            star.temperature as u32, star.spectral_class
-        );
+        let all_irradiances: Vec<f64> = stellar_info
+            .iter()
+            .flat_map(|info| {
+                wavelengths.iter().map(|&wl| {
+                    info.spectrum
+                        .spectral_irradiance(Wavelength::from_nanometers(wl))
+                })
+            })
+            .collect();
+        let irr_scan = StatsScan::new(&all_irradiances);
+        let max_irr = irr_scan.max().unwrap_or(1.0);
 
-        // Draw the spectrum with its perceived color
+        for star in &stellar_info {
+            let data_points: Vec<(f64, f64)> = wavelengths
+                .iter()
+                .map(|&wavelength| {
+                    let irradiance = star
+                        .spectrum
+                        .spectral_irradiance(Wavelength::from_nanometers(wavelength));
+                    (wavelength, irradiance / max_irr)
+                })
+                .collect();
+
+            let label = format!(
+                "{}K (Class {})",
+                star.temperature as u32, star.spectral_class
+            );
+
+            chart
+                .draw_series(LineSeries::new(data_points, &star.color))?
+                .label(label)
+                .legend(move |(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], star.color));
+        }
+
         chart
-            .draw_series(LineSeries::new(data_points, &star.color))?
-            .label(label)
-            .legend(move |(x, y)| PathElement::new(vec![(x, y), (x + 20, y)], star.color));
-    }
+            .configure_series_labels()
+            .background_style(BLACK.mix(0.7))
+            .border_style(WHITE)
+            .label_font(("sans-serif", 14).into_font().color(&WHITE))
+            .position(SeriesLabelPosition::UpperRight)
+            .draw()?;
 
-    // Draw the legend with black background for visibility
-    chart
-        .configure_series_labels()
-        .background_style(BLACK.mix(0.7))
-        .border_style(WHITE)
-        .label_font(("sans-serif", 14).into_font().color(&WHITE))
-        .position(SeriesLabelPosition::UpperRight)
-        .draw()?;
-
-    root.present()?;
-    Ok(())
+        Ok(())
+    })
 }

--- a/simulator/src/lib.rs
+++ b/simulator/src/lib.rs
@@ -73,6 +73,7 @@ pub mod hardware;
 pub mod image_proc; // render module lives here
 pub mod io;
 pub mod photometry;
+pub mod plotting;
 pub mod scene;
 pub mod shared_args;
 pub mod sims;

--- a/simulator/src/plotting.rs
+++ b/simulator/src/plotting.rs
@@ -1,0 +1,30 @@
+//! Plot-to-PNG helper that pairs `plotters::BitMapBackend` with the `image`
+//! crate for encoding.
+//!
+//! Plotters' built-in PNG saving (`BitMapBackend::new`) requires its
+//! `bitmap_encoder` feature, which hard-pulls `image 0.24` via
+//! `plotters-bitmap 0.3.7`. To keep the dependency tree on a single `image`
+//! version, we disable that feature and drive the buffer + encoder path here.
+
+use std::error::Error;
+use std::path::Path;
+
+use plotters::coord::Shift;
+use plotters::prelude::*;
+
+/// Draw a plot into an RGB8 buffer and save it to `path` as PNG.
+pub fn save_plot_png<P, F>(path: P, size: (u32, u32), draw: F) -> Result<(), Box<dyn Error>>
+where
+    P: AsRef<Path>,
+    F: FnOnce(&DrawingArea<BitMapBackend<'_>, Shift>) -> Result<(), Box<dyn Error>>,
+{
+    let (w, h) = size;
+    let mut buffer = vec![0u8; (w as usize) * (h as usize) * 3];
+    {
+        let root = BitMapBackend::with_buffer(&mut buffer, size).into_drawing_area();
+        draw(&root)?;
+        root.present()?;
+    }
+    image::save_buffer(path, &buffer, w, h, image::ColorType::Rgb8)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Plotters 0.3.7 hard-pulls \`image 0.24\` via its default \`image\` and \`bitmap_encoder\` features (and criterion's default \`plotters\` feature unifies it into our tree), forcing us to carry two major \`image\` versions alongside the 0.25 we use directly.

- Trim \`plotters\` to \`default-features = false\` and enable only the features we actually use: \`bitmap_backend\`, \`svg_backend\`, \`chrono\`, \`ttf\`, \`all_series\`, \`all_elements\`, \`full_palette\`, \`colormaps\`. Dropped: \`image\`, \`bitmap_encoder\`, \`bitmap_gif\`, \`deprecated_items\`.
- Trim \`criterion\` the same way (disable default \`plotters\` feature) so cargo's feature unification doesn't sneak them back in. Benchmarks still build HTML reports — just without inline plot PNGs, which we didn't rely on.
- Without \`plotters-bitmap/image_encoder\`, \`BitMapBackend::new(path, …)\` no longer saves to disk directly. Added \`simulator::plotting::save_plot_png\` that uses \`BitMapBackend::with_buffer\` and encodes the resulting RGB8 buffer with \`image 0.25\`.
- Routed all 12 \`BitMapBackend::new\` call sites (4 bins, 8 examples) through the helper.

## Result

\`\`\`
$ cargo tree -i image
image v0.25.9
├── shared (cfl-foundations)
├── simulator
└── starfield v0.11.0 → shared, simulator
\`\`\`

Single \`image\` version. \`cargo tree --duplicates\` no longer lists \`image\`, \`gif\`, \`jpeg_decoder\`, or the plotters-bitmap pull of \`png\`.

Closes #5.

## Test plan

- [x] \`cargo build --release\` clean
- [x] \`cargo test\` — all 205 tests pass
- [x] \`cargo fmt\` clean
- [x] \`cargo clippy --all-targets -- -W clippy::all\` — no new warnings
- [x] \`cargo tree -i image\` shows single 0.25.9