### PR TITLE
Use approx macros for float-equal checks in tests

### DIFF
--- a/simulator/src/sims/motion_blur.rs
+++ b/simulator/src/sims/motion_blur.rs
@@ -914,6 +914,7 @@ mod tests {
     use crate::hardware::telescope::TelescopeConfig;
     use crate::sims::orientation::orientation_from_pointing;
     use crate::sims::trajectory::Waypoint;
+    use approx::assert_abs_diff_eq;
     use shared::units::{Length, LengthExt, Temperature, TemperatureExt};
     use std::f64::consts::PI;
 
@@ -980,10 +981,10 @@ mod tests {
             .map(|d| d.as_secs_f64())
             .collect();
         // midpoints: 10 + (0.5, 1.5, 2.5, 3.5) = 10.5, 11.5, 12.5, 13.5
-        assert!((times[0] - 10.5).abs() < 1e-12);
-        assert!((times[1] - 11.5).abs() < 1e-12);
-        assert!((times[2] - 12.5).abs() < 1e-12);
-        assert!((times[3] - 13.5).abs() < 1e-12);
+        assert_abs_diff_eq!(times[0], 10.5, epsilon = 1e-12);
+        assert_abs_diff_eq!(times[1], 11.5, epsilon = 1e-12);
+        assert_abs_diff_eq!(times[2], 12.5, epsilon = 1e-12);
+        assert_abs_diff_eq!(times[3], 13.5, epsilon = 1e-12);
     }
 
     #[test]
@@ -1031,7 +1032,7 @@ mod tests {
         let traj = Trajectory::from_endpoints(start, end, Duration::from_secs(10)).unwrap();
         let full = max_drift_over_window(&traj, Duration::ZERO, Duration::from_secs(10)).unwrap();
         let half = max_drift_over_window(&traj, Duration::ZERO, Duration::from_secs(5)).unwrap();
-        assert!((full - 2.0 * half).abs() < 1e-9);
+        assert_abs_diff_eq!(full, 2.0 * half, epsilon = 1e-9);
         // About 1 degree total (cos(30)~0.866 but angle_to is proper 3D angle).
         assert!(full > 0.5_f64.to_radians());
         assert!(full < 1.5_f64.to_radians());
@@ -1568,15 +1569,10 @@ mod tests {
         // re-deriving the half-angle formula under roll composition.
         let q_expected = orientation_from_pointing(&pointing, roll);
         let wp0 = &meta.trajectory.waypoints[0];
-        assert!(
-            (wp0.quat[0] - q_expected.w).abs() < 1e-12,
-            "quat[0] (w) = {} vs nalgebra w = {}",
-            wp0.quat[0],
-            q_expected.w
-        );
-        assert!((wp0.quat[1] - q_expected.i).abs() < 1e-12);
-        assert!((wp0.quat[2] - q_expected.j).abs() < 1e-12);
-        assert!((wp0.quat[3] - q_expected.k).abs() < 1e-12);
+        assert_abs_diff_eq!(wp0.quat[0], q_expected.w, epsilon = 1e-12);
+        assert_abs_diff_eq!(wp0.quat[1], q_expected.i, epsilon = 1e-12);
+        assert_abs_diff_eq!(wp0.quat[2], q_expected.j, epsilon = 1e-12);
+        assert_abs_diff_eq!(wp0.quat[3], q_expected.k, epsilon = 1e-12);
 
         // Round-trip: reconstruct a UnitQuaternion from [w, x, y, z] and
         // check that roll_of recovers the original roll.
@@ -1587,11 +1583,6 @@ mod tests {
             wp0.quat[3],
         ));
         let recovered = roll_of(&q_round);
-        assert!(
-            (recovered - roll).abs() < 1e-9,
-            "roll_of(reconstructed quat) = {} expected {}",
-            recovered,
-            roll
-        );
+        assert_abs_diff_eq!(recovered, roll, epsilon = 1e-9);
     }
 }

