### PR TITLE
Use meawoppl/stop-ai composite action for PR attribution check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,23 +8,4 @@ jobs:
   check-attribution:
     runs-on: ubuntu-latest
     steps:
-      - name: Check PR for AI attribution
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-        run: |
-          echo "Checking PR title and body for AI attribution..."
-
-          if echo "$PR_TITLE" | grep -iE "(claude\.com|@claude|co-authored-by.*claude|generated.*with.*claude|created.*with.*claude)" > /dev/null 2>&1; then
-            echo "❌ AI attribution detected in PR title."
-            echo "This repository does not include AI attribution in PRs."
-            exit 1
-          fi
-
-          if echo "$PR_BODY" | grep -iE "(claude\.com|@claude|co-authored-by.*claude|generated.*with.*claude|created.*with.*claude)" > /dev/null 2>&1; then
-            echo "❌ AI attribution detected in PR body."
-            echo "This repository does not include AI attribution in PRs."
-            exit 1
-          fi
-
-          echo "✅ No AI attribution found."
+      - uses: meawoppl/stop-ai@main

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,4 +8,4 @@ jobs:
   check-attribution:
     runs-on: ubuntu-latest
     steps:
-      - uses: meawoppl/stop-ai@main
+      - uses: meawoppl/stop-ai@v1


### PR DESCRIPTION
## Summary

Replaces the inline AI-attribution grep in \`pr-check.yml\` with a call to the new composite action at **meawoppl/stop-ai**. The policy now lives in one place across all repos that want it.

## Diff

```yaml
jobs:
  check-attribution:
    runs-on: ubuntu-latest
    steps:
      - uses: meawoppl/stop-ai@main
```

- Check name in the PR panel is unchanged (\`check-attribution\`), so no branch-protection updates needed.
- Pinned at \`@main\` for now; suggest tagging \`v1\` on the stop-ai repo soon and swapping to \`@v1\` for stability.

## Test plan
- [x] Existing \`check-attribution\` rule behavior preserved (title/body regex against the same patterns)
- [ ] Green \`check-attribution\` status once CI picks up the new composite action