### PR TITLE
Polish context-view ROI overlay

### DIFF
--- a/simulator/src/bin/motion_simulator.rs
+++ b/simulator/src/bin/motion_simulator.rs
@@ -873,26 +873,43 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let frame_times = trajectory.frame_times(preview_timestep);
 
         // ROI anchor: picked once per run from the first frame so the
-        // zoom panel stays stationary across the whole preview.
-        let roi_anchor = if args.roi {
+        // zoom panel stays stationary across the whole preview. Picker
+        // scans every sensor and returns the brightest in-bounds star
+        // along with its catalog entry so we can label the panel.
+        let (roi_anchor, roi_label_lines) = if args.roi {
             let first_q = trajectory
                 .orientation_at(trajectory.start_time())
                 .map_err(|e| format!("first-frame orientation: {e}"))?;
             match pick_roi_anchor(&stars, &focal_plane, &first_q, args.roi_size) {
-                Some(a) => {
+                Some((a, star)) => {
+                    let bv_text = star
+                        .b_v
+                        .map(|v| format!("{v:.2}"))
+                        .unwrap_or_else(|| "-".into());
+                    let lines = vec![
+                        format!("MAG {:.2}", star.magnitude),
+                        format!("B-V {bv_text}"),
+                        format!("SENSOR {}", a.sensor_idx),
+                        format!("PX {:.0}, {:.0}", a.center_px.0, a.center_px.1),
+                    ];
                     info!(
-                        "ROI anchor: sensor {} px ({:.1}, {:.1}) size {}",
-                        a.sensor_idx, a.center_px.0, a.center_px.1, a.size_px
+                        "ROI anchor: sensor {} px ({:.1}, {:.1}) size {} — star id {} mag {:.2}",
+                        a.sensor_idx,
+                        a.center_px.0,
+                        a.center_px.1,
+                        a.size_px,
+                        star.id,
+                        star.magnitude,
                     );
-                    Some(a)
+                    (Some(a), lines)
                 }
                 None => {
                     warn!("No star satisfies ROI placement constraints; rendering without ROI");
-                    None
+                    (None, Vec::new())
                 }
             }
         } else {
-            None
+            (None, Vec::new())
         };
 
         info!(
@@ -911,29 +928,90 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let exposure = args.shared.exposure.0;
         let drift_budget = args.max_drift_per_sample_px;
         let base_seed = args.seed;
+
+        // ROI patches refresh once per `exposure` window. With a
+        // 24 fps preview and a 250 ms exposure that's once every six
+        // frames; each refresh integrates ±exposure/2 around the
+        // keyframe time so the patch represents the three frames
+        // before and three after.
+        let preview_timestep_s = preview_timestep.as_secs_f64();
+        let exposure_s = exposure.as_secs_f64();
+        let n_subframes = ((exposure_s / preview_timestep_s).round() as usize).max(1);
+        let keyframe_patches: Vec<Option<ndarray::Array2<u16>>> = if let Some(anchor) = roi_anchor {
+            let n_keyframes = frame_times.len().div_ceil(n_subframes);
+            info!(
+                "ROI keyframes: {} (1 per {} preview frames; integrating {:.0} ms ± centered)",
+                n_keyframes,
+                n_subframes,
+                exposure_s * 1000.0,
+            );
+            (0..n_keyframes)
+                .into_par_iter()
+                .map(|kf_idx| {
+                    let frame_idx = (kf_idx * n_subframes).min(frame_times.len() - 1);
+                    let kf_t = frame_times[frame_idx];
+                    let half = exposure / 2;
+                    let frame_start = kf_t.saturating_sub(half);
+                    let plan = simulator::sims::roi_render::RoiFramePlan {
+                        frame_start,
+                        exposure,
+                        max_drift_per_sample_px: drift_budget,
+                        seed: base_seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ kf_idx as u64,
+                    };
+                    render_roi_patch(&trajectory, &stars, &focal_plane, anchor, &plan)
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        // Freeze the ROI display range once per render: 1st/99th
+        // percentile pooled across every keyframe's patch. Reusing the
+        // same (black, white) stretch for every preview frame keeps
+        // absolute intensity changes visible (you actually see the
+        // star brighten/dim) instead of autoscale flattening them.
+        let frozen_display_range: Option<(u16, u16)> =
+            if keyframe_patches.iter().any(|p| p.is_some()) {
+                let mut all: Vec<u16> = Vec::new();
+                for patch in keyframe_patches.iter().filter_map(|p| p.as_ref()) {
+                    all.extend(patch.iter().copied());
+                }
+                if !all.is_empty() {
+                    all.sort_unstable();
+                    // Lower bound at 1% strips noise floor; upper bound at
+                    // 99.9% lets the star peak through (the bright PSF
+                    // covers ~0.3-0.5% of total pixels — the conventional
+                    // 99% percentile clips it flat).
+                    let lo = all[all.len() / 100];
+                    let hi_idx = all.len() - 1 - (all.len() / 1000);
+                    let hi = all[hi_idx];
+                    info!("ROI display range frozen at {lo}..={hi} (1%/99.9% pooled)");
+                    Some((lo, hi))
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
         let results: Vec<Result<(), String>> = frame_times
             .par_iter()
             .enumerate()
             .map(|(idx, t)| -> Result<(), String> {
                 let orientation = trajectory.orientation_at(*t).map_err(|e| e.to_string())?;
-                let overlay = if let Some(anchor) = roi_anchor {
-                    let plan = simulator::sims::roi_render::RoiFramePlan {
-                        frame_start: *t,
-                        exposure,
-                        max_drift_per_sample_px: drift_budget,
-                        seed: base_seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ idx as u64,
-                    };
-                    render_roi_patch(&trajectory, &stars, &focal_plane, anchor, &plan).map(
-                        |patch| RoiOverlay {
+                let overlay = roi_anchor.and_then(|anchor| {
+                    let kf_idx = idx / n_subframes;
+                    keyframe_patches
+                        .get(kf_idx)
+                        .and_then(|p| p.as_ref())
+                        .map(|patch| RoiOverlay {
                             anchor,
-                            patch,
+                            patch: patch.clone(),
                             zoom: args.roi_zoom,
-                            display_range: None,
-                        },
-                    )
-                } else {
-                    None
-                };
+                            display_range: frozen_display_range,
+                            label_lines: roi_label_lines.clone(),
+                        })
+                });
                 let path = context_dir.join(format!("frame_{idx:06}.png"));
                 render_context_frame(
                     &orientation,

--- a/simulator/src/sims/context_render.rs
+++ b/simulator/src/sims/context_render.rs
@@ -23,7 +23,7 @@ use shared::units::LengthExt;
 use starfield::catalogs::StarData;
 
 use crate::hardware::satellite::FocalPlaneConfig;
-use crate::sims::orientation::boresight_of;
+use crate::sims::orientation::{boresight_of, roll_of};
 use crate::sims::roi_render::RoiAnchor;
 use crate::sims::trajectory::TrajectoryError;
 
@@ -88,6 +88,9 @@ pub struct RoiOverlay {
     /// taken from the first frame) to keep intensity changes between
     /// frames visible rather than re-normalized away.
     pub display_range: Option<(u16, u16)>,
+    /// Optional star info rendered as text just outside the ROI panel
+    /// (one line per element). Caller decides what to show.
+    pub label_lines: Vec<String>,
 }
 
 impl Default for ContextRenderConfig {
@@ -234,16 +237,21 @@ pub fn render_context_frame(
     let tag_text = "NON-ANALYTIC";
     let (_tag_w, tag_h) = text_size(label_scale, &*FONT, tag_text);
     let bore = boresight_of(orientation);
-    let ra_text = format!("RA:  {:10.2}", bore.ra_degrees());
-    let dec_text = format!("DEC: {:+10.2}", bore.dec_degrees());
+    let roll_deg = roll_of(orientation).to_degrees();
+    // Tightly aligned readouts. Value column width 11 = sign + 3 digits +
+    // '.' + 6 decimals (max for ROLL ±180°); aligned colons across the
+    // three labels.
+    let ra_text = format!("RA  : {:>11.6}", bore.ra_degrees());
+    let dec_text = format!("DEC : {:>+11.6}", bore.dec_degrees());
+    let roll_text = format!("ROLL: {roll_deg:>+11.6}");
     let label_x = cx_i + gap;
     // Stack, top-to-bottom:
     //   NON-ANALYTIC
-    //   RA:  <value>
-    //   DEC: <value>
-    // each line separated from the next by 2 px, with the bottom of
-    // the DEC line sitting a few px above the right reticle arm.
-    let dec_y = cy_i - tag_h as i32 - 8;
+    //   RA   : <val>
+    //   DEC  : <val>
+    //   ROLL : <val>
+    let roll_y = cy_i - tag_h as i32 - 8;
+    let dec_y = roll_y - tag_h as i32 - 2;
     let ra_y = dec_y - tag_h as i32 - 2;
     let tag_y = ra_y - tag_h as i32 - 2;
     draw_text_mut(&mut img, red, label_x, tag_y, label_scale, &*FONT, tag_text);
@@ -256,6 +264,15 @@ pub fn render_context_frame(
         label_scale,
         &*FONT,
         &dec_text,
+    );
+    draw_text_mut(
+        &mut img,
+        red,
+        label_x,
+        roll_y,
+        label_scale,
+        &*FONT,
+        &roll_text,
     );
 
     // Optional ROI zoom panel: draws a physically correct oversampled
@@ -303,13 +320,25 @@ fn composite_roi_overlay(
         let (hi_x_mm, hi_y_mm) = mm_from_pixel(cx_px + size_px / 2.0, cy_px - size_px / 2.0);
         let (x0_px, y0_px) = mm_to_px(lo_x_mm, lo_y_mm);
         let (x1_px, y1_px) = mm_to_px(hi_x_mm, hi_y_mm);
-        // Axis-aligned rectangle in image pixels.
-        draw_rect_outline(
-            img,
-            (x0_px.min(x1_px) as i32, y0_px.min(y1_px) as i32),
-            (x0_px.max(x1_px) as i32, y0_px.max(y1_px) as i32),
-            red,
-        );
+        let bx0 = x0_px.min(x1_px) as i32;
+        let by0 = y0_px.min(y1_px) as i32;
+        let bx1 = x0_px.max(x1_px) as i32;
+        let by1 = y0_px.max(y1_px) as i32;
+        // Source-region marker: hairline 1-pixel outline in fully
+        // saturated red so it reads against the brighter pinkish red
+        // used for the ROI panel and the reticle labels.
+        let source_red = Rgb([255, 0, 0]);
+        draw_rect_outline(img, (bx0, by0), (bx1, by1), source_red);
+        // Tick-mark cross extending out from the box corners so the
+        // human eye can find the source even at extreme zoom-out.
+        let tick = ((img.width().min(img.height()) as f64) * 0.012).round() as i32;
+        let tick = tick.max(8);
+        let cx = (bx0 + bx1) / 2;
+        let cy = (by0 + by1) / 2;
+        draw_line(img, (bx0 - tick - 4, cy), (bx0 - 4, cy), source_red);
+        draw_line(img, (bx1 + 4, cy), (bx1 + tick + 4, cy), source_red);
+        draw_line(img, (cx, by0 - tick - 4), (cx, by0 - 4), source_red);
+        draw_line(img, (cx, by1 + 4), (cx, by1 + tick + 4), source_red);
         let _ = (w_px, h_px);
     }
 
@@ -319,18 +348,52 @@ fn composite_roi_overlay(
     // Auto-pick: prefer the corner whose 5%-margin rectangle fits the
     // panel entirely. Try bottom-right, bottom-left, top-right,
     // top-left in order.
+    let (width_i, height_i) = (img.width() as i32, img.height() as i32);
     let margin = ((img.width().min(img.height()) as f64) * 0.02).round() as i32;
     let candidates: &[(i32, i32)] = &[
         (
-            img.width() as i32 - panel_side as i32 - margin,
-            img.height() as i32 - panel_side as i32 - margin,
+            width_i - panel_side as i32 - margin,
+            height_i - panel_side as i32 - margin,
         ),
-        (margin, img.height() as i32 - panel_side as i32 - margin),
-        (img.width() as i32 - panel_side as i32 - margin, margin),
+        (margin, height_i - panel_side as i32 - margin),
+        (width_i - panel_side as i32 - margin, margin),
         (margin, margin),
     ];
-    let (panel_x, panel_y) = *candidates.first().unwrap_or(&(0, 0));
-    let (width_i, height_i) = (img.width() as i32, img.height() as i32);
+
+    // Compute the sensors' image-space AABBs so we can pick a corner
+    // that actually doesn't eclipse a sensor outline. Without this the
+    // panel happily draws on top of the nearest sensor, which is
+    // almost always the first corner we try.
+    let sensor_rects: Vec<(i32, i32, i32, i32)> = fp
+        .array
+        .sensors
+        .iter()
+        .map(|ps| {
+            let (w_len, h_len) = ps.sensor.dimensions.get_width_height();
+            let half_w = w_len.as_millimeters() / 2.0;
+            let half_h = h_len.as_millimeters() / 2.0;
+            let (cx, cy) = (ps.position.x_mm, ps.position.y_mm);
+            let (x0, y0) = mm_to_px(cx - half_w, cy + half_h);
+            let (x1, y1) = mm_to_px(cx + half_w, cy - half_h);
+            (
+                x0.min(x1) as i32,
+                y0.min(y1) as i32,
+                x0.max(x1) as i32,
+                y0.max(y1) as i32,
+            )
+        })
+        .collect();
+    let panel_overlaps = |x: i32, y: i32| -> bool {
+        let (px1, py1) = (x + panel_side as i32, y + panel_side as i32);
+        sensor_rects
+            .iter()
+            .any(|&(sx0, sy0, sx1, sy1)| x < sx1 && px1 > sx0 && y < sy1 && py1 > sy0)
+    };
+    let (panel_x, panel_y) = candidates
+        .iter()
+        .copied()
+        .find(|&(x, y)| !panel_overlaps(x, y))
+        .unwrap_or_else(|| *candidates.first().unwrap_or(&(0, 0)));
     // Clamp so even on tiny test canvases we don't try to draw off-image.
     let panel_x = panel_x.max(0).min(width_i - panel_side as i32 - 1);
     let panel_y = panel_y.max(0).min(height_i - panel_side as i32 - 1);
@@ -371,6 +434,33 @@ fn composite_roi_overlay(
         ),
         red,
     );
+
+    // Star-info label just outside the panel. Renders below by default;
+    // if there isn't room (panel hugs the bottom edge), renders above.
+    if !overlay.label_lines.is_empty() {
+        let label_scale = PxScale::from((width_i.min(height_i) as f32 / 100.0).max(11.0));
+        let probe_text = overlay
+            .label_lines
+            .iter()
+            .max_by_key(|s| s.len())
+            .map(|s| s.as_str())
+            .unwrap_or("");
+        let (_, line_h) = text_size(label_scale, &*FONT, probe_text);
+        let line_h = line_h as i32 + 2;
+        let total_h = line_h * overlay.label_lines.len() as i32;
+        let panel_bottom = panel_y + panel_side as i32 - 1;
+        let below_y = panel_bottom + 6;
+        let label_below = below_y + total_h <= height_i;
+        let mut text_y = if label_below {
+            below_y
+        } else {
+            panel_y - total_h - 4
+        };
+        for line in &overlay.label_lines {
+            draw_text_mut(img, red, panel_x, text_y, label_scale, &*FONT, line);
+            text_y += line_h;
+        }
+    }
 
     let _ = (width_f, height_f);
     Ok(())

--- a/simulator/src/sims/roi_render.rs
+++ b/simulator/src/sims/roi_render.rs
@@ -41,19 +41,22 @@ impl RoiAnchor {
     }
 }
 
-/// Pick the ROI anchor: the brightest in-field star on any sensor that
-/// sits at least `size_px / 2` pixels from every edge of its sensor.
-/// Brightness is ranked by [`StarData::magnitude`] (smaller = brighter).
+/// Pick the ROI anchor by scanning *every* sensor in the focal plane:
+/// the returned anchor is the projection of the single brightest
+/// in-field star whose pixel position sits at least `size_px / 2`
+/// pixels from every edge of *its* sensor. Brightness is ranked by
+/// [`StarData::magnitude`] (smaller = brighter). Also returns a
+/// reference to the chosen star so callers can label the ROI panel.
 /// Returns `None` if no qualifying star is found.
-pub fn pick_roi_anchor(
-    stars: &[StarData],
+pub fn pick_roi_anchor<'a>(
+    stars: &'a [StarData],
     fp: &FocalPlaneConfig,
     orientation: &nalgebra::UnitQuaternion<f64>,
     size_px: usize,
-) -> Option<RoiAnchor> {
+) -> Option<(RoiAnchor, &'a StarData)> {
     let padding_mm = 0.0;
     let half = size_px as f64 / 2.0;
-    let mut best: Option<(f64, RoiAnchor)> = None;
+    let mut best: Option<(f64, RoiAnchor, &StarData)> = None;
     for (sensor_idx, ps) in fp.array.sensors.iter().enumerate() {
         let (w_px, h_px) = ps.sensor.dimensions.get_pixel_width_height();
         let (w_px, h_px) = (w_px as f64, h_px as f64);
@@ -66,7 +69,7 @@ pub fn pick_roi_anchor(
                 continue;
             }
             let score = star.magnitude;
-            if best.as_ref().map(|(m, _)| score < *m).unwrap_or(true) {
+            if best.as_ref().map(|(m, _, _)| score < *m).unwrap_or(true) {
                 best = Some((
                     score,
                     RoiAnchor {
@@ -74,11 +77,12 @@ pub fn pick_roi_anchor(
                         center_px: (px, py),
                         size_px,
                     },
+                    star,
                 ));
             }
         }
     }
-    best.map(|(_, a)| a)
+    best.map(|(_, anchor, star)| (anchor, star))
 }
 
 /// Endpoint-approximation of maximum angular drift a trajectory covers
@@ -261,9 +265,11 @@ mod tests {
                 b_v: Some(0.6),
             },
         ];
-        let anchor = pick_roi_anchor(&stars, &fp, &orient, 64).expect("an anchor exists");
+        let (anchor, star) = pick_roi_anchor(&stars, &fp, &orient, 64).expect("an anchor exists");
         assert_eq!(anchor.sensor_idx, 0);
         assert_eq!(anchor.size_px, 64);
+        // mag 3.0 is brighter than mag 5.0, so star id 2 should win.
+        assert_eq!(star.id, 2);
     }
 
     #[test]
@@ -278,7 +284,7 @@ mod tests {
             b_v: Some(0.6),
         };
         let traj = static_trajectory(pointing);
-        let anchor = pick_roi_anchor(std::slice::from_ref(&star), &fp, &orient, 32).unwrap();
+        let (anchor, _) = pick_roi_anchor(std::slice::from_ref(&star), &fp, &orient, 32).unwrap();
         let plan = RoiFramePlan {
             frame_start: Duration::from_secs(0),
             exposure: Duration::from_millis(100),


### PR DESCRIPTION
## Summary

Iterative polish on top of the ROI overlay from #55, driven by a series of preview renders against the ODY trajectory.

**Reticle**
- Add `ROLL` line; align `RA` / `DEC` / `ROLL` on the colon and bump to 6-decimal precision.

**Source-region marker on the parent sensor outline**
- Hairline 1-px saturated-red box (was the same pinkish red as the panel and washed out against bright sensor outlines).
- Tick-mark cross extending out from the box midpoints so the source location is findable by eye when zoomed all the way out.

**ROI panel placement**
- Pre-compute every sensor's image-space AABB and pick the first candidate corner (BR / BL / TR / TL) whose panel rectangle does not overlap any sensor outline. Previously it always took the first corner, which usually buried the panel on top of a sensor.

**Star labelling**
- `pick_roi_anchor` now returns the chosen `&StarData` alongside the anchor.
- New `RoiOverlay::label_lines`; `motion_simulator` populates it with `MAG` / `B-V` / `SENSOR` / `PX-coords`. Drawn just outside the panel (below by default, flips above if there is no room).

**Keyframe-batched ROI patches**
- Patches now refresh once per exposure window (one keyframe per `N = round(exposure / preview_timestep)` preview frames). At 24 fps with 250 ms exposures that is 1 patch per 6 frames; sub-frames reuse the keyframe. Cuts ROI compute by ~6x and matches what a real shutter integrating across the same window would record.
- Each keyframe is centered on its frame time (`frame_start = kf_t - exposure/2`) so the patch represents the symmetric window around the displayed orientation.

**Frozen ROI display range**
- Pool every keyframe patch's pixels and freeze the (1%, 99.9%) percentile stretch for the whole preview. Reusing the same black/white points keeps absolute brightness changes visible (the star actually brightens / streaks) instead of having per-frame autoscale flatten them.

## Test plan
- [x] \`cargo fmt\`
- [x] \`cargo clippy -- -W clippy::all\` — clean (the two pre-existing \`motion_blur.rs\` doc-lazy-continuation warnings were inherited from #55, not introduced here)
- [x] \`cargo test\` — 241 passed, 0 failed
- [x] Validated on the full 100 s ODY render at \`/tmp/fp_ody100_full\`: 4 sensors × 101 frames + 2400-frame context preview, plus the iterative roi5–roi10 context-only previews