### PR TITLE
Show catalog-load progress bar in motion_simulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2882,9 +2882,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "starfield"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b93ef240e0fc643093ef80412cae570bc46a0e802f39fc65b38f4322ece9e1"
+checksum = "475de7509a4844328065d41bdb762b1155fa7485f7ed5580b6ddcd6be5ade70c"
 dependencies = [
  "base64",
  "byteorder",

--- a/simulator/src/bin/motion_simulator.rs
+++ b/simulator/src/bin/motion_simulator.rs
@@ -232,7 +232,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     info!("Loading catalog...");
-    let catalog = args.shared.load_catalog()?;
+    let catalog = args.shared.load_catalog_with_progress(args.quiet)?;
 
     let stars = catalog.stars_in_field(
         envelope_center.ra_degrees(),

--- a/simulator/src/shared_args.rs
+++ b/simulator/src/shared_args.rs
@@ -155,6 +155,7 @@ use crate::hardware::sensor::SensorConfig;
 use crate::hardware::telescope::TelescopeConfig;
 use crate::photometry::zodiacal::SolarAngularCoordinates;
 use clap::{Parser, ValueEnum};
+use indicatif::{ProgressBar, ProgressStyle};
 use log::info;
 use starfield::catalogs::minimal_catalog::{MinimalCatalog, MinimalStar};
 use std::path::PathBuf;
@@ -613,19 +614,56 @@ impl SharedSimulationArgs {
     /// - Returns a combined catalog with collision-free star IDs
     /// - Reports clear error messages if catalog loading fails
     pub fn load_catalog(&self) -> Result<MinimalCatalog, Box<dyn std::error::Error>> {
+        self.load_catalog_with_progress(true)
+    }
+
+    /// Load the catalog, optionally rendering an indicatif progress bar driven
+    /// by starfield's load-time progress callbacks.
+    ///
+    /// # Arguments
+    /// * `quiet` - When `true`, suppress the progress bar (INFO logs still fire).
+    pub fn load_catalog_with_progress(
+        &self,
+        quiet: bool,
+    ) -> Result<MinimalCatalog, Box<dyn std::error::Error>> {
         info!(
             "Loading binary star catalog from: {}",
             self.catalog.display()
         );
         let start_time = Instant::now();
 
-        let mut catalog = MinimalCatalog::load(&self.catalog).map_err(|e| {
+        let progress_bar = (!quiet).then(|| {
+            let pb = ProgressBar::new(0);
+            pb.set_style(
+                ProgressStyle::with_template(
+                    "  catalog {bar:30.cyan/blue} {human_pos}/{human_len} stars ({percent}%) [{elapsed_precise}]",
+                )
+                .expect("valid template")
+                .progress_chars("##-"),
+            );
+            pb.set_message("loading catalog");
+            pb
+        });
+
+        let mut catalog = MinimalCatalog::load_with_progress(&self.catalog, |update| {
+            if let Some(pb) = progress_bar.as_ref() {
+                if pb.length() != Some(update.stars_total as u64) {
+                    pb.set_length(update.stars_total as u64);
+                }
+                pb.set_position(update.stars_loaded as u64);
+            }
+        })
+        .map_err(|e| {
             format!(
                 "Failed to load catalog from '{}': {}",
                 self.catalog.display(),
                 e
             )
         })?;
+
+        if let Some(pb) = progress_bar {
+            pb.finish_and_clear();
+        }
 
         let load_duration = start_time.elapsed();
         let stars_per_second = catalog.len() as f64 / load_duration.as_secs_f64();


### PR DESCRIPTION
## Summary

\`starfield 0.11.1\` added [\`MinimalCatalog::load_with_progress\`](https://docs.rs/starfield/0.11.1/starfield/catalogs/struct.MinimalCatalog.html#method.load_with_progress), which fires a \`ProgressUpdate\` every ~1M stars during deserialization. Wire it into motion_simulator so the multi-minute catalog load isn't a silent stare.

- Bump starfield 0.11.0 → 0.11.1 (transitive version bump only; cfl-foundations already tracks 0.11.x).
- Add \`SharedSimulationArgs::load_catalog_with_progress(quiet)\` that renders an \`indicatif\` bar driven by the starfield callback, then calls the same bright-star merge as before.
- \`load_catalog()\` keeps its signature and just delegates with \`quiet = true\`, so \`sensor_shootout\` (the other caller) is unaffected.
- \`motion_simulator\` routes its existing \`--quiet\` flag through to the new call.

Bar format:
\`\`\`
  catalog ##########----------------  25000000/50000000 stars (50%) [00:07]
\`\`\`

## Test plan

- [x] \`cargo build --bin motion_simulator\` clean
- [x] \`cargo test\` — 236 tests pass
- [x] \`cargo fmt\` + \`cargo clippy --bin motion_simulator\` clean
- [ ] CI green