### PR TITLE
Per-sensor output layout with metadata.json descriptor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2827,6 +2827,8 @@ dependencies = [
  "rand",
  "rand_distr",
  "rayon",
+ "serde",
+ "serde_json",
  "shared",
  "shared-wasm",
  "starfield",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -34,6 +34,8 @@ rand = "0.9"
 rand_distr = "0.5"
 indicatif = "0.17"
 num_cpus = "1.16"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 plotters = { version = "0.3", default-features = false, features = [
     "bitmap_backend",

--- a/simulator/src/bin/motion_simulator.rs
+++ b/simulator/src/bin/motion_simulator.rs
@@ -45,7 +45,10 @@ fn parse_ra_dec(s: &str) -> Result<Equatorial, String> {
         a specified duration. The star catalog is queried once with a broad \
         field of view encompassing the entire trajectory, then each frame \
         is rendered by re-projecting cached stars at the interpolated pointing.\n\n\
-        Output is a sequence of 16-bit grayscale PNG files, one per sensor per frame."
+        Output layout under --output-dir:\n  \
+        - metadata.json at the root describing the run,\n  \
+        - one sensor_NN/ subdirectory per sensor, each containing \
+          frame_NNNNNN.png files (16-bit grayscale PNG)."
 )]
 struct Args {
     #[command(flatten)]
@@ -222,6 +225,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         max_drift_per_sample_px: Some(args.max_drift_per_sample_px),
         force_static: args.force_static,
         quiet: args.quiet,
+        telescope_name: telescope.name.clone(),
+        catalog_path: args.shared.catalog.clone(),
+        temperature_c: args.shared.temperature,
     };
     let frame_count = render_trajectory(&render_config)?;
 
@@ -232,7 +238,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         elapsed.as_secs_f64(),
         frame_count as f64 / elapsed.as_secs_f64()
     );
-    info!("Output: {}", args.output_dir);
+    info!(
+        "Output: {} (metadata.json + sensor_NN/frame_NNNNNN.png layout)",
+        args.output_dir
+    );
 
     Ok(())
 }

--- a/simulator/src/sims/mod.rs
+++ b/simulator/src/sims/mod.rs
@@ -1,6 +1,7 @@
 //! Simulation modules for various experiments
 
 pub mod motion_blur;
+pub mod motion_blur_metadata;
 pub mod orientation;
 pub mod scene_runner;
 pub mod single_detection;

--- a/simulator/src/sims/motion_blur.rs
+++ b/simulator/src/sims/motion_blur.rs
@@ -29,11 +29,12 @@
 //! draws noise, quantizes, and writes its PNG. Nothing is reduced
 //! across tiles.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use chrono::SecondsFormat;
 use image::{ImageBuffer, Luma};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use log::{debug, info};
@@ -53,7 +54,12 @@ use crate::image_proc::render::quantize_image;
 use crate::photometry::photoconversion::SourceFlux;
 use crate::photometry::spectrum::Spectrum;
 use crate::photometry::zodiacal::{SolarAngularCoordinates, ZodiacalLight};
-use crate::sims::orientation::boresight_of;
+use crate::sims::motion_blur_metadata::{
+    sensor_dir_name, sensor_relative_png_path, EquatorialMeta, FrameMeta, HardwareMeta,
+    RenderConfigMeta, RenderMetadata, SensorMeta, StarMeta, TrajectoryMeta, WaypointMeta,
+    ZodiacalMeta,
+};
+use crate::sims::orientation::{boresight_of, roll_of};
 use crate::sims::trajectory::{Trajectory, TrajectoryError};
 use crate::star_math::star_data_to_fluxes;
 
@@ -217,6 +223,17 @@ pub struct MotionBlurConfig {
     /// If true, suppress the indicatif progress bar (INFO logs still emit).
     /// Intended for non-interactive runs where the bar adds noise.
     pub quiet: bool,
+    /// Telescope display name copied into `metadata.json` under
+    /// `hardware.telescope`. Metadata-only; ignored by the render math.
+    pub telescope_name: String,
+    /// Catalog path recorded in `metadata.json` under
+    /// `render_config.catalog_path`. Metadata-only.
+    pub catalog_path: PathBuf,
+    /// Operating temperature (Celsius) recorded in `metadata.json` under
+    /// `hardware.temperature_c`. Metadata-only — the per-tile renderer reads
+    /// the temperature off the per-sensor `SatelliteConfig` built from
+    /// [`FocalPlaneConfig`].
+    pub temperature_c: f64,
 }
 
 impl Default for MotionBlurConfig {
@@ -228,6 +245,9 @@ impl Default for MotionBlurConfig {
             base_seed: None,
             force_static: false,
             quiet: false,
+            telescope_name: String::new(),
+            catalog_path: PathBuf::new(),
+            temperature_c: 0.0,
         }
     }
 }
