### PR TITLE
Add physics-rendered ROI overlay to context view

### DIFF
--- a/simulator/src/bin/motion_simulator.rs
+++ b/simulator/src/bin/motion_simulator.rs
@@ -6,7 +6,8 @@ use rayon::prelude::*;
 use simulator::hardware::satellite::FocalPlaneConfig;
 use simulator::hardware::sensor_array::{SensorArray, SPENCER_ARRAY_PLAN};
 use simulator::shared_args::{DurationArg, SensorModel, SharedSimulationArgs};
-use simulator::sims::context_render::{render_context_frame, ContextRenderConfig};
+use simulator::sims::context_render::{render_context_frame, ContextRenderConfig, RoiOverlay};
+use simulator::sims::roi_render::{pick_roi_anchor, render_roi_patch};
 use simulator::sims::trajectory::{
     fov_envelope, render_trajectory, Trajectory, TrajectoryRenderConfig, Waypoint,
 };
@@ -667,6 +668,25 @@ struct Args {
                 (implies --context-view)"
     )]
     context_only: bool,
+
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Overlay an oversampled, physics-rendered region of interest \
+                panel on each context frame (anchored on the brightest \
+                in-bounds star of the first frame)"
+    )]
+    roi: bool,
+
+    #[arg(long, default_value_t = 128, help = "ROI source size in sensor pixels")]
+    roi_size: usize,
+
+    #[arg(
+        long,
+        default_value_t = 4,
+        help = "Nearest-neighbor zoom factor for the ROI display panel"
+    )]
+    roi_zoom: u32,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -846,23 +866,84 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             padding_fraction: args.context_padding,
             ..Default::default()
         };