--- a/simulator/src/sims/trajectory.rs
+++ b/simulator/src/sims/trajectory.rs
@@ -379,6 +379,7 @@ pub fn render_trajectory(config: &TrajectoryRenderConfig) -> Result<usize, Traje
 mod tests {
     use super::*;
     use crate::sims::orientation::roll_of;
+    use approx::assert_abs_diff_eq;
     use std::time::Duration;
 
     fn make_pointing(ra_deg: f64, dec_deg: f64) -> Equatorial {
@@ -413,12 +414,12 @@ mod tests {
         .unwrap();
 
         let start = traj.pointing_at(Duration::ZERO).unwrap();
-        assert!((start.ra_degrees() - 10.0).abs() < 1e-9);
-        assert!((start.dec_degrees() - 20.0).abs() < 1e-9);
+        assert_abs_diff_eq!(start.ra_degrees(), 10.0, epsilon = 1e-9);
+        assert_abs_diff_eq!(start.dec_degrees(), 20.0, epsilon = 1e-9);
 
         let end = traj.pointing_at(Duration::from_secs(10)).unwrap();
-        assert!((end.ra_degrees() - 20.0).abs() < 1e-9);
-        assert!((end.dec_degrees() - 30.0).abs() < 1e-9);
+        assert_abs_diff_eq!(end.ra_degrees(), 20.0, epsilon = 1e-9);
+        assert_abs_diff_eq!(end.dec_degrees(), 30.0, epsilon = 1e-9);
     }
 
     #[test]
@@ -432,7 +433,7 @@ mod tests {
         let mid = traj.pointing_at(Duration::from_secs(5)).unwrap();
 
         assert!(mid.ra_degrees() > 10.0 && mid.ra_degrees() < 20.0);
-        assert!((mid.dec_degrees() - 20.0).abs() < 0.5);
+        assert_abs_diff_eq!(mid.dec_degrees(), 20.0, epsilon = 0.5);
     }
 
     #[test]
@@ -475,7 +476,7 @@ mod tests {
         let (center, diameter) = fov_envelope(&traj, base_fov);
 
         // Center should be near RA=15, Dec=0
-        assert!((center.ra_degrees() - 15.0).abs() < 1.0);
+        assert_abs_diff_eq!(center.ra_degrees(), 15.0, epsilon = 1.0);
         assert!(center.dec_degrees().abs() < 1.0);
 
         // Diameter should cover the 10 degree span plus the base FOV
@@ -487,7 +488,7 @@ mod tests {
         let a = make_pointing(0.0, 0.0);
         let b = make_pointing(90.0, 0.0);
         let dist = angular_distance_deg(&a, &b);
-        assert!((dist - 90.0).abs() < 0.01);
+        assert_abs_diff_eq!(dist, 90.0, epsilon = 0.01);
     }
 
     #[test]
@@ -517,18 +518,13 @@ mod tests {
 
         // Start/end orientations preserve their constructed rolls.
         let q0 = traj.orientation_at(Duration::ZERO).unwrap();
-        assert!((roll_of(&q0) - start_roll).abs() < 1e-9);
+        assert_abs_diff_eq!(roll_of(&q0), start_roll, epsilon = 1e-9);
         let q1 = traj.orientation_at(Duration::from_secs(10)).unwrap();
-        assert!((roll_of(&q1) - end_roll).abs() < 1e-9);
+        assert_abs_diff_eq!(roll_of(&q1), end_roll, epsilon = 1e-9);
 
         // Midpoint roll is exactly halfway.
         let qm = traj.orientation_at(Duration::from_secs(5)).unwrap();
         let expected_roll = 0.5 * (start_roll + end_roll);
-        assert!(
-            (roll_of(&qm) - expected_roll).abs() < 1e-9,
-            "midpoint roll {:.9} != expected {:.9}",
-            roll_of(&qm),
-            expected_roll
-        );
+        assert_abs_diff_eq!(roll_of(&qm), expected_roll, epsilon = 1e-9);
     }
 }


### PR DESCRIPTION
## Summary
- Replace `(a - b).abs() < eps` patterns in `simulator/src/sims/{motion_blur,trajectory}.rs` test modules with `assert_abs_diff_eq!` from the existing `approx` dep, matching the style already used elsewhere (e.g. `star_math.rs`, `hardware/satellite.rs`).
- 20 conversions total (10 per file). Redundant value-echo failure messages dropped; frame-index / loop-context messages preserved by leaving those asserts as plain `assert!`.
- Production code paths intentionally left alone: `scene_runner.rs:690`, `orientation.rs:70`, `star_math.rs:427`, `hardware/satellite.rs:650`. Example files (`airy_disk_demo.rs`, `undersampled_psf_bias.rs`) use the pattern in boolean predicates / control flow, not assertions, so they are not convertible to approx macros.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace -- -W clippy::all` clean
- [x] `cargo test --workspace` — 236 passed, 0 failed (identical to baseline)