@@ -569,7 +589,6 @@ pub fn render_motion_trajectory(
     );
 
     // Build (frame, sensor) tile list.
-    let single_sensor = sensor_count == 1;
     let base_seed = config.base_seed.unwrap_or(0xDEADBEEF_DEADBEEF);
 
     #[derive(Clone, Copy)]
@@ -598,16 +617,19 @@ pub fn render_motion_trajectory(
         })
         .collect();
 
+    // Pre-create per-sensor output directories (`<output_dir>/sensor_NN/`).
+    // Tile workers write 16-bit PNGs directly into these subdirs.
+    for sensor_idx in 0..sensor_count {
+        let sensor_dir = output_dir.join(sensor_dir_name(sensor_idx));
+        std::fs::create_dir_all(&sensor_dir)
+            .map_err(|e| TrajectoryError::ImageWrite(e.to_string()))?;
+    }
+
     let output_paths: Vec<PathBuf> = tiles
         .iter()
         .map(|tile| {
             let plan = &plans[tile.frame_plan_idx];
-            let name = if single_sensor {
-                format!("frame_{:06}.png", plan.idx)
-            } else {
-                format!("frame_{:06}_sensor_{:02}.png", plan.idx, tile.sensor_idx)
-            };
-            output_dir.join(name)
+            output_dir.join(sensor_relative_png_path(tile.sensor_idx, plan.idx))
         })
         .collect();
 
@@ -678,8 +700,164 @@ pub fn render_motion_trajectory(
         render_elapsed.as_secs_f64(),
         tiles_per_s,
     );
+    drop(cache);
+
+    // Assemble and write metadata.json describing the render. Every PNG path
+    // recorded here is relative (forward-slash) to `output_dir`.
+    let metadata = build_render_metadata(
+        trajectory,
+        catalog_stars,
+        fp,
+        &satellites,
+        &zodiacal,
+        config,
+        &plans
+            .iter()
+            .map(|p| (p.idx, p.schedule))
+            .collect::<Vec<_>>(),
+        sensor_count,
+    )?;
+    let metadata_path = output_dir.join("metadata.json");
+    let file = std::fs::File::create(&metadata_path)
+        .map_err(|e| TrajectoryError::ImageWrite(e.to_string()))?;
+    let mut writer = std::io::BufWriter::new(file);
+    serde_json::to_writer_pretty(&mut writer, &metadata)
+        .map_err(|e| TrajectoryError::ImageWrite(e.to_string()))?;
+    use std::io::Write;
+    writer
+        .flush()
+        .map_err(|e| TrajectoryError::ImageWrite(e.to_string()))?;
+    info!("Wrote render metadata to {}", metadata_path.display());
 
     Ok(total_frames)