-        let frame_times = trajectory.frame_times(args.timestep.0);
+        // Preview is always 24 fps regardless of the sensor-tile
+        // cadence. Sensor rendering keeps --timestep; the preview runs
+        // at the fixed 24 Hz frame rate.
+        let preview_timestep = std::time::Duration::from_secs_f64(1.0 / 24.0);
+        let frame_times = trajectory.frame_times(preview_timestep);
+
+        // ROI anchor: picked once per run from the first frame so the
+        // zoom panel stays stationary across the whole preview.
+        let roi_anchor = if args.roi {
+            let first_q = trajectory
+                .orientation_at(trajectory.start_time())
+                .map_err(|e| format!("first-frame orientation: {e}"))?;
+            match pick_roi_anchor(&stars, &focal_plane, &first_q, args.roi_size) {
+                Some(a) => {
+                    info!(
+                        "ROI anchor: sensor {} px ({:.1}, {:.1}) size {}",
+                        a.sensor_idx, a.center_px.0, a.center_px.1, a.size_px
+                    );
+                    Some(a)
+                }
+                None => {
+                    warn!("No star satisfies ROI placement constraints; rendering without ROI");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         info!(
-            "Rendering {} context-view frames at {}x{} into {}/",
+            "Rendering {} context-view frames at {}x{} into {}/{}",
             frame_times.len(),
             ctx_cfg.width,
             ctx_cfg.height,
-            context_dir.display()
+            context_dir.display(),
+            if roi_anchor.is_some() {
+                " (with ROI overlay)"
+            } else {
+                ""
+            },
         );
         let context_started = Instant::now();
+        let exposure = args.shared.exposure.0;
+        let drift_budget = args.max_drift_per_sample_px;
+        let base_seed = args.seed;
         let results: Vec<Result<(), String>> = frame_times
             .par_iter()
             .enumerate()
             .map(|(idx, t)| -> Result<(), String> {
                 let orientation = trajectory.orientation_at(*t).map_err(|e| e.to_string())?;
+                let overlay = if let Some(anchor) = roi_anchor {
+                    let plan = simulator::sims::roi_render::RoiFramePlan {
+                        frame_start: *t,
+                        exposure,
+                        max_drift_per_sample_px: drift_budget,
+                        seed: base_seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ idx as u64,
+                    };
+                    render_roi_patch(&trajectory, &stars, &focal_plane, anchor, &plan).map(
+                        |patch| RoiOverlay {
+                            anchor,
+                            patch,
+                            zoom: args.roi_zoom,
+                            display_range: None,
+                        },
+                    )
+                } else {
+                    None
+                };
                 let path = context_dir.join(format!("frame_{idx:06}.png"));
-                render_context_frame(&orientation, &stars, &focal_plane, &ctx_cfg, &path)
-                    .map_err(|e| e.to_string())
+                render_context_frame(
+                    &orientation,
+                    &stars,
+                    &focal_plane,
+                    &ctx_cfg,
+                    overlay.as_ref(),
+                    &path,
+                )
+                .map_err(|e| e.to_string())
             })
             .collect();
         for r in results {

--- a/simulator/src/sims/context_render.rs
+++ b/simulator/src/sims/context_render.rs
@@ -17,12 +17,14 @@ use ab_glyph::{FontRef, PxScale};
 use image::{ImageBuffer, Rgb};
 use imageproc::drawing::{draw_text_mut, text_size};
 use nalgebra::UnitQuaternion;
+use ndarray::Array2;
 use once_cell::sync::Lazy;
 use shared::units::LengthExt;
 use starfield::catalogs::StarData;
 
 use crate::hardware::satellite::FocalPlaneConfig;
 use crate::sims::orientation::boresight_of;
+use crate::sims::roi_render::RoiAnchor;
 use crate::sims::trajectory::TrajectoryError;
 
 type RgbImage = ImageBuffer<Rgb<u8>, Vec<u8>>;
@@ -65,6 +67,29 @@ pub struct ContextRenderConfig {
     pub astrometry_ring_radius_px: i32,
 }
 
+/// Per-call inputs for rendering a zoom-panel "region of interest"
+/// onto the context view. The panel is physically rendered via
+/// [`crate::sims::roi_render::render_roi_patch`] and composited as a
+/// nearest-neighbor upsample framed in red, with a matching red box
+/// drawn on the parent sensor's outline to show the source location.
+pub struct RoiOverlay {
+    /// Sensor-pixel anchor selected once per run (see
+    /// [`crate::sims::roi_render::pick_roi_anchor`]).
+    pub anchor: RoiAnchor,
+    /// Pre-rendered u16 patch (shape `(size_px, size_px)`), typically
+    /// the output of [`crate::sims::roi_render::render_roi_patch`] for
+    /// this frame.
+    pub patch: Array2<u16>,
+    /// Nearest-neighbor zoom factor: the panel is drawn at
+    /// `anchor.size_px * zoom` pixels on each side.
+    pub zoom: u32,
+    /// Fixed `(black, white)` stretch for the u16 patch. If `None`,
+    /// the overlay autoscales per-frame; pin the value (typically
+    /// taken from the first frame) to keep intensity changes between
+    /// frames visible rather than re-normalized away.
+    pub display_range: Option<(u16, u16)>,
+}
+
 impl Default for ContextRenderConfig {
     fn default() -> Self {
         Self {
@@ -84,11 +109,17 @@ impl Default for ContextRenderConfig {
 }
 
 /// Render a single context-view frame to `output_path`.
+///
+/// `roi_overlay`, if `Some`, also renders a physically correct zoom
+/// panel for the chosen sensor anchor and composites it onto the
+/// output, along with a matching red source-region box on the
+/// sensor's outline.
 pub fn render_context_frame(
     orientation: &UnitQuaternion<f64>,
     stars: &[StarData],
     fp: &FocalPlaneConfig,
     config: &ContextRenderConfig,
+    roi_overlay: Option<&RoiOverlay>,
     output_path: &Path,
 ) -> Result<(), TrajectoryError> {
     let (width, height) = (config.width, config.height);
@@ -203,28 +234,169 @@ pub fn render_context_frame(
     let tag_text = "NON-ANALYTIC";
     let (_tag_w, tag_h) = text_size(label_scale, &*FONT, tag_text);
     let bore = boresight_of(orientation);
-    let radec_text = format!(
-        "RA {:7.3}  DEC {:+7.3}",
-        bore.ra_degrees(),
-        bore.dec_degrees()
-    );
+    let ra_text = format!("RA:  {:10.2}", bore.ra_degrees());
+    let dec_text = format!("DEC: {:+10.2}", bore.dec_degrees());
     let label_x = cx_i + gap;
-    let radec_y = cy_i - tag_h as i32 - 8;
-    let tag_y = radec_y - tag_h as i32 - 2;
+    // Stack, top-to-bottom:
+    //   NON-ANALYTIC
+    //   RA:  <value>
+    //   DEC: <value>
+    // each line separated from the next by 2 px, with the bottom of
+    // the DEC line sitting a few px above the right reticle arm.
+    let dec_y = cy_i - tag_h as i32 - 8;
+    let ra_y = dec_y - tag_h as i32 - 2;
+    let tag_y = ra_y - tag_h as i32 - 2;
     draw_text_mut(&mut img, red, label_x, tag_y, label_scale, &*FONT, tag_text);
+    draw_text_mut(&mut img, red, label_x, ra_y, label_scale, &*FONT, &ra_text);
     draw_text_mut(
         &mut img,
         red,
         label_x,
-        radec_y,
+        dec_y,
         label_scale,
         &*FONT,
-        &radec_text,
+        &dec_text,
     );
+
+    // Optional ROI zoom panel: draws a physically correct oversampled
+    // patch of a chosen sensor region in an auto-picked empty corner,
+    // along with a red rectangle on the parent sensor outline marking
+    // where the ROI was sampled from.
+    if let Some(overlay) = roi_overlay {
+        composite_roi_overlay(&mut img, fp, overlay, &mm_to_px)?;
+    }
 
     img.save(output_path)
         .map_err(|e| TrajectoryError::ImageWrite(e.to_string()))?;
     Ok(())
+}
+
+/// Paint the ROI zoom panel and its source-location marker onto the
+/// context image.
+fn composite_roi_overlay(
+    img: &mut RgbImage,
+    fp: &FocalPlaneConfig,
+    overlay: &RoiOverlay,
+    mm_to_px: &dyn Fn(f64, f64) -> (f64, f64),
+) -> Result<(), TrajectoryError> {
+    let red = Rgb([255, 80, 80]);
+
+    // Draw the source-region box on the sensor outline. We convert the
+    // ROI's sensor-pixel bbox into sensor-local mm (pixel_size × px),
+    // add the sensor's mm-space offset, and map to context image pixels.
+    let sensor_idx = overlay.anchor.sensor_idx;
+    if let Some(ps) = fp.array.sensors.get(sensor_idx) {
+        let pixel_size_mm = ps.sensor.dimensions.pixel_size().as_millimeters();
+        let (sensor_w_len, sensor_h_len) = ps.sensor.dimensions.get_width_height();
+        let half_w = sensor_w_len.as_millimeters() / 2.0;
+        let half_h = sensor_h_len.as_millimeters() / 2.0;
+        let size_px = overlay.anchor.size_px as f64;
+        let (cx_px, cy_px) = overlay.anchor.center_px;
+        let (w_px, h_px) = ps.sensor.dimensions.get_pixel_width_height();
+        // Sensor-pixel (0,0) is top-left; focal-plane mm +y is up. Invert y.
+        let mm_from_pixel = |px: f64, py: f64| -> (f64, f64) {
+            let x_mm = ps.position.x_mm - half_w + px * pixel_size_mm;
+            let y_mm = ps.position.y_mm + half_h - py * pixel_size_mm;
+            (x_mm, y_mm)
+        };
+        let (lo_x_mm, lo_y_mm) = mm_from_pixel(cx_px - size_px / 2.0, cy_px + size_px / 2.0);
+        let (hi_x_mm, hi_y_mm) = mm_from_pixel(cx_px + size_px / 2.0, cy_px - size_px / 2.0);
+        let (x0_px, y0_px) = mm_to_px(lo_x_mm, lo_y_mm);
+        let (x1_px, y1_px) = mm_to_px(hi_x_mm, hi_y_mm);
+        // Axis-aligned rectangle in image pixels.
+        draw_rect_outline(
+            img,
+            (x0_px.min(x1_px) as i32, y0_px.min(y1_px) as i32),
+            (x0_px.max(x1_px) as i32, y0_px.max(y1_px) as i32),
+            red,
+        );
+        let _ = (w_px, h_px);
+    }
+
+    // Upsample the patch nearest-neighbor to zoom × size on each side.
+    let panel_side = overlay.anchor.size_px as u32 * overlay.zoom.max(1);
+    let (width_f, height_f) = (img.width() as f64, img.height() as f64);
+    // Auto-pick: prefer the corner whose 5%-margin rectangle fits the
+    // panel entirely. Try bottom-right, bottom-left, top-right,
+    // top-left in order.
+    let margin = ((img.width().min(img.height()) as f64) * 0.02).round() as i32;
+    let candidates: &[(i32, i32)] = &[
+        (
+            img.width() as i32 - panel_side as i32 - margin,
+            img.height() as i32 - panel_side as i32 - margin,
+        ),
+        (margin, img.height() as i32 - panel_side as i32 - margin),
+        (img.width() as i32 - panel_side as i32 - margin, margin),
+        (margin, margin),
+    ];
+    let (panel_x, panel_y) = *candidates.first().unwrap_or(&(0, 0));
+    let (width_i, height_i) = (img.width() as i32, img.height() as i32);
+    // Clamp so even on tiny test canvases we don't try to draw off-image.
+    let panel_x = panel_x.max(0).min(width_i - panel_side as i32 - 1);
+    let panel_y = panel_y.max(0).min(height_i - panel_side as i32 - 1);
+
+    // Normalize the u16 patch to 0..=255 for display.
+    let (lo, hi) = overlay
+        .display_range
+        .unwrap_or_else(|| autoscale_range(&overlay.patch));
+    let span = (hi as f64 - lo as f64).max(1.0);
+    let (patch_w, patch_h) = overlay.patch.dim();
+    let zoom = overlay.zoom.max(1) as i32;
+    for py in 0..(patch_h as i32) {
+        for px in 0..(patch_w as i32) {
+            let v = overlay.patch[[py as usize, px as usize]] as f64;
+            let gray = (((v - lo as f64).clamp(0.0, span)) / span * 255.0)
+                .round()
+                .clamp(0.0, 255.0) as u8;
+            let color = Rgb([gray, gray, gray]);
+            for dy in 0..zoom {
+                for dx in 0..zoom {
+                    let x = panel_x + px * zoom + dx;
+                    let y = panel_y + py * zoom + dy;
+                    if x >= 0 && x < width_i && y >= 0 && y < height_i {
+                        img.put_pixel(x as u32, y as u32, color);
+                    }
+                }
+            }
+        }
+    }
+
+    // Red frame around the panel.
+    draw_rect_outline(
+        img,
+        (panel_x, panel_y),
+        (
+            panel_x + panel_side as i32 - 1,
+            panel_y + panel_side as i32 - 1,
+        ),
+        red,
+    );
+
+    let _ = (width_f, height_f);
+    Ok(())
+}
+
+/// Draw a 1-pixel-thick rectangle outline between two opposite corners.
+fn draw_rect_outline(img: &mut RgbImage, a: (i32, i32), b: (i32, i32), color: Rgb<u8>) {
+    let (x0, y0) = (a.0.min(b.0), a.1.min(b.1));
+    let (x1, y1) = (a.0.max(b.0), a.1.max(b.1));
+    draw_line(img, (x0, y0), (x1, y0), color);
+    draw_line(img, (x1, y0), (x1, y1), color);
+    draw_line(img, (x1, y1), (x0, y1), color);
+    draw_line(img, (x0, y1), (x0, y0), color);
+}
+
+/// Cheap 1st-percentile / 99th-percentile autoscale for the ROI patch
+/// when the caller hasn't pinned a display range.
+fn autoscale_range(patch: &Array2<u16>) -> (u16, u16) {
+    let mut vals: Vec<u16> = patch.iter().copied().collect();
+    if vals.is_empty() {
+        return (0, u16::MAX);
+    }
+    vals.sort_unstable();
+    let lo_idx = vals.len() / 100;
+    let hi_idx = vals.len() - 1 - vals.len() / 100;
+    (vals[lo_idx], vals[hi_idx])
 }
 
 /// Linear position between `mag_bright` (t = 1.0) and `mag_dim` (t = 0.0),
@@ -490,7 +662,7 @@ mod tests {
             height: 256,
             ..Default::default()
         };
-        render_context_frame(&orient, &[], &fp, &cfg, &path).unwrap();
+        render_context_frame(&orient, &[], &fp, &cfg, None, &path).unwrap();
         assert!(path.is_file(), "context PNG must exist");
         let meta = std::fs::metadata(&path).unwrap();
         assert!(meta.len() > 100, "context PNG is suspiciously small");
@@ -511,7 +683,7 @@ mod tests {
             height: 256,
             ..Default::default()
         };
-        render_context_frame(&orient, &[], &fp, &cfg, &path).unwrap();
+        render_context_frame(&orient, &[], &fp, &cfg, None, &path).unwrap();
         let img = image::open(&path).unwrap().into_rgb8();
         let non_black = img.pixels().filter(|p| p.0 != [0, 0, 0]).count();
         assert!(

--- a/simulator/src/sims/mod.rs
+++ b/simulator/src/sims/mod.rs
@@ -4,6 +4,7 @@ pub mod context_render;
 pub mod motion_blur;
 pub mod motion_blur_metadata;
 pub mod orientation;
+pub mod roi_render;
 pub mod scene_runner;
 pub mod single_detection;
 pub mod trajectory;

--- a/simulator/src/sims/motion_blur.rs
+++ b/simulator/src/sims/motion_blur.rs
@@ -406,6 +406,145 @@ fn tile_seed(base_seed: u64, frame_idx: usize, sensor_idx: usize) -> u64 {
     h
 }
 
+/// Output region on a sensor. The full-tile path uses
+/// [`SensorRegion::full_sensor`] and writes the entire detector;
+/// narrower callers (the ROI zoom panel in `sims::roi_render`) use
+/// [`SensorRegion::from_offset`] to render just a small window.
+#[derive(Debug, Clone, Copy)]
+pub struct SensorRegion {
+    /// Which sensor in the focal-plane array this region belongs to.
+    pub sensor_idx: usize,
+    /// Top-left corner of the region in sensor-pixel space.
+    pub offset_px: (i32, i32),
+    /// Width of the output array in pixels.
+    pub width: usize,
+    /// Height of the output array in pixels.
+    pub height: usize,
+}
+
+impl SensorRegion {
+    /// Build a region that covers the entire sensor.
+    pub fn full_sensor(satellite: &SatelliteConfig, sensor_idx: usize) -> Self {
+        let (w, h) = satellite.sensor.dimensions.get_pixel_width_height();
+        Self {
+            sensor_idx,
+            offset_px: (0, 0),
+            width: w,
+            height: h,
+        }
+    }
+
+    /// Build a region from a sensor-pixel top-left corner + size.
+    pub fn from_offset(
+        sensor_idx: usize,
+        offset_px: (i32, i32),
+        width: usize,
+        height: usize,
+    ) -> Self {
+        Self {
+            sensor_idx,
+            offset_px,
+            width,
+            height,
+        }
+    }
+}
+
+/// Run the adaptive-subsample photon-integration + Poisson + read-noise
+/// + quantize pipeline for a chosen region of a sensor. Used by the
+/// full-tile render path as well as the ROI zoom renderer, so both
+/// share the exact motion-blur behavior.
+///
+/// `stars` should already be filtered to the set that could contribute
+/// to this region (the caller decides); `flux_cache` is optional —
+/// pass `None` for one-off renders that don't benefit from sharing the
+/// flux table.
+/// Bundle of borrowed inputs describing the scene side of a region
+/// render: trajectory, candidate stars, focal-plane hardware, and the
+/// satellite backing the chosen sensor. Keeps [`render_region`] at a
+/// sane argument count by grouping things that travel together.
+pub struct RegionRenderInputs<'a> {
+    pub trajectory: &'a Trajectory,
+    pub stars: &'a [&'a StarData],
+    pub fp: &'a FocalPlaneConfig,
+    pub satellite: &'a SatelliteConfig,
+}
+
+pub fn render_region(
+    inputs: &RegionRenderInputs,
+    region: &SensorRegion,
+    schedule: &SubsampleSchedule,
+    padding_mm: f64,
+    zodiacal_per_px: f64,
+    flux_cache: Option<&Arc<Mutex<FluxCache>>>,
+    seed: u64,
+) -> Result<Array2<u16>, TrajectoryError> {
+    let RegionRenderInputs {
+        trajectory,
+        stars,
+        fp,
+        satellite,
+    } = inputs;
+
+    let mut accumulator = SensorAccumulator::zero(region.width, region.height);
+    let aperture = satellite.telescope.clear_aperture_area();
+    let (x0, y0) = region.offset_px;
+
+    let dt = schedule.dt();
+    for t in schedule.sample_times() {
+        let t_clamped = t.min(trajectory.end_time()).max(trajectory.start_time());
+        let orientation = trajectory.orientation_at(t_clamped)?;
+        for star in *stars {
+            let hit = match fp.project_to_sensor(star, &orientation, region.sensor_idx, padding_mm)
+            {
+                Some(px) => px,
+                None => continue,
+            };
+            let flux = match flux_cache {
+                Some(cache) => {
+                    let mut cache = cache.lock().expect("flux cache mutex poisoned");
+                    cache
+                        .entry((star.id, region.sensor_idx))
+                        .or_insert_with(|| star_data_to_fluxes(star, satellite))
+                        .clone()
+                }
+                None => star_data_to_fluxes(star, satellite),
+            };
+            let total_electrons = flux.electrons.integrated_over(&dt, aperture);
+            // Offset into the region's local pixel grid.
+            let local_x = hit.0 - x0 as f64;
+            let local_y = hit.1 - y0 as f64;
+            accumulator.splat_psf(local_x, local_y, total_electrons, &flux.electrons.disk);
+        }
+    }
+
+    // Dark current: rate × full exposure, uniform over pixels.
+    let dark_rate = satellite
+        .sensor
+        .dark_current_at_temperature(satellite.temperature);
+    let dark_mean = (dark_rate * schedule.exposure.as_secs_f64()).max(0.0);
+
+    let mean_image = accumulator.combined_mean(zodiacal_per_px, dark_mean);
+    let poisson_image = apply_poisson_photon_noise(&mean_image, Some(seed));
+
+    let read_noise_rms = satellite
+        .sensor
+        .read_noise_estimator
+        .estimate(satellite.temperature.as_celsius(), schedule.exposure)
+        .unwrap_or(0.0)
+        .max(0.0);
+    let final_electrons = if read_noise_rms > 0.0 {
+        let mut rng = StdRng::seed_from_u64(seed ^ 0xA5A5_5A5A_A5A5_5A5A);
+        let normal =
+            Normal::new(0.0_f64, read_noise_rms).expect("read noise RMS must be non-negative");
+        poisson_image.mapv(|e| (e + normal.sample(&mut rng)).max(0.0))
+    } else {
+        poisson_image
+    };
+
+    Ok(quantize_image(&final_electrons, &satellite.sensor))
+}
+
 /// Render a single `(frame, sensor)` tile.
 ///
 /// Runs the adaptive subsample loop, composes the unified Poisson lambda,
@@ -419,70 +558,23 @@ fn render_tile(
     tile_seed: u64,
     output_path: &Path,
 ) -> Result<(), TrajectoryError> {
-    let (width, height) = satellite.sensor.dimensions.get_pixel_width_height();
-    let mut accumulator = SensorAccumulator::zero(width, height);
-    let aperture = satellite.telescope.clear_aperture_area();
-
-    let schedule = &plan.schedule;
-    let dt = schedule.dt();
-    let sample_times = schedule.sample_times();
-
-    for &t in &sample_times {
-        let t_clamped = t
-            .min(scene.trajectory.end_time())
-            .max(scene.trajectory.start_time());
-        let orientation = scene.trajectory.orientation_at(t_clamped)?;
-        for star in &plan.stars {
-            let hit =
-                match scene
-                    .fp
-                    .project_to_sensor(star, &orientation, sensor_idx, plan.padding_mm)
-                {
-                    Some(px) => px,
-                    None => continue,
-                };
-            let flux = {
-                let mut cache = flux_cache.lock().expect("flux cache mutex poisoned");
-                cache
-                    .entry((star.id, sensor_idx))
-                    .or_insert_with(|| star_data_to_fluxes(star, satellite))
-                    .clone()
-            };
-            // Per-subsample electron contribution for this star at this pixel
-            // position: flux.electrons is a rate (e-/s/cm^2), integrate over
-            // the subsample duration and telescope aperture.
-            let total_electrons = flux.electrons.integrated_over(&dt, aperture);
-            accumulator.splat_psf(hit.0, hit.1, total_electrons, &flux.electrons.disk);
-        }
-    }
-
-    // Dark current: rate × full exposure, uniform over pixels.
-    let dark_rate = satellite
-        .sensor
-        .dark_current_at_temperature(satellite.temperature);
-    let dark_mean = (dark_rate * schedule.exposure.as_secs_f64()).max(0.0);
-
-    // Build unified Poisson mean image and draw.
-    let mean_image = accumulator.combined_mean(plan.zodiacal_per_px[sensor_idx], dark_mean);
-    let poisson_image = apply_poisson_photon_noise(&mean_image, Some(tile_seed));
-
-    // Gaussian read noise (electronics, not shot noise) applied afterwards.
-    let read_noise_rms = satellite
-        .sensor
-        .read_noise_estimator
-        .estimate(satellite.temperature.as_celsius(), schedule.exposure)
-        .unwrap_or(0.0)
-        .max(0.0);
-    let final_electrons = if read_noise_rms > 0.0 {
-        let mut rng = StdRng::seed_from_u64(tile_seed ^ 0xA5A5_5A5A_A5A5_5A5A);
-        let normal =
-            Normal::new(0.0_f64, read_noise_rms).expect("read noise RMS must be non-negative");
-        poisson_image.mapv(|e| (e + normal.sample(&mut rng)).max(0.0))
-    } else {
-        poisson_image
+    let region = SensorRegion::full_sensor(satellite, sensor_idx);
+    let star_refs: Vec<&StarData> = plan.stars.to_vec();
+    let inputs = RegionRenderInputs {
+        trajectory: scene.trajectory,
+        stars: &star_refs,
+        fp: scene.fp,
+        satellite,
     };
-
-    let quantized = quantize_image(&final_electrons, &satellite.sensor);
+    let quantized = render_region(
+        &inputs,
+        &region,
+        &plan.schedule,
+        plan.padding_mm,
+        plan.zodiacal_per_px[sensor_idx],
+        Some(flux_cache),
+        tile_seed,
+    )?;
     save_u16_png(&quantized, output_path)
 }
 

--- a/simulator/src/sims/roi_render.rs
+++ b/simulator/src/sims/roi_render.rs
@@ -1,0 +1,292 @@
+//! Standalone physics renderer for a small region-of-interest (ROI) on
+//! a chosen sensor.
+//!
+//! Produces a `size_px × size_px` u16 patch rendered with the same
+//! motion-blur + Poisson + read-noise + quantization pipeline as the
+//! full sensor tile renderer in `sims::motion_blur`, but only for a
+//! small window around a chosen anchor. Used by the context-view
+//! renderer so the summary image can carry a physically correct,
+//! oversampled zoom that reveals intra-exposure motion artifacts
+//! without touching the full focal-plane render path.
+
+use std::time::Duration;
+
+use ndarray::Array2;
+use shared::units::{AngleExt, LengthExt};
+use starfield::catalogs::StarData;
+
+use crate::hardware::satellite::{FocalPlaneConfig, FocalPlaneProjector};
+use crate::sims::motion_blur::{
+    render_region, RegionRenderInputs, SensorRegion, SubsampleSchedule,
+};
+use crate::sims::trajectory::{Trajectory, TrajectoryError};
+
+/// Location + size of a region of interest in sensor-pixel space.
+#[derive(Debug, Clone, Copy)]
+pub struct RoiAnchor {
+    pub sensor_idx: usize,
+    pub center_px: (f64, f64),
+    pub size_px: usize,
+}
+
+impl RoiAnchor {
+    /// Top-left corner of the ROI as integer sensor pixels. The render
+    /// output covers `[x0, x0 + size_px) × [y0, y0 + size_px)`.
+    pub fn top_left_px(&self) -> (i32, i32) {
+        let half = self.size_px as f64 / 2.0;
+        (
+            (self.center_px.0 - half).round() as i32,
+            (self.center_px.1 - half).round() as i32,
+        )
+    }
+}
+
+/// Pick the ROI anchor: the brightest in-field star on any sensor that
+/// sits at least `size_px / 2` pixels from every edge of its sensor.
+/// Brightness is ranked by [`StarData::magnitude`] (smaller = brighter).
+/// Returns `None` if no qualifying star is found.
+pub fn pick_roi_anchor(
+    stars: &[StarData],
+    fp: &FocalPlaneConfig,
+    orientation: &nalgebra::UnitQuaternion<f64>,
+    size_px: usize,
+) -> Option<RoiAnchor> {
+    let padding_mm = 0.0;
+    let half = size_px as f64 / 2.0;
+    let mut best: Option<(f64, RoiAnchor)> = None;
+    for (sensor_idx, ps) in fp.array.sensors.iter().enumerate() {
+        let (w_px, h_px) = ps.sensor.dimensions.get_pixel_width_height();
+        let (w_px, h_px) = (w_px as f64, h_px as f64);
+        for star in stars {
+            let Some((px, py)) = fp.project_to_sensor(star, orientation, sensor_idx, padding_mm)
+            else {
+                continue;
+            };
+            if px < half || py < half || px > w_px - half || py > h_px - half {
+                continue;
+            }
+            let score = star.magnitude;
+            if best.as_ref().map(|(m, _)| score < *m).unwrap_or(true) {
+                best = Some((
+                    score,
+                    RoiAnchor {
+                        sensor_idx,
+                        center_px: (px, py),
+                        size_px,
+                    },
+                ));
+            }
+        }
+    }
+    best.map(|(_, a)| a)
+}
+
+/// Endpoint-approximation of maximum angular drift a trajectory covers
+/// from `t_start` to `t_end` (radians). Cheaper than the full per-segment
+/// sum used in `motion_blur::max_drift_over_window`; within a single
+/// frame's exposure the two agree to within a fraction of a percent.
+fn drift_over_window(
+    trajectory: &Trajectory,
+    t_start: Duration,
+    t_end: Duration,
+) -> Result<f64, TrajectoryError> {
+    if t_end <= t_start {
+        return Ok(0.0);
+    }
+    let q_a = trajectory.orientation_at(t_start)?;
+    let q_b = trajectory.orientation_at(t_end)?;
+    Ok(q_a.angle_to(&q_b))
+}
+
+/// Per-call frame knobs for [`render_roi_patch`]: when to start the
+/// integration, how long to integrate, how aggressive the motion-blur
+/// subsampler should be, and a seed for Poisson + read noise.
+#[derive(Debug, Clone, Copy)]
+pub struct RoiFramePlan {
+    pub frame_start: Duration,
+    pub exposure: Duration,
+    pub max_drift_per_sample_px: f64,
+    pub seed: u64,
+}
+
+/// Render a `size_px × size_px` ROI patch through the same motion-blur
+/// pipeline as the full sensor tile. Delegates to
+/// [`crate::sims::motion_blur::render_region`] so intra-exposure
+/// pointing drift produces matching motion-blur streaks in the ROI.
+pub fn render_roi_patch(
+    trajectory: &Trajectory,
+    stars: &[StarData],
+    fp: &FocalPlaneConfig,
+    anchor: RoiAnchor,
+    plan: &RoiFramePlan,
+) -> Option<Array2<u16>> {
+    let satellite = fp.satellite_for_sensor(anchor.sensor_idx)?;
+    let (x0, y0) = anchor.top_left_px();
+    let region =
+        SensorRegion::from_offset(anchor.sensor_idx, (x0, y0), anchor.size_px, anchor.size_px);
+
+    // Adaptive schedule: same shape as motion_blur, approximated via
+    // endpoint drift since the ROI is a one-off render without plan
+    // metadata.
+    let traj_end = trajectory.end_time();
+    let traj_start = trajectory.start_time();
+    let t_a = plan.frame_start.max(traj_start);
+    let t_b = (plan.frame_start + plan.exposure).min(traj_end);
+    let eff_exposure = if t_b > t_a { t_b - t_a } else { Duration::ZERO };
+    let drift = drift_over_window(trajectory, t_a, t_b).ok()?;
+    let plate_scale_rad = satellite.plate_scale_per_pixel().as_radians();
+    let schedule = SubsampleSchedule::adaptive(
+        t_a,
+        eff_exposure,
+        drift,
+        plate_scale_rad,
+        plan.max_drift_per_sample_px,
+    );
+
+    // Pixel-space halo for prefiltering stars that could contribute to
+    // the ROI through their PSF skirts.
+    let psf_radius_px = satellite.airy_disk_pixel_space().first_zero().ceil() as i32 * 2;
+    let padding_mm = psf_radius_px as f64 * satellite.sensor.pixel_size().as_millimeters();
+    let size_f = anchor.size_px as f64;
+    let halo = psf_radius_px as f64 + 1.0;
+
+    // Coarse prefilter: only pass stars whose projection under the
+    // first-sample orientation already lands within the ROI + halo.
+    // For small exposures with tight ODY residuals this is a perfect
+    // filter; worst case (slew in mid-exposure) it's conservative
+    // enough to keep the physics right without scanning every star at
+    // every subsample.
+    let first_sample = schedule.sample_times().into_iter().next().unwrap_or(t_a);
+    let sample_t = first_sample.min(traj_end).max(traj_start);
+    let orient0 = trajectory.orientation_at(sample_t).ok()?;
+    let kept: Vec<&StarData> = stars
+        .iter()
+        .filter(|star| {
+            fp.project_to_sensor(star, &orient0, anchor.sensor_idx, padding_mm)
+                .is_some_and(|(sx, sy)| {
+                    let lx = sx - x0 as f64;
+                    let ly = sy - y0 as f64;
+                    lx >= -halo && lx <= size_f + halo && ly >= -halo && ly <= size_f + halo
+                })
+        })
+        .collect();
+
+    let zodiacal_per_px = zodiacal_per_pixel(&satellite, &eff_exposure);
+    let inputs = RegionRenderInputs {
+        trajectory,
+        stars: &kept,
+        fp,
+        satellite: &satellite,
+    };
+    render_region(
+        &inputs,
+        &region,
+        &schedule,
+        padding_mm,
+        zodiacal_per_px,
+        None,
+        plan.seed,
+    )
+    .ok()
+}
+
+/// Per-pixel zodiacal electrons for the supplied satellite over
+/// `exposure`. Mirrors the formula in `motion_blur::zodiacal_per_px_per_s_at`
+/// so the ROI background matches the full-tile background.
+fn zodiacal_per_pixel(satellite: &crate::hardware::SatelliteConfig, exposure: &Duration) -> f64 {
+    use crate::photometry::spectrum::Spectrum;
+    use crate::photometry::zodiacal::{SolarAngularCoordinates, ZodiacalLight};
+    let zlight = ZodiacalLight::new();
+    let coords = SolarAngularCoordinates::zodiacal_minimum();
+    let Ok(z_spect) = zlight.get_zodiacal_spectrum(&coords) else {
+        return 0.0;
+    };
+    let focal_length_mm = satellite.telescope.focal_length.as_meters() * 1000.0;
+    let pixel_size_mm = satellite.sensor.dimensions.pixel_size().as_millimeters();
+    let pixel_scale_arcsec = 206265.0 * pixel_size_mm / focal_length_mm;
+    let pixel_solid_angle_arcsec2 = pixel_scale_arcsec * pixel_scale_arcsec;
+    let aperture = satellite.telescope.clear_aperture_area();
+    z_spect.photo_electrons(&satellite.combined_qe, aperture, exposure) * pixel_solid_angle_arcsec2
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hardware::sensor::models::GSENSE4040BSI;
+    use crate::hardware::sensor_array::SensorArray;
+    use crate::hardware::telescope::TelescopeConfig;
+    use crate::sims::orientation::orientation_from_pointing;
+    use crate::sims::trajectory::Waypoint;
+    use shared::units::{Length, LengthExt, TemperatureExt};
+    use starfield::Equatorial;
+
+    fn tiny_fp() -> FocalPlaneConfig {
+        let telescope = TelescopeConfig::new(
+            "Test",
+            Length::from_meters(0.5),
+            Length::from_meters(2.5),
+            0.8,
+        );
+        FocalPlaneConfig::new(
+            telescope,
+            SensorArray::single(GSENSE4040BSI.clone()),
+            shared::units::Temperature::from_celsius(-10.0),
+        )
+    }
+
+    fn static_trajectory(eq: Equatorial) -> Trajectory {
+        Trajectory::new(vec![
+            Waypoint::from_pointing_and_roll(Duration::ZERO, eq, 0.0),
+            Waypoint::from_pointing_and_roll(Duration::from_secs(10), eq, 0.0),
+        ])
+        .unwrap()
+    }
+
+    #[test]
+    fn roi_anchor_picks_brightest_in_bounds_star() {
+        let fp = tiny_fp();
+        let pointing = Equatorial::from_degrees(45.0, 30.0);
+        let orient = orientation_from_pointing(&pointing, 0.0);
+        let stars = vec![
+            StarData {
+                id: 1,
+                magnitude: 5.0,
+                position: pointing,
+                b_v: Some(0.6),
+            },
+            StarData {
+                id: 2,
+                magnitude: 3.0,
+                position: pointing,
+                b_v: Some(0.6),
+            },
+        ];
+        let anchor = pick_roi_anchor(&stars, &fp, &orient, 64).expect("an anchor exists");
+        assert_eq!(anchor.sensor_idx, 0);
+        assert_eq!(anchor.size_px, 64);
+    }
+
+    #[test]
+    fn render_roi_patch_returns_expected_shape() {
+        let fp = tiny_fp();
+        let pointing = Equatorial::from_degrees(45.0, 30.0);
+        let orient = orientation_from_pointing(&pointing, 0.0);
+        let star = StarData {
+            id: 1,
+            magnitude: 7.0,
+            position: pointing,
+            b_v: Some(0.6),
+        };
+        let traj = static_trajectory(pointing);
+        let anchor = pick_roi_anchor(std::slice::from_ref(&star), &fp, &orient, 32).unwrap();
+        let plan = RoiFramePlan {
+            frame_start: Duration::from_secs(0),
+            exposure: Duration::from_millis(100),
+            max_drift_per_sample_px: 0.1,
+            seed: 42,
+        };
+        let patch = render_roi_patch(&traj, std::slice::from_ref(&star), &fp, anchor, &plan)
+            .expect("patch renders");
+        assert_eq!(patch.dim(), (32, 32));
+    }
+}


### PR DESCRIPTION
## Stacked on #53 (pink + csv re-land)

## Summary

Drops a photometrically correct zoom panel onto each context-view frame so very small pointing residuals are visible at the pixel level. The ROI renders through the same motion-blur + Poisson + read-noise + quantize pipeline as the full sensor tiles, so intra-exposure drift produces matching streaks in the zoom.

## Behavior

- **Anchor** — brightest star on any sensor that sits ≥ \`size/2\` pixels from every edge, picked from the first frame and frozen for the rest of the run.
- **Panel** — nearest-neighbor upsampled to \`size × zoom\` pixels per side, auto-placed in an empty corner with a red outline.
- **Source box** — matching red rectangle drawn on the parent sensor's outline in the context view.
- **Preview cadence** — now always 24 fps (decoupled from \`--timestep\` which still drives sensor tiles).
- **RA/DEC readout** — split to two aligned lines with 2-decimal precision.

## CLI
- \`--roi\` — enable overlay.
- \`--roi-size N\` — source sensor pixels (default 128).
- \`--roi-zoom K\` — nearest-neighbor zoom factor (default 4 → 512 px panel).

## Refactor

Extracted a single photon-integration + noise + quantize helper shared by the full-tile and ROI paths:

- \`SensorRegion\` — output area on a sensor (full-sensor or arbitrary offset/size).
- \`RegionRenderInputs\` — bundle of borrowed scene inputs; keeps the shared helper at 7 args.
- \`render_region\` — one implementation, no duplicated physics.
- \`RoiFramePlan\` — per-frame ROI knobs.

Result: the full-tile renderer (\`render_tile\`) is now a thin wrapper that calls \`render_region\` with the full-sensor region and writes a PNG, and \`render_roi_patch\` does the same with the chosen sub-region.

## Test plan
- [x] \`cargo test\` — 255 passing (was 253 pre-ROI).
- [x] \`cargo clippy -- -W clippy::all\` — clean (no \`too_many_arguments\` silences).
- [x] End-to-end smoke test: Spencer array + circle trajectory + \`--roi --roi-size 128 --roi-zoom 4\` renders 120 context frames in 3.6 s with visible motion-blur streaks in the ROI panel.