### PR TITLE
Add --mode csv: quaternion trajectories from file + ODY converter

### DIFF
--- a/scripts/ody_to_trajectory_csv.py
+++ b/scripts/ody_to_trajectory_csv.py
@@ -1,0 +1,147 @@
+"""
+Convert an ODY Att Error CSV into the quaternion-waypoint format consumed
+by `motion_simulator --mode csv --trajectory-csv …`.
+
+The ODY file records *errors* in body axes (BDYX, BDYY, BDYZ in radians)
+around a commanded attitude. This script composes those errors onto a
+user-supplied nominal pointing (RA/Dec/roll, all optional) to produce a
+series of absolute orientation quaternions, and writes a simple CSV with
+columns `time_s, qw, qx, qy, qz`.
+
+Usage:
+  uv run --with pandas --with numpy --with scipy \
+    scripts/ody_to_trajectory_csv.py \
+    --input Run0001_20260224205907_2999.csv \
+    --output trajectory.csv \
+    --ra 213.39 --dec -55.86 --roll 0.0 \
+    --start-time 1000 --end-time 2000
+
+Small-angle approximation is fine for ODY errors (<< 1 rad); the
+perturbation quaternion is built directly from the axis-angle form with
+a non-normalized input vector, then normalized.
+
+Keeps the Rust side completely agnostic about CSV layout or conventions.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from scipy.spatial.transform import Rotation
+
+
+DEFAULT_COLUMNS = {
+    "time": "SCET",
+    "bdyx": "OER_TOTATTERR_BDYX",
+    "bdyy": "OER_TOTATTERR_BDYY",
+    "bdyz": "OER_TOTATTERR_BDYZ",
+}
+
+
+def nominal_body_to_world(ra_deg: float, dec_deg: float, roll_deg: float) -> Rotation:
+    """Return the nominal body->world rotation: body +Z = boresight, body +X = east, body +Y = north."""
+    ra = np.deg2rad(ra_deg)
+    dec = np.deg2rad(dec_deg)
+    sin_ra, cos_ra = np.sin(ra), np.cos(ra)
+    sin_dec, cos_dec = np.sin(dec), np.cos(dec)
+    east = np.array([-sin_ra, cos_ra, 0.0])
+    north = np.array([-sin_dec * cos_ra, -sin_dec * sin_ra, cos_dec])
+    bore = np.array([cos_dec * cos_ra, cos_dec * sin_ra, sin_dec])
+    base_mat = np.column_stack([east, north, bore])
+    base = Rotation.from_matrix(base_mat)
+    twist = Rotation.from_rotvec([0.0, 0.0, np.deg2rad(roll_deg)])
+    return base * twist
+
+
+def body_error_to_perturbation(bdyx: np.ndarray, bdyy: np.ndarray, bdyz: np.ndarray) -> Rotation:
+    """Stack per-sample small-angle body-axis errors into a Rotation sequence."""
+    vecs = np.stack([bdyx, bdyy, bdyz], axis=1)  # (N, 3)
+    return Rotation.from_rotvec(vecs)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[1])
+    p.add_argument("--input", type=Path, required=True, help="ODY telemetry CSV")
+    p.add_argument("--output", type=Path, required=True, help="Destination trajectory CSV")
+    p.add_argument("--ra", type=float, default=0.0, help="Nominal boresight RA in degrees")
+    p.add_argument("--dec", type=float, default=0.0, help="Nominal boresight Dec in degrees")
+    p.add_argument("--roll", type=float, default=0.0, help="Nominal roll in degrees")
+    p.add_argument(
+        "--start-time",
+        type=float,
+        default=None,
+        help="Lower bound on SCET-relative time (seconds)",
+    )
+    p.add_argument(
+        "--end-time",
+        type=float,
+        default=None,
+        help="Upper bound on SCET-relative time (seconds)",
+    )
+    p.add_argument(
+        "--time-col",
+        default=DEFAULT_COLUMNS["time"],
+        help=f"Time column name (default: {DEFAULT_COLUMNS['time']})",
+    )
+    p.add_argument("--bdyx-col", default=DEFAULT_COLUMNS["bdyx"])
+    p.add_argument("--bdyy-col", default=DEFAULT_COLUMNS["bdyy"])
+    p.add_argument("--bdyz-col", default=DEFAULT_COLUMNS["bdyz"])
+    args = p.parse_args()
+
+    # Row 1 of the reference telemetry CSVs holds the short OER_* names.
+    df = pd.read_csv(args.input, header=1, low_memory=False)
+    t_raw = df[args.time_col].to_numpy(dtype=float)
+    t = t_raw - t_raw[0]
+
+    mask = np.ones_like(t, dtype=bool)
+    if args.start_time is not None:
+        mask &= t >= args.start_time
+    if args.end_time is not None:
+        mask &= t <= args.end_time
+    if not mask.any():
+        raise SystemExit(
+            f"No rows in window [{args.start_time}, {args.end_time}] (spans 0 to {t[-1]:.2f}s)"
+        )
+
+    df = df.loc[mask].reset_index(drop=True)
+    t = t[mask]
+    t_rel = t - t[0]  # re-zero so the output starts at t=0
+
+    bdyx = df[args.bdyx_col].to_numpy(dtype=float)
+    bdyy = df[args.bdyy_col].to_numpy(dtype=float)
+    bdyz = df[args.bdyz_col].to_numpy(dtype=float)
+
+    nominal = nominal_body_to_world(args.ra, args.dec, args.roll)
+    perturb = body_error_to_perturbation(bdyx, bdyy, bdyz)
+    # Compose in world frame: absolute = nominal ∘ perturbation_in_body
+    total = nominal * perturb
+
+    # scipy returns (x, y, z, w); reorder to (w, x, y, z) to match nalgebra.
+    quat_xyzw = total.as_quat()
+    quat_wxyz = np.column_stack(
+        [quat_xyzw[:, 3], quat_xyzw[:, 0], quat_xyzw[:, 1], quat_xyzw[:, 2]]
+    )
+
+    out = pd.DataFrame(
+        {
+            "time_s": t_rel,
+            "qw": quat_wxyz[:, 0],
+            "qx": quat_wxyz[:, 1],
+            "qy": quat_wxyz[:, 2],
+            "qz": quat_wxyz[:, 3],
+        }
+    )
+    out.to_csv(args.output, index=False)
+
+    print(
+        f"wrote {len(out)} rows to {args.output}  "
+        f"(window {t_rel[0]:.3f}–{t_rel[-1]:.3f} s, dt={np.mean(np.diff(t_rel)):.4f} s)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/simulator/src/bin/motion_simulator.rs
+++ b/simulator/src/bin/motion_simulator.rs
@@ -159,6 +159,87 @@ fn build_pink_trajectory(
     Ok(Trajectory::new(waypoints)?)
 }
 
+/// Load a trajectory from a simple CSV of absolute orientations.
+/// Expected columns (by header, case-sensitive): `time_s`, `qw`, `qx`,
+/// `qy`, `qz`. Extra columns are ignored. Quaternions are normalized on
+/// load; non-monotonic `time_s` is rejected.
+fn build_csv_trajectory(path: &std::path::Path) -> Result<Trajectory, Box<dyn std::error::Error>> {
+    use nalgebra::{Quaternion, UnitQuaternion};
+    use std::io::{BufRead, BufReader};
+
+    let file = std::fs::File::open(path).map_err(|e| format!("opening {}: {e}", path.display()))?;
+    let mut lines = BufReader::new(file).lines();
+
+    let header = lines
+        .next()
+        .ok_or_else(|| format!("{} is empty", path.display()))?
+        .map_err(|e| e.to_string())?;
+    let columns: Vec<&str> = header.split(',').map(str::trim).collect();
+    let idx = |name: &str| -> Result<usize, String> {
+        columns
+            .iter()
+            .position(|c| *c == name)
+            .ok_or_else(|| format!("{} is missing column `{name}`", path.display()))
+    };
+    let (i_t, i_qw, i_qx, i_qy, i_qz) = (
+        idx("time_s")?,
+        idx("qw")?,
+        idx("qx")?,
+        idx("qy")?,
+        idx("qz")?,
+    );
+
+    let mut waypoints: Vec<Waypoint> = Vec::new();
+    let mut last_t = f64::NEG_INFINITY;
+    for (line_no, line) in lines.enumerate() {
+        let line = line.map_err(|e| e.to_string())?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let cells: Vec<&str> = line.split(',').map(str::trim).collect();
+        let parse = |i: usize, name: &str| -> Result<f64, String> {
+            cells
+                .get(i)
+                .ok_or_else(|| format!("line {}: missing `{name}` cell", line_no + 2))?
+                .parse::<f64>()
+                .map_err(|e| format!("line {}: bad `{name}` value: {e}", line_no + 2))
+        };
+        let t_s = parse(i_t, "time_s")?;
+        if t_s <= last_t {
+            return Err(format!(
+                "{}: `time_s` must be strictly increasing (line {} has {} ≤ previous {})",
+                path.display(),
+                line_no + 2,
+                t_s,
+                last_t,
+            )
+            .into());
+        }
+        last_t = t_s;
+
+        let q = UnitQuaternion::from_quaternion(Quaternion::new(
+            parse(i_qw, "qw")?,
+            parse(i_qx, "qx")?,
+            parse(i_qy, "qy")?,
+            parse(i_qz, "qz")?,
+        ));
+        waypoints.push(Waypoint::new(
+            std::time::Duration::from_secs_f64(t_s.max(0.0)),
+            q,
+        ));
+    }
+
+    if waypoints.len() < 2 {
+        return Err(format!(
+            "{}: need at least 2 rows, found {}",
+            path.display(),
+            waypoints.len()
+        )
+        .into());
+    }
+    Ok(Trajectory::new(waypoints)?)
+}
+
 /// Generate a 2-D pink-noise offset series (RA, Dec) in arcseconds,
 /// scaled so the mean magnitude `mean(|offset|)` equals
 /// `target_mean_arcsec`. Centered at zero after generation.
@@ -211,6 +292,10 @@ enum TrajectoryMode {
     /// Pink-spectrum pointing residual around `--start`; uses
     /// `--pink-mean-arcsec`, `--pink-waypoints`, `--pink-seed`.
     Pink,
+    /// Trajectory loaded from a CSV of (time_s, qw, qx, qy, qz) rows
+    /// via `--trajectory-csv`. `--start` is not required; the CSV
+    /// supplies absolute orientations.
+    Csv,
 }
 
 /// Resolved trajectory description with mode-specific parameters
@@ -235,6 +320,9 @@ enum TrajectoryKind {
         waypoints: usize,
         seed: u64,
     },
+    Csv {
+        path: std::path::PathBuf,
+    },
 }
 
 impl TrajectoryKind {
@@ -243,15 +331,20 @@ impl TrajectoryKind {
     /// by the time we get here, so the `expect` messages just describe
     /// the invariant rather than running in practice.
     fn from_args(args: &Args) -> Self {
+        let start = || {
+            args.start.expect(
+                "clap required_unless_present guarantees --start for line/circle/pink modes",
+            )
+        };
         match args.mode {
             TrajectoryMode::Line => TrajectoryKind::Line {
-                start: args.start,
+                start: start(),
                 end: args
                     .end
                     .expect("clap required_if_eq guarantees --end when --mode=line"),
             },
             TrajectoryMode::Circle => TrajectoryKind::Circle {
-                start: args.start,
+                start: start(),
                 radius_deg: args.circle_radius_deg.expect(
                     "clap required_if_eq guarantees --circle-radius-deg when --mode=circle",
                 ),
@@ -259,12 +352,18 @@ impl TrajectoryKind {
                 waypoints_per_turn: args.circle_waypoints,
             },
             TrajectoryMode::Pink => TrajectoryKind::Pink {
-                start: args.start,
+                start: start(),
                 mean_arcsec: args
                     .pink_mean_arcsec
                     .expect("clap required_if_eq guarantees --pink-mean-arcsec when --mode=pink"),
                 waypoints: args.pink_waypoints,
                 seed: args.pink_seed,
+            },
+            TrajectoryMode::Csv => TrajectoryKind::Csv {
+                path: args
+                    .trajectory_csv
+                    .clone()
+                    .expect("clap required_if_eq guarantees --trajectory-csv when --mode=csv"),
             },
         }
     }
@@ -314,6 +413,7 @@ impl TrajectoryKind {
                 start_roll_deg,
                 total_roll_deg,
             ),
+            TrajectoryKind::Csv { path } => build_csv_trajectory(path),
         }
     }
 }
@@ -405,9 +505,11 @@ struct Args {
     #[arg(
         long,
         value_parser = parse_ra_dec,
-        help = "Start pointing in 'ra,dec' degrees (e.g., '56.75,24.12')"
+        required_unless_present = "trajectory_csv",
+        help = "Start pointing in 'ra,dec' degrees (e.g., '56.75,24.12'); \
+                not required when --mode=csv"
     )]
-    start: Equatorial,
+    start: Option<Equatorial>,
 
     #[arg(
         long,
@@ -455,6 +557,14 @@ struct Args {
 
     #[arg(long, default_value_t = 0, help = "RNG seed for pink-noise trajectory")]
     pink_seed: u64,
+
+    #[arg(
+        long,
+        required_if_eq("mode", "csv"),
+        help = "Path to a CSV file with columns time_s, qw, qx, qy, qz \
+                (required when --mode=csv)"
+    )]
+    trajectory_csv: Option<std::path::PathBuf>,
 
     #[arg(
         long,
@@ -655,6 +765,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 trajectory.waypoints().len(),
                 args.duration.0.as_secs_f64(),
                 seed,
+            );
+        }
+        TrajectoryKind::Csv { path } => {
+            info!(
+                "Trajectory: loaded {} waypoints from {} spanning {:.3}s",
+                trajectory.waypoints().len(),
+                path.display(),
+                trajectory.end_time().as_secs_f64() - trajectory.start_time().as_secs_f64(),
             );
         }
     }
@@ -924,5 +1042,80 @@ mod tests {
             .sum::<f64>()
             / ra.len() as f64;
         assert_relative_eq!(mean_mag, 6.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn csv_mode_requires_trajectory_csv() {
+        let argv = [
+            "motion_simulator",
+            "--mode",
+            "csv",
+            "--duration",
+            "1s",
+            "--catalog",
+            "fake.bin",
+            "--output-dir",
+            "/tmp/x",
+        ];
+        let err = Args::try_parse_from(argv).expect_err("missing --trajectory-csv must fail");
+        assert!(
+            err.to_string().contains("trajectory-csv"),
+            "clap error should mention --trajectory-csv, got: {err}"
+        );
+    }
+
+    #[test]
+    fn csv_mode_does_not_require_start() {
+        let argv = [
+            "motion_simulator",
+            "--mode",
+            "csv",
+            "--trajectory-csv",
+            "/tmp/nope.csv",
+            "--duration",
+            "1s",
+            "--catalog",
+            "fake.bin",
+            "--output-dir",
+            "/tmp/x",
+        ];
+        let args = Args::try_parse_from(argv).expect("csv + path parses without --start");
+        assert_eq!(args.mode, TrajectoryMode::Csv);
+        assert!(args.start.is_none());
+        assert!(args.trajectory_csv.is_some());
+    }
+
+    #[test]
+    fn build_csv_trajectory_loads_three_waypoints() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            "time_s,qw,qx,qy,qz\n\
+             0.0,1.0,0.0,0.0,0.0\n\
+             0.5,0.99999,0.004,0.001,0.0\n\
+             1.0,0.99998,0.006,0.002,0.0\n",
+        )
+        .unwrap();
+        let traj = build_csv_trajectory(tmp.path()).unwrap();
+        assert_eq!(traj.waypoints().len(), 3);
+        assert_relative_eq!(traj.end_time().as_secs_f64(), 1.0, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn build_csv_trajectory_rejects_nonmonotonic_time() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            "time_s,qw,qx,qy,qz\n\
+             0.0,1.0,0.0,0.0,0.0\n\
+             1.0,1.0,0.0,0.0,0.0\n\
+             0.5,1.0,0.0,0.0,0.0\n",
+        )
+        .unwrap();
+        let err = build_csv_trajectory(tmp.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("strictly increasing"),
+            "expected monotonicity error, got: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Stacked on #51 (which is stacked on #50)

## Summary

Teaches \`motion_simulator\` to ingest pre-computed quaternion trajectories from a CSV, so upstream telemetry or scripted maneuvers can drive the render without growing the Rust side any format-specific knowledge.

### Rust side
- New \`TrajectoryMode::Csv\` + \`TrajectoryKind::Csv { path }\` variants
- \`--trajectory-csv <path>\` flag, clap-required when \`--mode=csv\`
- \`--start\` becomes optional (CSV supplies absolute orientations)
- \`build_csv_trajectory\` validates strictly-increasing \`time_s\` and normalizes loaded quaternions
- **4 new binary tests**: missing path, no \`--start\` required, round-trip loading, non-monotonic rejected

CSV columns expected (by header, case-sensitive): \`time_s, qw, qx, qy, qz\`.

### Python companion
\`scripts/ody_to_trajectory_csv.py\` converts ODY body-axis attitude-error telemetry (\`OER_TOTATTERR_BDY{X,Y,Z}\`, radians) into the CSV format this mode ingests. Composes small-angle body errors onto a commanded RA/Dec/roll via \`scipy.spatial.transform.Rotation\`. Invoke with \`uv run --with pandas --with numpy --with scipy …\`.

Kept as a standalone one-off script so the Rust side stays agnostic about upstream CSV column conventions or unit choices.

## Test plan
- [x] \`cargo test\` — 253 passing (was 249; +4 CSV tests).
- [x] \`cargo clippy -- -W clippy::all\` — clean.
- [x] \`cargo fmt --check\` — clean.
- [x] End-to-end: ODY Run0001 CSV → Python converter → 10k-row quaternion CSV → \`motion_simulator --mode csv\` → 1001 context frames rendered cleanly over the 1000 s window.