+}
+
+/// Build the [`RenderMetadata`] descriptor from the finalized render plan.
+///
+/// Consumes the per-frame `(frame_idx, schedule)` pairs produced during the
+/// serial planning pass plus the static inputs (catalog, hardware, render
+/// config, zodiacal coords). The `stars` list mirrors `catalog_stars`
+/// verbatim — the caller queries the catalog once for the trajectory
+/// envelope and passes that slice through.
+#[allow(clippy::too_many_arguments)]
+fn build_render_metadata(
+    trajectory: &Trajectory,
+    catalog_stars: &[StarData],
+    fp: &FocalPlaneConfig,
+    satellites: &[SatelliteConfig],
+    zodiacal: &SolarAngularCoordinates,
+    config: &MotionBlurConfig,
+    frame_plans: &[(usize, SubsampleSchedule)],
+    sensor_count: usize,
+) -> Result<RenderMetadata, TrajectoryError> {
+    let rendered_at = chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+
+    let start = trajectory.start_time();
+    let end = trajectory.end_time();
+    let trajectory_meta = TrajectoryMeta {
+        duration_s: (end - start).as_secs_f64(),
+        start_time_s: start.as_secs_f64(),
+        end_time_s: end.as_secs_f64(),
+        waypoints: trajectory
+            .waypoints()
+            .iter()
+            .map(|wp| {
+                let q = wp.orientation;
+                let bore = boresight_of(&q);
+                WaypointMeta {
+                    time_s: wp.time.as_secs_f64(),
+                    quat: [q.w, q.i, q.j, q.k],
+                    boresight: EquatorialMeta {
+                        ra_deg: bore.ra_degrees(),
+                        dec_deg: bore.dec_degrees(),
+                    },
+                    roll_deg: roll_of(&q).to_degrees(),
+                }
+            })
+            .collect(),
+    };
+
+    let mut frames: Vec<FrameMeta> = Vec::with_capacity(frame_plans.len());
+    for (frame_idx, schedule) in frame_plans {
+        let mid_t = (schedule.frame_start + schedule.exposure / 2)
+            .min(trajectory.end_time())
+            .max(trajectory.start_time());
+        let q = trajectory.orientation_at(mid_t)?;
+        let bore = boresight_of(&q);
+        let mut paths: BTreeMap<String, String> = BTreeMap::new();
+        for sensor_idx in 0..sensor_count {
+            paths.insert(
+                sensor_dir_name(sensor_idx),
+                sensor_relative_png_path(sensor_idx, *frame_idx),
+            );
+        }
+        frames.push(FrameMeta {
+            idx: *frame_idx,
+            t_s: schedule.frame_start.as_secs_f64(),
+            exposure_s: schedule.exposure.as_secs_f64(),
+            quat: [q.w, q.i, q.j, q.k],
+            boresight: EquatorialMeta {
+                ra_deg: bore.ra_degrees(),
+                dec_deg: bore.dec_degrees(),
+            },
+            roll_deg: roll_of(&q).to_degrees(),
+            n_subsamples: schedule.n,
+            paths,
+        });
+    }
+
+    let stars: Vec<StarMeta> = catalog_stars
+        .iter()
+        .map(|s| StarMeta {
+            id: s.id,
+            ra_deg: s.position.ra_degrees(),
+            dec_deg: s.position.dec_degrees(),
+            magnitude: s.magnitude,
+            color_index: s.b_v,
+        })
+        .collect();
+
+    let sensors: Vec<SensorMeta> = (0..sensor_count)
+        .map(|i| {
+            let ps = &fp.array.sensors[i];
+            let (width, height) = ps.sensor.dimensions.get_pixel_width_height();
+            SensorMeta {
+                idx: i,
+                name: satellites[i].sensor.name.clone(),
+                dimensions_px: [width, height],
+                position_mm: [ps.position.x_mm, ps.position.y_mm],
+            }
+        })
+        .collect();
+
+    let hardware = HardwareMeta {
+        telescope: config.telescope_name.clone(),
+        temperature_c: config.temperature_c,
+        sensors,
+    };
+
+    let render_config = RenderConfigMeta {
+        exposure_s: config.exposure.as_secs_f64(),
+        timestep_s: config.timestep.as_secs_f64(),
+        max_drift_per_sample_px: config.max_drift_per_sample_px,
+        seed: config.base_seed.unwrap_or(0),
+        force_static: config.force_static,
+        catalog_path: config.catalog_path.to_string_lossy().into_owned(),
+        zodiacal: ZodiacalMeta {
+            elongation_deg: zodiacal.elongation(),
+            latitude_deg: zodiacal.latitude(),
+        },
+    };
+
+    Ok(RenderMetadata {
+        version: "1.0".to_string(),
+        rendered_at,
+        trajectory: trajectory_meta,
+        frames,
+        stars,
+        hardware,
+        render_config,
+    })
 }
 
 /// Per-pixel-per-second zodiacal electron rate at a given boresight for a
@@ -868,6 +1046,7 @@ mod tests {
             base_seed: Some(7),
             force_static,
             quiet: true,
+            ..Default::default()
         };
         let tmp = tempfile::tempdir().unwrap();
         let frames = render_motion_trajectory(
@@ -910,6 +1089,7 @@ mod tests {
             base_seed: Some(3),
             force_static: true,
             quiet: true,
+            ..Default::default()
         };
         let tmp = tempfile::tempdir().unwrap();
         let frames = render_motion_trajectory(
@@ -950,6 +1130,7 @@ mod tests {
             base_seed: Some(11),
             force_static: true,
             quiet: true,
+            ..Default::default()
         };
         let tmp = tempfile::tempdir().unwrap();
         // Render normally to exercise the cache.
@@ -1009,6 +1190,7 @@ mod tests {
             base_seed: Some(101),
             force_static: false,
             quiet: true,
+            ..Default::default()
         };
         let cfg_moving = cfg_static.clone();
 
@@ -1110,6 +1292,7 @@ mod tests {
             base_seed: Some(0),
             force_static: true,
             quiet: true,
+            ..Default::default()
         };
         let acc = simulate_tile_accumulator(&traj, &star, &fp, &cfg);
 
@@ -1159,6 +1342,7 @@ mod tests {
             base_seed: Some(1337),
             force_static: false,
             quiet: true,
+            ..Default::default()
         };
         let tmp_a = tempfile::tempdir().unwrap();
         let tmp_b = tempfile::tempdir().unwrap();
@@ -1181,10 +1365,233 @@ mod tests {
         )
         .unwrap();
 
-        // Compare the PNG bytes of one frame.
-        let name = "frame_000000.png";
+        // Compare the PNG bytes of one frame. The new layout routes frame 0
+        // of sensor 0 to `sensor_00/frame_000000.png`.
+        let name = "sensor_00/frame_000000.png";
         let a = std::fs::read(tmp_a.path().join(name)).unwrap();
         let b = std::fs::read(tmp_b.path().join(name)).unwrap();
         assert_eq!(a, b);
+    }
+
+    // -----------------------------------------------------------------------
+    // Output layout and metadata.json coverage.
+    // -----------------------------------------------------------------------
+
+    /// Build a minimal motion-blur config shaped for the layout/metadata
+    /// tests below. Kept local to tests so production does not carry a
+    /// test-only constructor.
+    fn minimal_metadata_cfg(seed: u64) -> MotionBlurConfig {
+        MotionBlurConfig {
+            timestep: Duration::from_secs(1),
+            exposure: Duration::from_secs(1),
+            max_drift_per_sample_px: 0.1,
+            base_seed: Some(seed),
+            force_static: true,
+            quiet: true,
+            telescope_name: "Test".to_string(),
+            catalog_path: std::path::PathBuf::from("fake_catalog.bin"),
+            temperature_c: -10.0,
+        }
+    }
+
+    #[test]
+    fn test_output_structure_creates_per_sensor_dirs() {
+        // Render two frames on a single-sensor focal plane. Assert that the
+        // per-sensor directory is created, that both frame files land inside
+        // it, and that metadata.json is written at the output root.
+        let fp = tiny_fp();
+        let traj = static_trajectory();
+        let cfg = minimal_metadata_cfg(5);
+        let tmp = tempfile::tempdir().unwrap();
+        let frames = render_motion_trajectory(
+            &traj,
+            &[],
+            &fp,
+            SolarAngularCoordinates::zodiacal_minimum(),
+            &cfg,
+            tmp.path(),
+        )
+        .unwrap();
+        assert!(frames >= 2, "expected at least 2 frames, got {}", frames);
+
+        let sensor_dir = tmp.path().join("sensor_00");
+        assert!(sensor_dir.is_dir(), "sensor_00 directory must exist");
+        assert!(sensor_dir.join("frame_000000.png").is_file());
+        assert!(sensor_dir.join("frame_000001.png").is_file());
+
+        let metadata_path = tmp.path().join("metadata.json");
+        assert!(metadata_path.is_file(), "metadata.json must exist");
+
+        // The legacy flat-layout file must not be produced any more.
+        assert!(!tmp.path().join("frame_000000.png").exists());
+        assert!(!tmp.path().join("frame_000000_sensor_00.png").exists());
+    }
+
+    #[test]
+    fn test_metadata_json_round_trip() {
+        // Render a tiny sequence, parse metadata.json back as a generic
+        // serde_json::Value, and spot-check the shape-level invariants.
+        let fp = tiny_fp();
+        let traj = static_trajectory();
+        let cfg = minimal_metadata_cfg(17);
+        let tmp = tempfile::tempdir().unwrap();
+        let frames = render_motion_trajectory(
+            &traj,
+            &[],
+            &fp,
+            SolarAngularCoordinates::zodiacal_minimum(),
+            &cfg,
+            tmp.path(),
+        )
+        .unwrap();
+        let raw = std::fs::read_to_string(tmp.path().join("metadata.json")).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
+
+        assert_eq!(v["version"], "1.0");
+        let frames_arr = v["frames"].as_array().unwrap();
+        assert_eq!(frames_arr.len(), frames);
+        assert!(frames_arr[0]["paths"]
+            .as_object()
+            .unwrap()
+            .contains_key("sensor_00"));
+        assert_eq!(
+            frames_arr[0]["paths"]["sensor_00"], "sensor_00/frame_000000.png",
+            "relative PNG path should use forward slashes and match layout"
+        );
+
+        let waypoints = v["trajectory"]["waypoints"].as_array().unwrap();
+        assert!(
+            waypoints.len() >= 2,
+            "trajectory must expose >= 2 waypoints"
+        );
+        // quat is [w, x, y, z] — 4 elements.
+        assert_eq!(waypoints[0]["quat"].as_array().unwrap().len(), 4);
+
+        assert!(v["stars"].is_array());
+
+        let sensors = v["hardware"]["sensors"].as_array().unwrap();
+        let dims = sensors[0]["dimensions_px"].as_array().unwrap();
+        assert_eq!(dims.len(), 2);
+        assert!(dims[0].as_u64().unwrap() > 0);
+        assert!(dims[1].as_u64().unwrap() > 0);
+
+        let zodi = &v["render_config"]["zodiacal"];
+        assert!(zodi["elongation_deg"].is_number());
+        assert!(zodi["latitude_deg"].is_number());
+    }
+
+    #[test]
+    fn test_metadata_frame_boresight_matches_trajectory() {
+        // The mid-frame boresight recorded in metadata.json must match the
+        // one computed from `trajectory.orientation_at(mid_t)` to within
+        // numerical noise.
+        let fp = tiny_fp();
+        let traj = static_trajectory();
+        let cfg = minimal_metadata_cfg(23);
+        let tmp = tempfile::tempdir().unwrap();
+        render_motion_trajectory(
+            &traj,
+            &[],
+            &fp,
+            SolarAngularCoordinates::zodiacal_minimum(),
+            &cfg,
+            tmp.path(),
+        )
+        .unwrap();
+        let raw = std::fs::read_to_string(tmp.path().join("metadata.json")).unwrap();
+        let meta: crate::sims::motion_blur_metadata::RenderMetadata =
+            serde_json::from_str(&raw).unwrap();
+
+        for frame in &meta.frames {
+            // Mid-frame orientation: same clamping as the renderer.
+            let frame_start = Duration::from_secs_f64(frame.t_s);
+            let exposure = Duration::from_secs_f64(frame.exposure_s);
+            let mid_t = (frame_start + exposure / 2)
+                .min(traj.end_time())
+                .max(traj.start_time());
+            let q = traj.orientation_at(mid_t).unwrap();
+            let expected = boresight_of(&q);
+            assert!(
+                (frame.boresight.ra_deg - expected.ra_degrees()).abs() < 1e-9,
+                "frame {} RA mismatch: meta={} expected={}",
+                frame.idx,
+                frame.boresight.ra_deg,
+                expected.ra_degrees()
+            );
+            assert!(
+                (frame.boresight.dec_deg - expected.dec_degrees()).abs() < 1e-9,
+                "frame {} Dec mismatch: meta={} expected={}",
+                frame.idx,
+                frame.boresight.dec_deg,
+                expected.dec_degrees()
+            );
+        }
+    }
+
+    #[test]
+    fn test_metadata_quat_is_wxyz_order() {
+        // Build a trajectory whose first waypoint has a known roll about the
+        // boresight. The UnitQuaternion for a rotation of angle θ about a
+        // unit axis has w = cos(θ/2). We emit quat = [w, x, y, z], so
+        // meta.waypoints[0].quat[0] must match cos(θ/2) under the composed
+        // orientation.
+        use crate::sims::orientation::orientation_from_pointing;
+
+        let pointing = Equatorial::from_degrees(45.0, 30.0);
+        let roll = 0.7_f64; // radians
+        let traj = Trajectory::from_endpoints_with_roll(
+            pointing,
+            roll,
+            pointing,
+            roll,
+            Duration::from_secs(10),
+        )
+        .unwrap();
+
+        let fp = tiny_fp();
+        let cfg = minimal_metadata_cfg(31);
+        let tmp = tempfile::tempdir().unwrap();
+        render_motion_trajectory(
+            &traj,
+            &[],
+            &fp,
+            SolarAngularCoordinates::zodiacal_minimum(),
+            &cfg,
+            tmp.path(),
+        )
+        .unwrap();
+        let raw = std::fs::read_to_string(tmp.path().join("metadata.json")).unwrap();
+        let meta: crate::sims::motion_blur_metadata::RenderMetadata =
+            serde_json::from_str(&raw).unwrap();
+
+        // Expected quat comes directly from nalgebra's constructor to avoid
+        // re-deriving the half-angle formula under roll composition.
+        let q_expected = orientation_from_pointing(&pointing, roll);
+        let wp0 = &meta.trajectory.waypoints[0];
+        assert!(
+            (wp0.quat[0] - q_expected.w).abs() < 1e-12,
+            "quat[0] (w) = {} vs nalgebra w = {}",
+            wp0.quat[0],
+            q_expected.w
+        );
+        assert!((wp0.quat[1] - q_expected.i).abs() < 1e-12);
+        assert!((wp0.quat[2] - q_expected.j).abs() < 1e-12);
+        assert!((wp0.quat[3] - q_expected.k).abs() < 1e-12);
+
+        // Round-trip: reconstruct a UnitQuaternion from [w, x, y, z] and
+        // check that roll_of recovers the original roll.
+        let q_round = nalgebra::UnitQuaternion::from_quaternion(nalgebra::Quaternion::new(
+            wp0.quat[0],
+            wp0.quat[1],
+            wp0.quat[2],
+            wp0.quat[3],
+        ));
+        let recovered = roll_of(&q_round);
+        assert!(
+            (recovered - roll).abs() < 1e-9,
+            "roll_of(reconstructed quat) = {} expected {}",
+            recovered,
+            roll
+        );
     }
 }

--- a/simulator/src/sims/motion_blur_metadata.rs
+++ b/simulator/src/sims/motion_blur_metadata.rs
@@ -1,0 +1,263 @@
+//! Render-descriptor schema emitted alongside the motion-blur PNG sequence.
+//!
+//! The motion-blur renderer writes one `metadata.json` per output directory
+//! describing the trajectory, per-frame orientation/exposure, the set of
+//! catalog stars queried for the run, the hardware configuration, and the
+//! render knobs. The JSON shape is stable and versioned via
+//! [`RenderMetadata::version`] so downstream consumers can match on it.
+//!
+//! # File layout assumption
+//!
+//! The renderer writes PNG files under per-sensor subdirectories:
+//!
+//! ```text
+//! <output_dir>/
+//! ├── metadata.json
+//! ├── sensor_00/
+//! │   ├── frame_000000.png
+//! │   └── frame_000001.png
+//! └── sensor_01/
+//!     └── ...
+//! ```
+//!
+//! The `paths` map on each [`FrameMeta`] stores relative forward-slash paths
+//! of the form `"sensor_00/frame_000000.png"` — portable across platforms.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Root descriptor written as `metadata.json` at the output-directory root.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RenderMetadata {
+    /// Schema version for this descriptor. Currently always `"1.0"`.
+    pub version: String,
+    /// ISO-8601 UTC timestamp at which the render finished building metadata.
+    pub rendered_at: String,
+    /// Trajectory-level summary (duration and waypoints).
+    pub trajectory: TrajectoryMeta,
+    /// One entry per rendered frame.
+    pub frames: Vec<FrameMeta>,
+    /// Catalog stars covering the trajectory envelope, recorded verbatim.
+    pub stars: Vec<StarMeta>,
+    /// Telescope + sensor array hardware summary.
+    pub hardware: HardwareMeta,
+    /// Render knobs (exposure, timestep, seed, etc.).
+    pub render_config: RenderConfigMeta,
+}
+
+/// Summary of the trajectory: duration and its waypoints.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrajectoryMeta {
+    /// End time minus start time, in seconds.
+    pub duration_s: f64,
+    /// Trajectory start time (seconds from trajectory origin).
+    pub start_time_s: f64,
+    /// Trajectory end time (seconds from trajectory origin).
+    pub end_time_s: f64,
+    /// Ordered list of waypoints, matching the input trajectory.
+    pub waypoints: Vec<WaypointMeta>,
+}
+
+/// Single trajectory waypoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WaypointMeta {
+    /// Waypoint time (seconds from trajectory origin).
+    pub time_s: f64,
+    /// Orientation quaternion in `[w, x, y, z]` order (nalgebra's
+    /// `UnitQuaternion::{w, i, j, k}` maps directly to this layout).
+    pub quat: [f64; 4],
+    /// Boresight pointing derived from `quat`.
+    pub boresight: EquatorialMeta,
+    /// Roll angle derived from `quat`, in degrees.
+    pub roll_deg: f64,
+}
+
+/// Equatorial coordinate pair in degrees.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct EquatorialMeta {
+    /// Right ascension in degrees.
+    pub ra_deg: f64,
+    /// Declination in degrees.
+    pub dec_deg: f64,
+}
+
+/// Per-frame metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FrameMeta {
+    /// Frame index (0-based).
+    pub idx: usize,
+    /// Frame start time (seconds from trajectory origin).
+    pub t_s: f64,
+    /// Exposure duration for this frame, in seconds.
+    pub exposure_s: f64,
+    /// Mid-frame orientation quaternion in `[w, x, y, z]` order.
+    pub quat: [f64; 4],
+    /// Mid-frame boresight pointing derived from `quat`.
+    pub boresight: EquatorialMeta,
+    /// Mid-frame roll angle derived from `quat`, in degrees.
+    pub roll_deg: f64,
+    /// Number of sub-orientation samples used inside this exposure.
+    pub n_subsamples: usize,
+    /// Map from `"sensor_NN"` (zero-padded sensor index) to the relative
+    /// forward-slash PNG path, e.g. `"sensor_00/frame_000000.png"`.
+    pub paths: BTreeMap<String, String>,
+}
+
+/// Catalog star recorded verbatim from the trajectory envelope query.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StarMeta {
+    /// Catalog star identifier.
+    pub id: u64,
+    /// Right ascension in degrees.
+    pub ra_deg: f64,
+    /// Declination in degrees.
+    pub dec_deg: f64,
+    /// Apparent magnitude (catalog-defined band).
+    pub magnitude: f64,
+    /// Optional color index (`B - V`, a.k.a. `bp_rp` for Gaia-style catalogs).
+    pub color_index: Option<f64>,
+}
+
+/// Hardware summary: telescope + per-sensor layout.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HardwareMeta {
+    /// Telescope name.
+    pub telescope: String,
+    /// Operating temperature in Celsius.
+    pub temperature_c: f64,
+    /// Per-sensor entries in array-index order.
+    pub sensors: Vec<SensorMeta>,
+}
+
+/// Per-sensor layout entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SensorMeta {
+    /// Sensor index in the array.
+    pub idx: usize,
+    /// Sensor model name.
+    pub name: String,
+    /// Sensor dimensions in pixels, `[width, height]`.
+    pub dimensions_px: [usize; 2],
+    /// Sensor center position in the focal plane, `[x_mm, y_mm]`.
+    pub position_mm: [f64; 2],
+}
+
+/// Render knobs captured for reproducibility.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RenderConfigMeta {
+    /// Exposure duration per frame, in seconds.
+    pub exposure_s: f64,
+    /// Time between successive frame start times, in seconds.
+    pub timestep_s: f64,
+    /// Per-subsample drift budget in pixels.
+    pub max_drift_per_sample_px: f64,
+    /// Base RNG seed used to derive per-tile seeds.
+    pub seed: u64,
+    /// If true, the adaptive scheduler was bypassed (N = 1 per frame).
+    pub force_static: bool,
+    /// Catalog path the run was configured with.
+    pub catalog_path: String,
+    /// Solar angular coordinates used for zodiacal-light evaluation.
+    pub zodiacal: ZodiacalMeta,
+}
+
+/// Solar angular coordinate pair in degrees.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ZodiacalMeta {
+    /// Solar elongation in degrees.
+    pub elongation_deg: f64,
+    /// Ecliptic latitude in degrees.
+    pub latitude_deg: f64,
+}
+
+/// Relative PNG path for a given sensor index, using forward slashes.
+///
+/// Matches the on-disk layout `sensor_NN/frame_NNNNNN.png`.
+pub fn sensor_relative_png_path(sensor_idx: usize, frame_idx: usize) -> String {
+    format!(
+        "{}/{}",
+        sensor_dir_name(sensor_idx),
+        frame_file_name(frame_idx),
+    )
+}
+
+/// Zero-padded `"sensor_NN"` directory name.
+pub fn sensor_dir_name(sensor_idx: usize) -> String {
+    format!("sensor_{sensor_idx:02}")
+}
+
+/// Zero-padded `"frame_NNNNNN.png"` file name (no sensor suffix).
+pub fn frame_file_name(frame_idx: usize) -> String {
+    format!("frame_{frame_idx:06}.png")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sensor_dir_name_is_zero_padded() {
+        assert_eq!(sensor_dir_name(0), "sensor_00");
+        assert_eq!(sensor_dir_name(7), "sensor_07");
+        assert_eq!(sensor_dir_name(42), "sensor_42");
+    }
+
+    #[test]
+    fn test_frame_file_name_is_zero_padded() {
+        assert_eq!(frame_file_name(0), "frame_000000.png");
+        assert_eq!(frame_file_name(12345), "frame_012345.png");
+    }
+
+    #[test]
+    fn test_sensor_relative_png_path_uses_forward_slash() {
+        let p = sensor_relative_png_path(3, 100);
+        assert_eq!(p, "sensor_03/frame_000100.png");
+        assert!(p.contains('/'));
+    }
+
+    #[test]
+    fn test_render_metadata_round_trip_via_serde() {
+        let meta = RenderMetadata {
+            version: "1.0".to_string(),
+            rendered_at: "2026-04-22T00:00:00Z".to_string(),
+            trajectory: TrajectoryMeta {
+                duration_s: 10.0,
+                start_time_s: 0.0,
+                end_time_s: 10.0,
+                waypoints: vec![WaypointMeta {
+                    time_s: 0.0,
+                    quat: [1.0, 0.0, 0.0, 0.0],
+                    boresight: EquatorialMeta {
+                        ra_deg: 0.0,
+                        dec_deg: 0.0,
+                    },
+                    roll_deg: 0.0,
+                }],
+            },
+            frames: Vec::new(),
+            stars: Vec::new(),
+            hardware: HardwareMeta {
+                telescope: "Test".to_string(),
+                temperature_c: -10.0,
+                sensors: Vec::new(),
+            },
+            render_config: RenderConfigMeta {
+                exposure_s: 1.0,
+                timestep_s: 1.0,
+                max_drift_per_sample_px: 0.1,
+                seed: 42,
+                force_static: false,
+                catalog_path: "catalog.bin".to_string(),
+                zodiacal: ZodiacalMeta {
+                    elongation_deg: 90.0,
+                    latitude_deg: 45.0,
+                },
+            },
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        let parsed: RenderMetadata = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.version, "1.0");
+        assert_eq!(parsed.hardware.telescope, "Test");
+    }
+}

--- a/simulator/src/sims/trajectory.rs
+++ b/simulator/src/sims/trajectory.rs
@@ -332,6 +332,13 @@ pub struct TrajectoryRenderConfig<'a> {
     pub force_static: bool,
     /// Suppress the indicatif progress bar during rendering.
     pub quiet: bool,
+    /// Telescope display name recorded in `metadata.json`. Metadata-only.
+    pub telescope_name: String,
+    /// Catalog path recorded in `metadata.json`. Metadata-only.
+    pub catalog_path: std::path::PathBuf,
+    /// Operating temperature (Celsius) recorded in `metadata.json`.
+    /// Metadata-only.
+    pub temperature_c: f64,
 }
 
 /// Render a sequence of frames along a trajectory, writing 16-bit PNG files.
@@ -354,6 +361,9 @@ pub fn render_trajectory(config: &TrajectoryRenderConfig) -> Result<usize, Traje
         base_seed: config.base_seed,
         force_static: config.force_static,
         quiet: config.quiet,
+        telescope_name: config.telescope_name.clone(),
+        catalog_path: config.catalog_path.clone(),
+        temperature_c: config.temperature_c,
     };
     render_motion_trajectory(
         config.trajectory,


### PR DESCRIPTION
## Summary
- Replace the flat `frame_NNNNNN_sensor_NN.png` layout with `sensor_NN/frame_NNNNNN.png` under `<output_dir>`; worker tiles are pre-routed into per-sensor subdirs created before the parallel render starts.
- Emit a versioned `metadata.json` at the root describing the run: trajectory with per-waypoint quaternions (`[w, x, y, z]` order) and derived boresight/roll, per-frame orientation/exposure/subsample-count/paths, catalog envelope stars verbatim, hardware layout (telescope name + per-sensor name/dimensions/position), and render knobs (exposure, timestep, drift budget, seed, zodiacal coords, etc.).
- Thread `telescope_name`, `catalog_path`, and `temperature_c` through `MotionBlurConfig` / `TrajectoryRenderConfig` so callers like `motion_simulator` populate the descriptor without threading ad-hoc state through the renderer.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -W clippy::all` (clean)
- [x] `cargo test --workspace` (236 simulator-lib tests pass; +8 new tests covering directory layout, JSON round-trip, boresight parity with the trajectory, and `[w, x, y, z]` quaternion order / `roll_of` recovery)