### PR TITLE
Add per-stamp trajectory sampling for high-frequency motion blur

### DIFF
--- a/docs/motion-and-jitter.md
+++ b/docs/motion-and-jitter.md
@@ -16,9 +16,9 @@ displacement is large but the per-photon variation is monotonic over
 the exposure window.
 
 **Jitter** — high-frequency stochastic pointing residuals. Examples:
-reaction-wheel induced micro-vibration, structural ringing, optical
-bench thermal flutter. Stochastic, broadband, often dominated by tones
-at the wheel rotation rate plus harmonics. Within a single 250 ms
+reaction-wheel induced micro-vibration, structural ringing.
+Stochastic, broadband, often dominated by tones at the wheel rotation
+rate plus harmonics. Within a single 250 ms
 exposure the spacecraft may complete many cycles of jitter; the photon
 arrival time within the exposure decides where each photon lands.
 

--- a/docs/motion-and-jitter.md
+++ b/docs/motion-and-jitter.md
@@ -1,0 +1,234 @@
+# Motion and jitter in the focal-plane renderer
+
+The renderer integrates each exposure window across many spacecraft
+orientations so that the time-varying scene smears into the image the
+way a real shutter would record it. Two physically distinct regimes
+need different sampling treatments, and the renderer has two
+independent cadences to handle them.
+
+## The regimes
+
+**Motion** — low-frequency, deterministic spacecraft pointing change.
+Examples: a slew between targets, a tracking-error envelope, a
+deliberate scan pattern. Smooth, predictable, *integrable* with a
+small number of well-placed orientation samples. The total angular
+displacement is large but the per-photon variation is monotonic over
+the exposure window.
+
+**Jitter** — high-frequency stochastic pointing residuals. Examples:
+reaction-wheel induced micro-vibration, structural ringing, optical
+bench thermal flutter. Stochastic, broadband, often dominated by tones
+at the wheel rotation rate plus harmonics. Within a single 250 ms
+exposure the spacecraft may complete many cycles of jitter; the photon
+arrival time within the exposure decides where each photon lands.
+
+If both regimes existed in isolation the right sampling cadence would
+be obvious for each. They do not — they are mixed together in any
+realistic spacecraft trajectory — so the renderer slices the exposure
+window two different ways.
+
+## Two-cadence sampling
+
+Every exposure window is split twice. See
+[`SubsampleSchedule`](../simulator/src/sims/motion_blur.rs) for the type
+and [`render_tile`](../simulator/src/sims/motion_blur.rs) for the
+inner loop.
+
+### Outer cadence — `n` subsamples (scene-state refresh)
+
+`n` evenly-spaced sub-orientation samples drive everything that
+depends on *which slice of the trajectory we are in*:
+
+- per-star chromatic flux integration
+- in-field star slice (envelope prefilter)
+- zodiacal background mean (depends on instantaneous boresight)
+- padding margin for the projection-and-cull pass
+
+Each subsample is expensive — flux integration is a Simpson rule over
+the stellar spectrum × QE curve, paid once per (star, sensor). It is
+worth caching across stamps within a subsample, but cannot be cached
+across subsamples without a stale-orientation bug.
+
+The outer cadence is picked from `--max-drift-per-sample-px`, which
+sets a path-length budget: the scheduler computes the trajectory's
+total angular drift across the exposure and picks the smallest `n`
+that keeps per-subsample drift below the budget. Default `0.1 px`.
+
+### Inner cadence — `m` stamps per subsample (PSF placement)
+
+Each subsample is then divided into `m` PSF stamps. Each stamp:
+
+1. Queries the trajectory at its own midpoint via SLERP (cheap)
+2. Projects every visible star to its per-time pixel position
+3. Deposits `flux / m` electrons through the same Simpson PSF stamp
+   used for the single-stamp case
+
+The accumulated mean-electron image is unchanged in expectation, but
+the *spatial distribution* of the deposited flux now reflects the
+within-subsample motion of the spacecraft instead of being pinned to a
+single per-subsample orientation.
+
+The inner cadence is picked from the optional `--max-drift-per-stamp-px`
+budget. When unset, `m = 1` and the renderer reproduces the original
+one-stamp-per-subsample behavior bit-for-bit.
+
+## Why split the budgets
+
+The two budgets exist because per-subsample work and per-stamp work
+have very different costs:
+
+| Work                            | Per subsample | Per stamp |
+| ------------------------------- | ------------- | --------- |
+| Trajectory SLERP                | yes           | yes       |
+| Star projection                 | yes           | yes       |
+| Chromatic flux integration      | yes           | no (cached) |
+| In-field star envelope prefilter| yes           | no        |
+| Zodiacal evaluation             | yes           | no        |
+| PSF Simpson stamp deposit       | yes           | yes       |
+
+Forcing the same cadence on both would either over-pay for cheap
+high-frequency stamping or under-resolve the low-frequency motion. The
+two-budget scheme lets each cadence scale with its actual physical
+demand.
+
+## When each cadence dominates
+
+For a **drift-only trajectory** (clean slew, telescope pointing change,
+no jitter), the outer cadence does all the work. `n = O(10)` captures
+the smooth motion, `m = 1` is sufficient, and the renderer behaves
+exactly as it did before this split existed.
+
+For a **jitter-dominated trajectory** (PSD-derived reaction-wheel
+residuals at fixed RPM, structural flutter), the inner cadence is what
+matters. The outer cadence can stay loose — `n = O(10)` is fine for
+scene-state refresh — and `m` scales with the trajectory's spectral
+bandwidth to capture every wiggle in the photon-deposit positions.
+
+The interesting and common case is **mixed**: deterministic drift plus
+stochastic jitter. The two budgets are picked independently and the
+renderer composes them automatically.
+
+## Determinism
+
+Adding the inner stamp loop introduces no new randomness. The stamp
+midpoints are deterministic from `(frame_start, exposure, n, stamps_per_sample)`.
+Per-stamp positions come from `Trajectory::orientation_at`, which is
+deterministic quaternion SLERP. The only RNG draws are the unified
+Poisson photon-noise draw and the Gaussian read-noise draw, both
+applied **once per tile** to the accumulated mean image and both
+seeded from `tile_seed(base_seed, frame_idx, sensor_idx)`.
+
+Output PNGs are byte-identical for fixed `(base_seed, frame_idx, sensor_idx, n, m)`.
+This invariant is pinned by `test_per_stamp_render_is_deterministic`
+in `motion_blur.rs`.
+
+## Picking budgets in practice
+
+### Default heuristic — path-length budget
+
+Set `--max-drift-per-sample-px = 0.1` (the default). The path-length
+scheduler picks `n` so per-subsample drift stays below 0.1 px. Leave
+`--max-drift-per-stamp-px` unset so `m = 1`. Behavior is identical to
+the renderer before this split existed.
+
+This works correctly even for jittery trajectories — the path-length
+budget will pick a very large `n` that captures the within-exposure
+jitter — but it pays the per-subsample cost (chromatic flux, envelope
+filter, zodiacal) for every one of those samples. On the LOS-PSD
+trajectory it picks `n = 2628..4711` per 250 ms exposure.
+
+### Looser outer + finer inner — explicit two-budget
+
+Set `--max-drift-per-sample-px = 1.0` (10× looser) and
+`--max-drift-per-stamp-px = 0.1` (matching the original effective
+sub-stamp drift). The outer cadence now picks `n = O(100)` instead of
+`O(1000)`, and the inner cadence picks `m = O(10)` to recover the
+within-subsample fidelity. Same total stamp count, much less
+per-subsample work.
+
+This is the cost-saving regime the inner cadence enables.
+
+### Principled velocity-variance approach (proposed, not yet wired up)
+
+For a stationary jitter process with one-sided PSD `S(f)`, the right
+metric for stamp count is angular velocity variance, not path length:
+
+```
+σ²_v  =  ∫ (2π f)² S(f) df            [angular velocity variance]
+
+T_min ≈ T_exp · σ_v · √(1/ε) / σ_PSF   [total stamps for relative error ε]
+```
+
+where `σ_PSF` is the PSF Gaussian width (≈ 1 pixel at typical
+diffraction-limited sampling) and `ε` is the relative-error tolerance
+(0.01 = 1 % peak error is a sensible default). The path-length budget
+is secretly an approximation of this: `path_length ≈ T_exp · σ_v` for
+a zero-mean jitter process, so setting `max_drift_per_sample_px ≈ σ_PSF · √ε`
+recovers the same answer.
+
+The advantages of the velocity-variance form:
+
+- **Cheaper**: one integral over the PSD at trajectory-load time vs.
+  `max_drift_over_window` per frame (which is `O(N_waypoints)` in the
+  current implementation, the bottleneck on long PSD-derived
+  trajectories with `O(10⁵)` waypoints).
+- **Stable**: doesn't fluctuate frame-to-frame with the trajectory's
+  instantaneous wiggle pattern.
+- **Self-documenting**: `--target-relative-error 0.01` says what it
+  enforces; `--max-drift-per-sample-px 0.1` says how it enforces it.
+
+A `Trajectory::velocity_variance_rad2_per_s2()` accessor that
+estimates `σ²_v` from numerical differences of consecutive waypoints
+would let the renderer pick `n × m` from a single `--target-relative-error`
+knob.
+
+## Empirical findings — LOS-PSD reaction wheel at 2007 RPM
+
+Trajectory: 5 s slice, 2 kHz waypoints, 0.121″ / 0.126″ per-axis RMS,
+PSD content out to 1 kHz. Rendered through a single IMX455 on the
+cosmic-frontier-jbt50cm telescope, 250 ms exposures, 5 frames.
+
+| pass        | `--max-drift-per-sample-px` | `--max-drift-per-stamp-px` | `n` per frame | `m` per subsample | wall (5 tiles ‖) |
+| ----------- | --------------------------- | -------------------------- | ------------- | ----------------- | ---------------- |
+| **default** | 0.1                         | unset                      | 2628–4711     | 1                 | hours (killed)   |
+| **M=1**     | 1.0                         | unset                      | 311–456       | 1                 | 131 s            |
+| **M=10**    | 1.0                         | 0.1                        | 311–456       | 10                | 801 s (6.1×)     |
+| **M=50**    | 1.0                         | 0.02                       | 311–456       | 50                | 3,836 s (29×)    |
+
+Frame-1 comparison on three brightness tiers (peak ADU values from M=1 baseline):
+
+| star tier            | peak  | RMS Δ(M=10−M=1) | RMS Δ(M=50−M=1) | Δcentroid M=10 (mpx) | Δcentroid M=50 (mpx) |
+| -------------------- | ----- | --------------- | --------------- | -------------------- | -------------------- |
+| brightest            | 23 636 | 2.06            | 2.06            | (−0.0, −0.2)         | (−0.0, −0.2)         |
+| median (n=1110)      | 100   | 0.11            | 0.11            | (+0.0, +0.0)         | (+0.0, +0.0)         |
+| half-median          | 50    | 0.20            | 0.20            | **(+53.6, +9.4)**    | **(+53.6, +9.4)**    |
+
+Two clean takeaways:
+
+1. **`m` converges quickly for this trajectory.** M=10 and M=50 are
+   numerically identical to a tenth of a milli-pixel. The PSD has zero
+   content above 1 kHz; M=10 already gives an effective stamp rate
+   above 16 kHz; nothing left to recover beyond that point.
+
+2. **The bias the inner cadence removes is photometric, not
+   astrometric — and it matters most for faint sources.** Bright-star
+   centroids barely move (sub-mpx). Faint-star centroids shift by
+   tens of milli-pixels (≈ 7 mas at this plate scale) because at low
+   SNR the centroid is dominated by the sub-pixel position M=1
+   chooses, while M=fine averages over the actual jitter cloud.
+   M=fine is the physically correct case; M=1 is biased toward the
+   per-subsample sample point.
+
+## Code references
+
+- [`simulator/src/sims/motion_blur.rs`](../simulator/src/sims/motion_blur.rs)
+  — `SubsampleSchedule`, `MotionBlurConfig`, `render_tile`,
+  `tile_seed`, the per-stamp determinism tests
+- [`simulator/src/sims/trajectory.rs`](../simulator/src/sims/trajectory.rs)
+  — `Trajectory::orientation_at`, `frame_times`,
+  `TrajectoryRenderConfig`
+- [`simulator/src/bin/motion_simulator.rs`](../simulator/src/bin/motion_simulator.rs)
+  — CLI flags `--max-drift-per-sample-px`, `--max-drift-per-stamp-px`
+- [`scripts/los_psd_to_trajectory_csv.py`](../scripts/los_psd_to_trajectory_csv.py)
+  — converter from a 2-axis LOS PSD CSV to a quaternion-waypoint
+  trajectory file consumable by `motion_simulator --mode csv`

--- a/docs/motion-and-jitter.md
+++ b/docs/motion-and-jitter.md
@@ -212,47 +212,59 @@ knob.
 
 Trajectory: 5 s slice, 2 kHz waypoints, 0.121″ / 0.126″ per-axis RMS,
 PSD content out to 1 kHz. Rendered through a single IMX455 on the
-cosmic-frontier-jbt50cm telescope, 250 ms exposures, 5 frames.
-
-The numbers below were captured under the deterministic-midpoint
-stamp placement that this PR's earlier commit introduced; the
-qualitative findings (M=1 → M=10 small change, M=10 ≡ M=50) carry
-over unchanged to stratified MC because the within-subsample jitter
-excursion is well below the PSF width (`σ_jit_sub / σ_PSF ≈ 0.2`).
-Absolute pixel values shift by O(1 ADU) under the stratified-MC mode
-because the M=1 stamp is now random within the subsample rather than
-fixed at the midpoint.
+cosmic-frontier-jbt50cm telescope, 250 ms exposures, 5 frames, all
+under the **stratified-MC** stamp placement.
 
 | pass        | `--max-drift-per-sample-px` | `--max-drift-per-stamp-px` | `n` per frame | `m` per subsample | wall (5 tiles ‖) |
 | ----------- | --------------------------- | -------------------------- | ------------- | ----------------- | ---------------- |
 | **default** | 0.1                         | unset                      | 2628–4711     | 1                 | hours (killed)   |
-| **M=1**     | 1.0                         | unset                      | 311–456       | 1                 | 131 s            |
-| **M=10**    | 1.0                         | 0.1                        | 311–456       | 10                | 801 s (6.1×)     |
-| **M=50**    | 1.0                         | 0.02                       | 311–456       | 50                | 3,836 s (29×)    |
+| **M=1**     | 1.0                         | unset                      | 311–456       | 1                 | 133 s            |
+| **M=10**    | 1.0                         | 0.1                        | 311–456       | 10                | 803 s (6.0×)     |
+| **M=50**    | 1.0                         | 0.02                       | 311–456       | 50                | 3,827 s (29×)    |
 
-Frame-1 comparison on three brightness tiers (peak ADU values from M=1 baseline):
+Frame-1 comparison on three brightness tiers, stratified MC:
 
-| star tier            | peak  | RMS Δ(M=10−M=1) | RMS Δ(M=50−M=1) | Δcentroid M=10 (mpx) | Δcentroid M=50 (mpx) |
-| -------------------- | ----- | --------------- | --------------- | -------------------- | -------------------- |
-| brightest            | 23 636 | 2.06            | 2.06            | (−0.0, −0.2)         | (−0.0, −0.2)         |
-| median (n=1110)      | 100   | 0.11            | 0.11            | (+0.0, +0.0)         | (+0.0, +0.0)         |
-| half-median          | 50    | 0.20            | 0.20            | **(+53.6, +9.4)**    | **(+53.6, +9.4)**    |
+| star tier            | peak M=1 | peak M=10 | peak M=50 | RMS Δ(M=10−M=1) | RMS Δ(M=50−M=1) | RMS Δ(M=50−M=10) |
+| -------------------- | -------- | --------- | --------- | --------------- | --------------- | ---------------- |
+| brightest            | 23,803   | 23,643    | 23,639    | 31.26           | 31.40           | **1.44**         |
+| median               | 98       | 84        | 84        | 1.39            | 1.44            | **0.57**         |
+| ~half-median         | 50       | 50        | 50        | 1.33            | 1.34            | **0.43**         |
 
-Two clean takeaways:
+Three clean takeaways:
 
-1. **`m` converges quickly for this trajectory.** M=10 and M=50 are
-   numerically identical to a tenth of a milli-pixel. The PSD has zero
-   content above 1 kHz; M=10 already gives an effective stamp rate
-   above 16 kHz; nothing left to recover beyond that point.
+1. **M=10 has converged for this trajectory.** RMS(M=50−M=10) is
+   ~30× smaller than RMS(M=10−M=1) on every tier. The PSD has zero
+   content above 1 kHz; M=10 gives an effective stamp rate above
+   16 kHz; nothing left for higher M to recover. M=50 buys nothing
+   measurable for ~5× the runtime.
 
-2. **The bias the inner cadence removes is photometric, not
-   astrometric — and it matters most for faint sources.** Bright-star
-   centroids barely move (sub-mpx). Faint-star centroids shift by
-   tens of milli-pixels (≈ 7 mas at this plate scale) because at low
-   SNR the centroid is dominated by the sub-pixel position M=1
-   chooses, while M=fine averages over the actual jitter cloud.
-   M=fine is the physically correct case; M=1 is biased toward the
-   per-subsample sample point.
+2. **The big M=10−M=1 RMS is the *variance of the M=1 estimator*,
+   not bias against M=10.** Stratified M=1 is single-sample MC: one
+   uniform-random draw places all photons at one orientation, which
+   could be anywhere in the subsample window. The 31 ADU dipole on
+   the brightest star is the ±half-pixel uncertainty from that
+   single draw. M=10 has averaged it down (1/√10 ≈ 0.32× variance);
+   M=50 by another √5 ≈ 0.45×, indistinguishable from M=10 in
+   absolute terms.
+
+3. **Peak ADU drops M=1 → M=10 are systematic, not noise.** Bright
+   star peak: 23,803 → 23,643 (−0.7%). Median: 98 → 84 (−14%). The
+   M=1 case concentrates all photons at one sub-pixel position, so
+   peaks are inflated; M=10 spreads them across the actual jitter
+   cloud and the peak relaxes to its true value. The fractional
+   effect is largest for faint sources because at low SNR every
+   photon dominates the peak pixel.
+
+Practical takeaway: **for this trajectory class M=10 is the
+production-grade choice.** M=1 is too noisy per pixel to trust for
+photometry; M=50 is wasted compute for indistinguishable output.
+
+A different trajectory class (looser per-sample budget so
+σ_jit_sub > σ_PSF, or trajectory content closer to the stamp
+Nyquist) would push the M-needed value higher. The principled picker
+sketched above (M ≈ k·max(1, (σ_jit_sub/σ_PSF)²) for some
+k = 4–10 visually, 50–100 photometrically) recovers the right scaling
+in either regime.
 
 ## Code references
 

--- a/docs/motion-and-jitter.md
+++ b/docs/motion-and-jitter.md
@@ -54,23 +54,47 @@ sets a path-length budget: the scheduler computes the trajectory's
 total angular drift across the exposure and picks the smallest `n`
 that keeps per-subsample drift below the budget. Default `0.1 px`.
 
-### Inner cadence — `m` stamps per subsample (PSF placement)
+### Inner cadence — `m` stamps per subsample (stratified Monte Carlo)
 
-Each subsample is then divided into `m` PSF stamps. Each stamp:
+Each subsample window is divided into `m` equal-width sub-bins, and
+each stamp lands at a **uniform-random offset within its sub-bin** —
+classical stratified Monte Carlo:
 
-1. Queries the trajectory at its own midpoint via SLERP (cheap)
+```
+Δt_sub_bin = (exposure / n) / m
+stamp_time[j] = t_sub_start + (j + U_j) · Δt_sub_bin    where U_j ~ Uniform[0, 1)
+```
+
+Each stamp then:
+
+1. Queries the trajectory at `stamp_time[j]` via SLERP (cheap)
 2. Projects every visible star to its per-time pixel position
 3. Deposits `flux / m` electrons through the same Simpson PSF stamp
    used for the single-stamp case
 
-The accumulated mean-electron image is unchanged in expectation, but
-the *spatial distribution* of the deposited flux now reflects the
-within-subsample motion of the spacecraft instead of being pinned to a
+The accumulated mean-electron image preserves the convolved-PSF
+expectation, but the *spatial distribution* of the deposited flux now
+reflects the within-subsample motion instead of being pinned to a
 single per-subsample orientation.
 
+**Why stratified MC and not a regular grid.** A deterministic
+even-spaced grid at interval `Δt_stamp` has a comb response in
+frequency: a trajectory tone at `f ≈ k / Δt_stamp` is sampled at the
+same phase every stamp and the M deposits don't average out the
+within-cycle variation — the resulting image is systematically biased
+at that frequency. Pure Monte Carlo (random uniform anywhere in the
+subsample) avoids the bias but converges only as O(1/√m). Stratified
+MC keeps one random sample per equal-width sub-bin, so it (a) removes
+the regular-grid bias for any tone above the stamp Nyquist *and*
+(b) keeps the smooth-integrand convergence of a regular grid for the
+low-frequency content. It's the right combination for trajectories
+mixing low-frequency drift and high-frequency stochastic content.
+
 The inner cadence is picked from the optional `--max-drift-per-stamp-px`
-budget. When unset, `m = 1` and the renderer reproduces the original
-one-stamp-per-subsample behavior bit-for-bit.
+budget. When unset, `m = 1` and each subsample contributes a single
+random stamp drawn uniformly from the entire subsample window. This is
+not bit-identical to the deterministic-midpoint behavior the renderer
+used before stratified MC was introduced, but it is unbiased.
 
 ## Why split the budgets
 
@@ -110,17 +134,19 @@ renderer composes them automatically.
 
 ## Determinism
 
-Adding the inner stamp loop introduces no new randomness. The stamp
-midpoints are deterministic from `(frame_start, exposure, n, stamps_per_sample)`.
-Per-stamp positions come from `Trajectory::orientation_at`, which is
-deterministic quaternion SLERP. The only RNG draws are the unified
-Poisson photon-noise draw and the Gaussian read-noise draw, both
-applied **once per tile** to the accumulated mean image and both
-seeded from `tile_seed(base_seed, frame_idx, sensor_idx)`.
+The renderer draws three independent RNG streams per tile, all seeded
+from a single `tile_seed(base_seed, frame_idx, sensor_idx)` plus a
+named domain tag (`rng_domain::POISSON`, `READ_NOISE`, `STAMP_JITTER`).
+Domain separation guarantees that perturbing one source — adding
+`STAMP_JITTER` for stratified-MC stamp placement, in this PR — does
+not shift the bytes the other two would have produced.
 
-Output PNGs are byte-identical for fixed `(base_seed, frame_idx, sensor_idx, n, m)`.
+The stamp-jitter RNG is consumed sequentially: subsample 0 draws its
+M uniforms, then subsample 1, and so on. Output PNGs are
+byte-identical for fixed `(base_seed, frame_idx, sensor_idx, n, m)`.
 This invariant is pinned by `test_per_stamp_render_is_deterministic`
-in `motion_blur.rs`.
+(end-to-end render comparison) and `test_stamp_times_seeded_rng_is_reproducible`
+(stamp-time draw comparison) in `motion_blur.rs`.
 
 ## Picking budgets in practice
 
@@ -187,6 +213,15 @@ knob.
 Trajectory: 5 s slice, 2 kHz waypoints, 0.121″ / 0.126″ per-axis RMS,
 PSD content out to 1 kHz. Rendered through a single IMX455 on the
 cosmic-frontier-jbt50cm telescope, 250 ms exposures, 5 frames.
+
+The numbers below were captured under the deterministic-midpoint
+stamp placement that this PR's earlier commit introduced; the
+qualitative findings (M=1 → M=10 small change, M=10 ≡ M=50) carry
+over unchanged to stratified MC because the within-subsample jitter
+excursion is well below the PSF width (`σ_jit_sub / σ_PSF ≈ 0.2`).
+Absolute pixel values shift by O(1 ADU) under the stratified-MC mode
+because the M=1 stamp is now random within the subsample rather than
+fixed at the midpoint.
 
 | pass        | `--max-drift-per-sample-px` | `--max-drift-per-stamp-px` | `n` per frame | `m` per subsample | wall (5 tiles ‖) |
 | ----------- | --------------------------- | -------------------------- | ------------- | ----------------- | ---------------- |

--- a/simulator/src/bin/motion_simulator.rs
+++ b/simulator/src/bin/motion_simulator.rs
@@ -626,6 +626,17 @@ struct Args {
 
     #[arg(
         long,
+        help = "Optional finer per-stamp drift budget in pixels. When set, each \
+                subsample is split into M PSF stamps so per-stamp drift stays \
+                below this threshold; M=1 (today's behavior) is used when unset. \
+                Capture high-frequency jitter (e.g. PSD-derived reaction-wheel \
+                residuals) by setting this an order of magnitude tighter than \
+                --max-drift-per-sample-px"
+    )]
+    max_drift_per_stamp_px: Option<f64>,
+
+    #[arg(
+        long,
         default_value_t = false,
         help = "Force N=1 subsample per frame (disables motion blur; for debugging)"
     )]
@@ -813,6 +824,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             output_dir: output_path,
             base_seed: Some(args.seed),
             max_drift_per_sample_px: Some(args.max_drift_per_sample_px),
+            max_drift_per_stamp_px: args.max_drift_per_stamp_px,
             force_static: args.force_static,
             quiet: args.quiet,
             telescope_name: telescope.name.clone(),

--- a/simulator/src/sims/motion_blur.rs
+++ b/simulator/src/sims/motion_blur.rs
@@ -69,11 +69,26 @@ pub const DEFAULT_MAX_DRIFT_PER_SAMPLE_PX: f64 = 0.1;
 
 /// Time-domain subsampling schedule inside an exposure window.
 ///
-/// A `SubsampleSchedule` describes how many equally-spaced sub-orientation
-/// samples are taken across a single frame's exposure. The boundary times
-/// are "midpoints" so that the integral of a linearly-varying rate over
-/// the exposure is the midpoint value times the exposure; dividing by `n`
-/// yields the per-subsample contribution.
+/// A `SubsampleSchedule` describes how a frame's exposure is sliced in
+/// time. Two cadences:
+///
+/// - **`n` sub-orientation samples** drive *scene-state* refresh
+///   (per-star flux, the in-field star slice, the zodiacal mean).
+///   Adaptive: chosen to keep per-subsample boresight drift under
+///   `max_drift_per_sample_px`. Typically 1–10.
+/// - **`stamps_per_sample` finer trajectory queries inside each
+///   subsample** drive *PSF-stamp* placement. Each stamp queries the
+///   trajectory at its own midpoint and deposits `flux / M` electrons
+///   at the per-time projected pixel position. Defaults to 1 (one
+///   stamp per subsample, identical to the original renderer);
+///   raise it to capture high-frequency jitter that would otherwise
+///   alias instead of contributing motion blur.
+///
+/// Subsample boundaries are midpoints so the integral of a
+/// linearly-varying rate over the exposure equals the midpoint value
+/// times the exposure; dividing by `n` yields the per-subsample
+/// contribution and dividing again by `stamps_per_sample` yields the
+/// per-stamp contribution.
 #[derive(Debug, Clone, Copy)]
 pub struct SubsampleSchedule {
     /// Absolute trajectory time at which the frame's exposure starts.
@@ -82,6 +97,9 @@ pub struct SubsampleSchedule {
     pub exposure: Duration,
     /// Number of sub-orientation samples across the exposure (>= 1).
     pub n: usize,
+    /// Number of fine trajectory queries inside each subsample (>= 1).
+    /// `1` reproduces the original one-stamp-per-subsample behavior.
+    pub stamps_per_sample: usize,
 }
 
 impl SubsampleSchedule {
@@ -100,6 +118,21 @@ impl SubsampleSchedule {
             .collect()
     }
 
+    /// Stamp midpoints inside subsample `sample_idx`. Returns a vector
+    /// of length `stamps_per_sample.max(1)`, evenly spaced across the
+    /// subsample window using the same midpoint convention as
+    /// [`Self::sample_times`].
+    pub fn stamp_times_for_sample(&self, sample_idx: usize) -> Vec<Duration> {
+        let n = self.n.max(1);
+        let m = self.stamps_per_sample.max(1);
+        let dt = self.exposure.as_secs_f64() / n as f64;
+        let stamp_dt = dt / m as f64;
+        let t_sub_start = self.frame_start.as_secs_f64() + sample_idx as f64 * dt;
+        (0..m)
+            .map(|j| Duration::from_secs_f64(t_sub_start + (j as f64 + 0.5) * stamp_dt))
+            .collect()
+    }
+
     /// Adaptive schedule from a drift budget.
     ///
     /// `max_drift_rad_over_exposure` is the total angular distance the
@@ -111,12 +144,40 @@ impl SubsampleSchedule {
     /// `N = max(1, ceil(max_drift_over_exposure_rad / (max_drift_per_sample_px * pixel_scale_rad)))`
     ///
     /// When the drift budget is zero (static pointing), `N = 1`.
+    /// `stamps_per_sample` is set to 1 — see [`Self::adaptive_with_stamps`]
+    /// for finer per-subsample stamping.
     pub fn adaptive(
         frame_start: Duration,
         exposure: Duration,
         max_drift_rad_over_exposure: f64,
         pixel_scale_rad: f64,
         max_drift_per_sample_px: f64,
+    ) -> Self {
+        Self::adaptive_with_stamps(
+            frame_start,
+            exposure,
+            max_drift_rad_over_exposure,
+            pixel_scale_rad,
+            max_drift_per_sample_px,
+            None,
+        )
+    }
+
+    /// Adaptive schedule that also picks `stamps_per_sample` from a
+    /// finer per-stamp drift budget. When `max_drift_per_stamp_px` is
+    /// `Some(b)`, each subsample is divided into
+    /// `M = max(1, ceil((per-subsample drift) / (b * pixel_scale)))`
+    /// stamps. When `None`, `M = 1` and behavior is identical to
+    /// [`Self::adaptive`]. The two budgets are independent: the outer
+    /// one drives scene-state refresh, the inner one drives PSF-stamp
+    /// placement and is what actually captures sub-subsample jitter.
+    pub fn adaptive_with_stamps(
+        frame_start: Duration,
+        exposure: Duration,
+        max_drift_rad_over_exposure: f64,
+        pixel_scale_rad: f64,
+        max_drift_per_sample_px: f64,
+        max_drift_per_stamp_px: Option<f64>,
     ) -> Self {
         let n = if max_drift_rad_over_exposure <= 0.0
             || pixel_scale_rad <= 0.0
@@ -127,10 +188,27 @@ impl SubsampleSchedule {
             let budget_rad = max_drift_per_sample_px * pixel_scale_rad;
             (max_drift_rad_over_exposure / budget_rad).ceil() as usize
         };
+        let n = n.max(1);
+        let stamps_per_sample = match max_drift_per_stamp_px {
+            Some(stamp_budget_px)
+                if stamp_budget_px > 0.0
+                    && pixel_scale_rad > 0.0
+                    && max_drift_rad_over_exposure > 0.0 =>
+            {
+                // Per-subsample drift assumes the trajectory is
+                // approximately uniform over the exposure (the same
+                // assumption the per-sample budget already makes).
+                let per_sub_drift_rad = max_drift_rad_over_exposure / n as f64;
+                let stamp_budget_rad = stamp_budget_px * pixel_scale_rad;
+                ((per_sub_drift_rad / stamp_budget_rad).ceil() as usize).max(1)
+            }
+            _ => 1,
+        };
         Self {
             frame_start,
             exposure,
-            n: n.max(1),
+            n,
+            stamps_per_sample,
         }
     }
 }
@@ -241,6 +319,14 @@ pub struct MotionBlurConfig {
     /// Per-subsample drift budget in pixels. The adaptive scheduler picks
     /// `N` so that drift per subsample stays below this threshold.
     pub max_drift_per_sample_px: f64,
+    /// Optional finer per-stamp drift budget (pixels). When `Some(b)`,
+    /// each subsample is divided into `M` PSF stamps so drift per
+    /// stamp stays below `b`. When `None`, `M = 1` and behavior matches
+    /// the original one-stamp-per-subsample renderer. Set this an order
+    /// of magnitude tighter than `max_drift_per_sample_px` to capture
+    /// high-frequency jitter (e.g. PSD-derived reaction-wheel residuals)
+    /// that would otherwise alias instead of contributing motion blur.
+    pub max_drift_per_stamp_px: Option<f64>,
     /// Optional base RNG seed (combined per-tile with `(frame_idx, sensor_idx)`).
     pub base_seed: Option<u64>,
     /// If true, force `N = 1` per frame regardless of the adaptive budget.
@@ -268,6 +354,7 @@ impl Default for MotionBlurConfig {
             timestep: Duration::from_secs(1),
             exposure: Duration::from_secs(1),
             max_drift_per_sample_px: DEFAULT_MAX_DRIFT_PER_SAMPLE_PX,
+            max_drift_per_stamp_px: None,
             base_seed: None,
             force_static: false,
             quiet: false,
@@ -425,34 +512,44 @@ fn render_tile(
 
     let schedule = &plan.schedule;
     let dt = schedule.dt();
-    let sample_times = schedule.sample_times();
+    let stamps_per_sample = schedule.stamps_per_sample.max(1);
+    let stamp_weight = 1.0 / stamps_per_sample as f64;
 
-    for &t in &sample_times {
-        let t_clamped = t
-            .min(scene.trajectory.end_time())
-            .max(scene.trajectory.start_time());
-        let orientation = scene.trajectory.orientation_at(t_clamped)?;
-        for star in &plan.stars {
-            let hit =
-                match scene
-                    .fp
-                    .project_to_sensor(star, &orientation, sensor_idx, plan.padding_mm)
-                {
+    for sample_idx in 0..schedule.n.max(1) {
+        // Per-subsample per-star flux is shared across all M stamps of
+        // this subsample (flux depends on star+sensor only, not on
+        // orientation), so we pull it from the global cache once and
+        // hold a local copy to avoid M lock acquisitions per star.
+        let mut subsample_flux: HashMap<u64, SourceFlux> = HashMap::new();
+        for stamp_t in schedule.stamp_times_for_sample(sample_idx) {
+            let t_clamped = stamp_t
+                .min(scene.trajectory.end_time())
+                .max(scene.trajectory.start_time());
+            let orientation = scene.trajectory.orientation_at(t_clamped)?;
+            for star in &plan.stars {
+                let hit = match scene.fp.project_to_sensor(
+                    star,
+                    &orientation,
+                    sensor_idx,
+                    plan.padding_mm,
+                ) {
                     Some(px) => px,
                     None => continue,
                 };
-            let flux = {
-                let mut cache = flux_cache.lock().expect("flux cache mutex poisoned");
-                cache
-                    .entry((star.id, sensor_idx))
-                    .or_insert_with(|| star_data_to_fluxes(star, satellite))
-                    .clone()
-            };
-            // Per-subsample electron contribution for this star at this pixel
-            // position: flux.electrons is a rate (e-/s/cm^2), integrate over
-            // the subsample duration and telescope aperture.
-            let total_electrons = flux.electrons.integrated_over(&dt, aperture);
-            accumulator.splat_psf(hit.0, hit.1, total_electrons, &flux.electrons.disk);
+                let flux = subsample_flux.entry(star.id).or_insert_with(|| {
+                    let mut cache = flux_cache.lock().expect("flux cache mutex poisoned");
+                    cache
+                        .entry((star.id, sensor_idx))
+                        .or_insert_with(|| star_data_to_fluxes(star, satellite))
+                        .clone()
+                });
+                // Per-stamp electron contribution: integrate flux rate
+                // over the *subsample* dt, then split evenly across the
+                // subsample's M stamps. Sum over M stamps reproduces the
+                // single-stamp budget exactly.
+                let total_electrons = flux.electrons.integrated_over(&dt, aperture) * stamp_weight;
+                accumulator.splat_psf(hit.0, hit.1, total_electrons, &flux.electrons.disk);
+            }
         }
     }
 
@@ -575,14 +672,16 @@ pub fn render_motion_trajectory(
                 frame_start: t,
                 exposure,
                 n: 1,
+                stamps_per_sample: 1,
             }
         } else {
-            SubsampleSchedule::adaptive(
+            SubsampleSchedule::adaptive_with_stamps(
                 t,
                 exposure,
                 drift,
                 px_scale,
                 config.max_drift_per_sample_px,
+                config.max_drift_per_stamp_px,
             )
         };
         n_min = n_min.min(schedule.n);
@@ -1002,6 +1101,7 @@ mod tests {
             frame_start: Duration::from_secs(10),
             exposure: Duration::from_secs(4),
             n: 4,
+            stamps_per_sample: 1,
         };
         let times: Vec<f64> = sched
             .sample_times()
@@ -1013,6 +1113,99 @@ mod tests {
         assert_abs_diff_eq!(times[1], 11.5, epsilon = 1e-12);
         assert_abs_diff_eq!(times[2], 12.5, epsilon = 1e-12);
         assert_abs_diff_eq!(times[3], 13.5, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn test_stamp_times_default_is_one_per_subsample() {
+        // With stamps_per_sample = 1, stamp midpoints collapse onto sample midpoints.
+        let sched = SubsampleSchedule {
+            frame_start: Duration::from_secs(10),
+            exposure: Duration::from_secs(4),
+            n: 4,
+            stamps_per_sample: 1,
+        };
+        for i in 0..sched.n {
+            let stamps = sched.stamp_times_for_sample(i);
+            assert_eq!(stamps.len(), 1);
+            assert_abs_diff_eq!(
+                stamps[0].as_secs_f64(),
+                sched.sample_times()[i].as_secs_f64(),
+                epsilon = 1e-12
+            );
+        }
+    }
+
+    #[test]
+    fn test_stamp_times_subdivide_subsample_window() {
+        // Each 1s subsample is divided into 4 stamps at the 1/8, 3/8, 5/8, 7/8 marks.
+        let sched = SubsampleSchedule {
+            frame_start: Duration::from_secs(10),
+            exposure: Duration::from_secs(4),
+            n: 4,
+            stamps_per_sample: 4,
+        };
+        let stamps_first: Vec<f64> = sched
+            .stamp_times_for_sample(0)
+            .iter()
+            .map(|d| d.as_secs_f64())
+            .collect();
+        // Subsample 0 spans [10.0, 11.0). Stamp dt = 0.25, midpoints at 10.125, 10.375, 10.625, 10.875.
+        assert_eq!(stamps_first.len(), 4);
+        assert_abs_diff_eq!(stamps_first[0], 10.125, epsilon = 1e-12);
+        assert_abs_diff_eq!(stamps_first[1], 10.375, epsilon = 1e-12);
+        assert_abs_diff_eq!(stamps_first[2], 10.625, epsilon = 1e-12);
+        assert_abs_diff_eq!(stamps_first[3], 10.875, epsilon = 1e-12);
+
+        // Subsample 3 spans [13.0, 14.0). Last stamp midpoint at 13.875.
+        let stamps_last = sched.stamp_times_for_sample(3);
+        assert_abs_diff_eq!(stamps_last[3].as_secs_f64(), 13.875, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn test_adaptive_with_stamps_picks_m_from_per_subsample_drift() {
+        // 10 px drift / 1s exposure, 0.1 px per-sub budget => N = 100, so each
+        // subsample sees 0.1 px drift. With per-stamp budget 0.01 px, each
+        // subsample should be split into M = 10 stamps.
+        let pixel_scale = 1e-5_f64;
+        let drift_px = 10.0;
+        let sched = SubsampleSchedule::adaptive_with_stamps(
+            Duration::ZERO,
+            Duration::from_secs(1),
+            drift_px * pixel_scale,
+            pixel_scale,
+            0.1,        // per-sub budget
+            Some(0.01), // per-stamp budget
+        );
+        assert_eq!(sched.n, 100);
+        assert_eq!(sched.stamps_per_sample, 10);
+    }
+
+    #[test]
+    fn test_adaptive_with_stamps_none_collapses_to_m_1() {
+        let pixel_scale = 1e-5_f64;
+        let sched = SubsampleSchedule::adaptive_with_stamps(
+            Duration::ZERO,
+            Duration::from_secs(1),
+            10.0 * pixel_scale,
+            pixel_scale,
+            0.1,
+            None,
+        );
+        assert_eq!(sched.stamps_per_sample, 1);
+    }
+
+    #[test]
+    fn test_adaptive_with_stamps_static_trajectory_gives_m_1() {
+        let sched = SubsampleSchedule::adaptive_with_stamps(
+            Duration::ZERO,
+            Duration::from_secs(1),
+            0.0, // no drift
+            1e-5,
+            0.1,
+            Some(0.01),
+        );
+        assert_eq!(sched.n, 1);
+        assert_eq!(sched.stamps_per_sample, 1);
     }
 
     #[test]
@@ -1347,6 +1540,139 @@ mod tests {
     }
 
     #[test]
+    fn test_per_stamp_render_is_deterministic() {
+        // Same (base_seed, frame, sensor, M) must produce byte-identical
+        // PNGs across runs even with the per-stamp inner loop active. A
+        // genuine sub-arcsec sweep across the exposure exercises the
+        // per-stamp orientation queries, not just the M=1 fallback.
+        let fp = tiny_fp();
+        let pointing = Equatorial::from_degrees(45.0, 30.0);
+        let drift = Equatorial::from_degrees(45.0 + 0.001, 30.0); // ~3.6"
+        let traj = Trajectory::new(vec![
+            Waypoint::new(Duration::ZERO, orientation_from_pointing(&pointing, 0.0)),
+            Waypoint::new(
+                Duration::from_secs(10),
+                orientation_from_pointing(&drift, 0.0),
+            ),
+        ])
+        .unwrap();
+        let stars: Vec<StarData> = (0..4)
+            .map(|i| StarData {
+                id: i as u64,
+                magnitude: 7.0,
+                position: Equatorial::from_degrees(
+                    pointing.ra_degrees() + 0.0005 * i as f64,
+                    pointing.dec_degrees(),
+                ),
+                b_v: Some(0.6),
+            })
+            .collect();
+        let cfg = MotionBlurConfig {
+            timestep: Duration::from_secs(1),
+            exposure: Duration::from_secs(1),
+            max_drift_per_sample_px: 0.1,
+            max_drift_per_stamp_px: Some(0.01),
+            base_seed: Some(424242),
+            force_static: false,
+            quiet: true,
+            ..Default::default()
+        };
+        let tmp_a = tempfile::tempdir().unwrap();
+        let tmp_b = tempfile::tempdir().unwrap();
+        render_motion_trajectory(
+            &traj,
+            &stars,
+            &fp,
+            SolarAngularCoordinates::zodiacal_minimum(),
+            &cfg,
+            tmp_a.path(),
+        )
+        .unwrap();
+        render_motion_trajectory(
+            &traj,
+            &stars,
+            &fp,
+            SolarAngularCoordinates::zodiacal_minimum(),
+            &cfg,
+            tmp_b.path(),
+        )
+        .unwrap();
+        let name = "sensor_00/frame_000000.png";
+        let a = std::fs::read(tmp_a.path().join(name)).unwrap();
+        let b = std::fs::read(tmp_b.path().join(name)).unwrap();
+        assert_eq!(a, b, "per-stamp rendering must be deterministic");
+    }
+
+    #[test]
+    fn test_per_stamp_changes_render_vs_per_subsample() {
+        // Same trajectory, same seed, only the per-stamp budget differs.
+        // The two outputs MUST differ — otherwise the inner stamp loop is
+        // a no-op. Uses a sweep big enough to cross multiple pixels so
+        // the smear shape is sensitive to where stamps land within each
+        // subsample.
+        let fp = tiny_fp();
+        let pointing = Equatorial::from_degrees(45.0, 30.0);
+        let drift = Equatorial::from_degrees(45.0 + 0.01, 30.0); // ~36"
+        let traj = Trajectory::new(vec![
+            Waypoint::new(Duration::ZERO, orientation_from_pointing(&pointing, 0.0)),
+            Waypoint::new(
+                Duration::from_secs(10),
+                orientation_from_pointing(&drift, 0.0),
+            ),
+        ])
+        .unwrap();
+        let stars = vec![StarData {
+            id: 0,
+            magnitude: 5.0,
+            position: pointing,
+            b_v: Some(0.6),
+        }];
+        let cfg_coarse = MotionBlurConfig {
+            timestep: Duration::from_secs(1),
+            exposure: Duration::from_secs(1),
+            // Loose per-sub budget so N stays small and there's room for
+            // M to actually change the within-subsample distribution.
+            max_drift_per_sample_px: 1.0,
+            max_drift_per_stamp_px: None,
+            base_seed: Some(99),
+            force_static: false,
+            quiet: true,
+            ..Default::default()
+        };
+        let cfg_fine = MotionBlurConfig {
+            max_drift_per_stamp_px: Some(0.05),
+            ..cfg_coarse.clone()
+        };
+        let tmp_coarse = tempfile::tempdir().unwrap();
+        let tmp_fine = tempfile::tempdir().unwrap();
+        render_motion_trajectory(
+            &traj,
+            &stars,
+            &fp,
+            SolarAngularCoordinates::zodiacal_minimum(),
+            &cfg_coarse,
+            tmp_coarse.path(),
+        )
+        .unwrap();
+        render_motion_trajectory(
+            &traj,
+            &stars,
+            &fp,
+            SolarAngularCoordinates::zodiacal_minimum(),
+            &cfg_fine,
+            tmp_fine.path(),
+        )
+        .unwrap();
+        let name = "sensor_00/frame_000000.png";
+        let coarse = std::fs::read(tmp_coarse.path().join(name)).unwrap();
+        let fine = std::fs::read(tmp_fine.path().join(name)).unwrap();
+        assert_ne!(
+            coarse, fine,
+            "raising stamps_per_sample on a moving trajectory must change the rendered streak"
+        );
+    }
+
+    #[test]
     fn test_frame_sensor_tile_parallelism_determinism() {
         // Rendering twice with the same seeds should produce identical
         // output bytes regardless of rayon pool size.
@@ -1414,6 +1740,7 @@ mod tests {
             timestep: Duration::from_secs(1),
             exposure: Duration::from_secs(1),
             max_drift_per_sample_px: 0.1,
+            max_drift_per_stamp_px: None,
             base_seed: Some(seed),
             force_static: true,
             quiet: true,

--- a/simulator/src/sims/motion_blur.rs
+++ b/simulator/src/sims/motion_blur.rs
@@ -487,29 +487,68 @@ fn envelope_prefilter<'a>(
     Ok(kept)
 }
 
-/// Deterministic tile seed derived from `(base_seed, frame_idx, sensor_idx)`.
-fn tile_seed(base_seed: u64, frame_idx: usize, sensor_idx: usize) -> u64 {
-    // Cheap splitmix-style mix; reproducible, well-distributed enough for
-    // RNG seeding.
-    let mut h = base_seed
-        .wrapping_mul(0x9E37_79B9_7F4A_7C15)
-        .wrapping_add(frame_idx as u64)
-        .wrapping_mul(0xBF58_476D_1CE4_E5B9);
-    h ^= (sensor_idx as u64).wrapping_mul(0x94D0_49BB_1331_11EB);
-    h ^= h >> 27;
-    h = h.wrapping_mul(0x94D0_49BB_1331_11EB);
-    h ^= h >> 31;
-    h
+/// Named randomness sources within a single render tile. Each source
+/// gets its own deterministic seed derived from the tile's master
+/// seed, so perturbing one (e.g. changing the stamp-jitter sequence)
+/// cannot shift the bytes the others would have produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RngDomain {
+    /// Unified Poisson photon-noise draw on the accumulated mean image.
+    Poisson,
+    /// Gaussian read-noise draw applied after Poisson.
+    ReadNoise,
+    /// Stratified-MC uniform-random per-stamp time jitter inside each subsample.
+    StampJitter,
 }
 
-/// Domain tags for deriving sub-seeds from a `tile_seed`. Each tile
-/// draws independent RNG streams for Poisson photon noise, Gaussian
-/// read noise, and stratified-MC stamp jitter; the tags below
-/// separate them so changing one source does not perturb the others.
-mod rng_domain {
-    pub const POISSON: u64 = 0;
-    pub const READ_NOISE: u64 = 0xA5A5_5A5A_A5A5_5A5A;
-    pub const STAMP_JITTER: u64 = 0x4D6F_6E74_6543_726C; // "MonteCarl"
+impl RngDomain {
+    /// Domain-specific 64-bit XOR tag. Values are arbitrary as long
+    /// as they are pairwise distinct; the downstream
+    /// `StdRng::seed_from_u64` does its own state expansion. Treat
+    /// these as labels, not as cryptographic constants.
+    const fn tag(self) -> u64 {
+        match self {
+            RngDomain::Poisson => 0x0000_0000_0000_0000,
+            RngDomain::ReadNoise => 0xA5A5_5A5A_A5A5_5A5A,
+            RngDomain::StampJitter => 0x4D6F_6E74_6543_6172, // "MonteCar" (8 ASCII bytes)
+        }
+    }
+}
+
+/// Per-tile master seed plus the API for deriving sub-stream seeds
+/// and RNGs for each [`RngDomain`]. All streams are deterministic
+/// from `(base_seed, frame_idx, sensor_idx)`, and each domain is
+/// independent of the others — adding a new randomness source via a
+/// new [`RngDomain`] variant does not perturb existing output.
+#[derive(Debug, Clone, Copy)]
+pub struct TileSeed(u64);
+
+impl TileSeed {
+    /// Build the per-tile master seed from `(base, frame_idx, sensor_idx)`.
+    pub fn for_tile(base: u64, frame_idx: usize, sensor_idx: usize) -> Self {
+        // Cheap splitmix-style mix; reproducible, well-distributed
+        // enough for RNG seeding.
+        let mut h = base
+            .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+            .wrapping_add(frame_idx as u64)
+            .wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        h ^= (sensor_idx as u64).wrapping_mul(0x94D0_49BB_1331_11EB);
+        h ^= h >> 27;
+        h = h.wrapping_mul(0x94D0_49BB_1331_11EB);
+        h ^= h >> 31;
+        Self(h)
+    }
+
+    /// Sub-stream seed for APIs that consume `u64` directly
+    /// (e.g. [`apply_poisson_photon_noise`]).
+    pub fn seed(self, domain: RngDomain) -> u64 {
+        self.0 ^ domain.tag()
+    }
+
+    /// Sub-stream RNG ready to consume for APIs that take `&mut impl Rng`.
+    pub fn rng(self, domain: RngDomain) -> StdRng {
+        StdRng::seed_from_u64(self.seed(domain))
+    }
 }
 
 /// Render a single `(frame, sensor)` tile.
@@ -522,7 +561,7 @@ fn render_tile(
     sensor_idx: usize,
     flux_cache: &Arc<Mutex<FluxCache>>,
     satellite: &SatelliteConfig,
-    tile_seed: u64,
+    tile_seed: TileSeed,
     output_path: &Path,
 ) -> Result<(), TrajectoryError> {
     let (width, height) = satellite.sensor.dimensions.get_pixel_width_height();
@@ -538,8 +577,8 @@ fn render_tile(
     // sample_idx in order with a single sequential RNG keeps the draw
     // sequence (and therefore the stamp times, the orientation
     // queries, and the deposited image) bit-deterministic for a
-    // given tile_seed.
-    let mut stamp_rng = StdRng::seed_from_u64(tile_seed ^ rng_domain::STAMP_JITTER);
+    // given tile seed.
+    let mut stamp_rng = tile_seed.rng(RngDomain::StampJitter);
 
     for sample_idx in 0..schedule.n.max(1) {
         // Per-subsample per-star flux is shared across all M stamps of
@@ -588,7 +627,7 @@ fn render_tile(
     // Build unified Poisson mean image and draw.
     let mean_image = accumulator.combined_mean(plan.zodiacal_per_px[sensor_idx], dark_mean);
     let poisson_image =
-        apply_poisson_photon_noise(&mean_image, Some(tile_seed ^ rng_domain::POISSON));
+        apply_poisson_photon_noise(&mean_image, Some(tile_seed.seed(RngDomain::Poisson)));
 
     // Gaussian read noise (electronics, not shot noise) applied afterwards.
     let read_noise_rms = satellite
@@ -598,7 +637,7 @@ fn render_tile(
         .unwrap_or(0.0)
         .max(0.0);
     let final_electrons = if read_noise_rms > 0.0 {
-        let mut rng = StdRng::seed_from_u64(tile_seed ^ rng_domain::READ_NOISE);
+        let mut rng = tile_seed.rng(RngDomain::ReadNoise);
         let normal =
             Normal::new(0.0_f64, read_noise_rms).expect("read noise RMS must be non-negative");
         poisson_image.mapv(|e| (e + normal.sample(&mut rng)).max(0.0))
@@ -808,7 +847,7 @@ pub fn render_motion_trajectory(
         .map(|(tile, out_path)| {
             let plan = &plans[tile.frame_plan_idx];
             let sat = &satellites[tile.sensor_idx];
-            let seed = tile_seed(base_seed, plan.idx, tile.sensor_idx);
+            let seed = TileSeed::for_tile(base_seed, plan.idx, tile.sensor_idx);
             let tile_started = Instant::now();
             let result = render_tile(
                 &scene,
@@ -1284,14 +1323,31 @@ mod tests {
 
     #[test]
     fn test_tile_seed_is_deterministic_and_varies() {
-        let a = tile_seed(42, 0, 0);
-        let b = tile_seed(42, 0, 0);
-        let c = tile_seed(42, 1, 0);
-        let d = tile_seed(42, 0, 1);
+        let a = TileSeed::for_tile(42, 0, 0).seed(RngDomain::Poisson);
+        let b = TileSeed::for_tile(42, 0, 0).seed(RngDomain::Poisson);
+        let c = TileSeed::for_tile(42, 1, 0).seed(RngDomain::Poisson);
+        let d = TileSeed::for_tile(42, 0, 1).seed(RngDomain::Poisson);
         assert_eq!(a, b);
         assert_ne!(a, c);
         assert_ne!(a, d);
         assert_ne!(c, d);
+    }
+
+    #[test]
+    fn test_tile_seed_domains_are_independent() {
+        // The same tile must produce three distinct sub-seeds for the
+        // three named domains, so that perturbing (e.g.) the stamp
+        // jitter does not accidentally shift the Poisson or read-noise
+        // streams.
+        let tile = TileSeed::for_tile(1234, 5, 6);
+        let p = tile.seed(RngDomain::Poisson);
+        let r = tile.seed(RngDomain::ReadNoise);
+        let s = tile.seed(RngDomain::StampJitter);
+        assert_ne!(p, r);
+        assert_ne!(p, s);
+        assert_ne!(r, s);
+        // Same domain on the same tile must reproduce the same seed.
+        assert_eq!(tile.seed(RngDomain::StampJitter), s);
     }
 
     fn static_trajectory() -> Trajectory {

--- a/simulator/src/sims/motion_blur.rs
+++ b/simulator/src/sims/motion_blur.rs
@@ -40,7 +40,7 @@ use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use log::{debug, info};
 use nalgebra::UnitQuaternion;
 use ndarray::Array2;
-use rand::{rngs::StdRng, SeedableRng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use rand_distr::{Distribution, Normal};
 use rayon::prelude::*;
 use shared::image_proc::noise::apply_poisson_photon_noise;
@@ -77,12 +77,14 @@ pub const DEFAULT_MAX_DRIFT_PER_SAMPLE_PX: f64 = 0.1;
 ///   Adaptive: chosen to keep per-subsample boresight drift under
 ///   `max_drift_per_sample_px`. Typically 1–10.
 /// - **`stamps_per_sample` finer trajectory queries inside each
-///   subsample** drive *PSF-stamp* placement. Each stamp queries the
-///   trajectory at its own midpoint and deposits `flux / M` electrons
-///   at the per-time projected pixel position. Defaults to 1 (one
-///   stamp per subsample, identical to the original renderer);
-///   raise it to capture high-frequency jitter that would otherwise
-///   alias instead of contributing motion blur.
+///   subsample** drive *PSF-stamp* placement via **stratified Monte
+///   Carlo**: each subsample window is divided into `m` equal-width
+///   sub-bins, and each stamp lands at a uniform-random offset within
+///   its sub-bin. Each stamp queries the trajectory at its own time
+///   and deposits `flux / m` electrons at the per-time projected
+///   pixel position. Stratification preserves smooth-integrand
+///   convergence while removing the systematic bias a regular grid
+///   produces against trajectory tones near `k / Δt_sub`.
 ///
 /// Subsample boundaries are midpoints so the integral of a
 /// linearly-varying rate over the exposure equals the midpoint value
@@ -118,18 +120,25 @@ impl SubsampleSchedule {
             .collect()
     }
 
-    /// Stamp midpoints inside subsample `sample_idx`. Returns a vector
-    /// of length `stamps_per_sample.max(1)`, evenly spaced across the
-    /// subsample window using the same midpoint convention as
-    /// [`Self::sample_times`].
-    pub fn stamp_times_for_sample(&self, sample_idx: usize) -> Vec<Duration> {
+    /// Stratified Monte Carlo stamp times inside subsample `sample_idx`.
+    /// Returns a vector of length `stamps_per_sample.max(1)`. Stamp `j`
+    /// lands at `t_sub_start + (j + U) * stamp_dt`, where `U ~ Uniform[0, 1)`
+    /// is drawn from `rng` and `stamp_dt = (exposure / n) / m`. The
+    /// stratification by sub-bin guarantees one stamp per equal-width
+    /// slice of the subsample window; randomness within each slice
+    /// removes the bias a fixed-midpoint grid produces against
+    /// trajectory content at frequencies near `k / stamp_dt`.
+    pub fn stamp_times_for_sample<R: Rng>(&self, sample_idx: usize, rng: &mut R) -> Vec<Duration> {
         let n = self.n.max(1);
         let m = self.stamps_per_sample.max(1);
         let dt = self.exposure.as_secs_f64() / n as f64;
         let stamp_dt = dt / m as f64;
         let t_sub_start = self.frame_start.as_secs_f64() + sample_idx as f64 * dt;
         (0..m)
-            .map(|j| Duration::from_secs_f64(t_sub_start + (j as f64 + 0.5) * stamp_dt))
+            .map(|j| {
+                let u: f64 = rng.random();
+                Duration::from_secs_f64(t_sub_start + (j as f64 + u) * stamp_dt)
+            })
             .collect()
     }
 
@@ -493,6 +502,16 @@ fn tile_seed(base_seed: u64, frame_idx: usize, sensor_idx: usize) -> u64 {
     h
 }
 
+/// Domain tags for deriving sub-seeds from a `tile_seed`. Each tile
+/// draws independent RNG streams for Poisson photon noise, Gaussian
+/// read noise, and stratified-MC stamp jitter; the tags below
+/// separate them so changing one source does not perturb the others.
+mod rng_domain {
+    pub const POISSON: u64 = 0;
+    pub const READ_NOISE: u64 = 0xA5A5_5A5A_A5A5_5A5A;
+    pub const STAMP_JITTER: u64 = 0x4D6F_6E74_6543_726C; // "MonteCarl"
+}
+
 /// Render a single `(frame, sensor)` tile.
 ///
 /// Runs the adaptive subsample loop, composes the unified Poisson lambda,
@@ -515,13 +534,20 @@ fn render_tile(
     let stamps_per_sample = schedule.stamps_per_sample.max(1);
     let stamp_weight = 1.0 / stamps_per_sample as f64;
 
+    // Per-tile RNG for stratified-MC stamp placement. Iterating
+    // sample_idx in order with a single sequential RNG keeps the draw
+    // sequence (and therefore the stamp times, the orientation
+    // queries, and the deposited image) bit-deterministic for a
+    // given tile_seed.
+    let mut stamp_rng = StdRng::seed_from_u64(tile_seed ^ rng_domain::STAMP_JITTER);
+
     for sample_idx in 0..schedule.n.max(1) {
         // Per-subsample per-star flux is shared across all M stamps of
         // this subsample (flux depends on star+sensor only, not on
         // orientation), so we pull it from the global cache once and
         // hold a local copy to avoid M lock acquisitions per star.
         let mut subsample_flux: HashMap<u64, SourceFlux> = HashMap::new();
-        for stamp_t in schedule.stamp_times_for_sample(sample_idx) {
+        for stamp_t in schedule.stamp_times_for_sample(sample_idx, &mut stamp_rng) {
             let t_clamped = stamp_t
                 .min(scene.trajectory.end_time())
                 .max(scene.trajectory.start_time());
@@ -561,7 +587,8 @@ fn render_tile(
 
     // Build unified Poisson mean image and draw.
     let mean_image = accumulator.combined_mean(plan.zodiacal_per_px[sensor_idx], dark_mean);
-    let poisson_image = apply_poisson_photon_noise(&mean_image, Some(tile_seed));
+    let poisson_image =
+        apply_poisson_photon_noise(&mean_image, Some(tile_seed ^ rng_domain::POISSON));
 
     // Gaussian read noise (electronics, not shot noise) applied afterwards.
     let read_noise_rms = satellite
@@ -571,7 +598,7 @@ fn render_tile(
         .unwrap_or(0.0)
         .max(0.0);
     let final_electrons = if read_noise_rms > 0.0 {
-        let mut rng = StdRng::seed_from_u64(tile_seed ^ 0xA5A5_5A5A_A5A5_5A5A);
+        let mut rng = StdRng::seed_from_u64(tile_seed ^ rng_domain::READ_NOISE);
         let normal =
             Normal::new(0.0_f64, read_noise_rms).expect("read noise RMS must be non-negative");
         poisson_image.mapv(|e| (e + normal.sample(&mut rng)).max(0.0))
@@ -1116,49 +1143,87 @@ mod tests {
     }
 
     #[test]
-    fn test_stamp_times_default_is_one_per_subsample() {
-        // With stamps_per_sample = 1, stamp midpoints collapse onto sample midpoints.
+    fn test_stamp_times_one_stamp_uniform_in_subsample() {
+        // With stamps_per_sample = 1, the single stamp lands at a
+        // uniform-random time within the entire subsample window
+        // [t_sub_start, t_sub_start + dt_sub).
         let sched = SubsampleSchedule {
             frame_start: Duration::from_secs(10),
             exposure: Duration::from_secs(4),
             n: 4,
             stamps_per_sample: 1,
         };
+        let mut rng = StdRng::seed_from_u64(0xCAFE);
         for i in 0..sched.n {
-            let stamps = sched.stamp_times_for_sample(i);
+            let stamps = sched.stamp_times_for_sample(i, &mut rng);
             assert_eq!(stamps.len(), 1);
-            assert_abs_diff_eq!(
-                stamps[0].as_secs_f64(),
-                sched.sample_times()[i].as_secs_f64(),
-                epsilon = 1e-12
+            let lo = sched.frame_start.as_secs_f64() + i as f64 * 1.0;
+            let hi = lo + 1.0;
+            let t = stamps[0].as_secs_f64();
+            assert!(
+                t >= lo && t < hi,
+                "stamp {t} must fall inside subsample [{lo}, {hi})"
             );
         }
     }
 
     #[test]
-    fn test_stamp_times_subdivide_subsample_window() {
-        // Each 1s subsample is divided into 4 stamps at the 1/8, 3/8, 5/8, 7/8 marks.
+    fn test_stamp_times_stratified_into_equal_sub_bins() {
+        // M=4: each subsample window is divided into four equal sub-bins
+        // and each stamp lands at a uniform-random offset *within its
+        // own bin*. Verify the per-bin containment for a couple of
+        // (sample_idx, m, dt) combinations and that draws differ
+        // across calls (random) but stay within their stratum.
         let sched = SubsampleSchedule {
             frame_start: Duration::from_secs(10),
             exposure: Duration::from_secs(4),
             n: 4,
             stamps_per_sample: 4,
         };
-        let stamps_first: Vec<f64> = sched
-            .stamp_times_for_sample(0)
-            .iter()
-            .map(|d| d.as_secs_f64())
-            .collect();
-        // Subsample 0 spans [10.0, 11.0). Stamp dt = 0.25, midpoints at 10.125, 10.375, 10.625, 10.875.
+        let mut rng = StdRng::seed_from_u64(0xBEEF);
+        let stamps_first = sched.stamp_times_for_sample(0, &mut rng);
         assert_eq!(stamps_first.len(), 4);
-        assert_abs_diff_eq!(stamps_first[0], 10.125, epsilon = 1e-12);
-        assert_abs_diff_eq!(stamps_first[1], 10.375, epsilon = 1e-12);
-        assert_abs_diff_eq!(stamps_first[2], 10.625, epsilon = 1e-12);
-        assert_abs_diff_eq!(stamps_first[3], 10.875, epsilon = 1e-12);
+        // Subsample 0 spans [10.0, 11.0); sub-bin width = 0.25.
+        for (j, t) in stamps_first.iter().enumerate() {
+            let lo = 10.0 + 0.25 * j as f64;
+            let hi = lo + 0.25;
+            let v = t.as_secs_f64();
+            assert!(
+                v >= lo && v < hi,
+                "stamp {v} (j={j}) must land in stratum [{lo}, {hi})"
+            );
+        }
+        // Subsample 3 spans [13.0, 14.0); same per-bin containment.
+        let stamps_last = sched.stamp_times_for_sample(3, &mut rng);
+        for (j, t) in stamps_last.iter().enumerate() {
+            let lo = 13.0 + 0.25 * j as f64;
+            let hi = lo + 0.25;
+            let v = t.as_secs_f64();
+            assert!(
+                v >= lo && v < hi,
+                "stamp {v} (j={j}) must land in stratum [{lo}, {hi})"
+            );
+        }
+    }
 
-        // Subsample 3 spans [13.0, 14.0). Last stamp midpoint at 13.875.
-        let stamps_last = sched.stamp_times_for_sample(3);
-        assert_abs_diff_eq!(stamps_last[3].as_secs_f64(), 13.875, epsilon = 1e-12);
+    #[test]
+    fn test_stamp_times_seeded_rng_is_reproducible() {
+        // Two calls with two RNGs seeded identically must produce
+        // identical stamp time sequences — the determinism contract
+        // the renderer relies on.
+        let sched = SubsampleSchedule {
+            frame_start: Duration::ZERO,
+            exposure: Duration::from_secs(1),
+            n: 8,
+            stamps_per_sample: 16,
+        };
+        let mut rng_a = StdRng::seed_from_u64(0xDEADBEEF);
+        let mut rng_b = StdRng::seed_from_u64(0xDEADBEEF);
+        for i in 0..sched.n {
+            let a = sched.stamp_times_for_sample(i, &mut rng_a);
+            let b = sched.stamp_times_for_sample(i, &mut rng_b);
+            assert_eq!(a, b);
+        }
     }
 
     #[test]

--- a/simulator/src/sims/trajectory.rs
+++ b/simulator/src/sims/trajectory.rs
@@ -333,6 +333,13 @@ pub struct TrajectoryRenderConfig<'a> {
     /// Optional override for the per-subsample drift budget (pixels).
     /// Defaults to [`crate::sims::motion_blur::DEFAULT_MAX_DRIFT_PER_SAMPLE_PX`].
     pub max_drift_per_sample_px: Option<f64>,
+    /// Optional finer per-stamp drift budget (pixels). When `Some`,
+    /// each subsample is divided into `M` PSF stamps so drift per stamp
+    /// stays below this threshold; when `None`, `M = 1` and behavior
+    /// matches the original renderer. Use this to capture
+    /// high-frequency jitter that would otherwise alias across
+    /// subsamples (e.g. PSD-derived reaction-wheel residuals).
+    pub max_drift_per_stamp_px: Option<f64>,
     /// Force a single sub-orientation per frame regardless of drift.
     pub force_static: bool,
     /// Suppress the indicatif progress bar during rendering.
@@ -363,6 +370,7 @@ pub fn render_trajectory(config: &TrajectoryRenderConfig) -> Result<usize, Traje
         max_drift_per_sample_px: config
             .max_drift_per_sample_px
             .unwrap_or(DEFAULT_MAX_DRIFT_PER_SAMPLE_PX),
+        max_drift_per_stamp_px: config.max_drift_per_stamp_px,
         base_seed: config.base_seed,
         force_static: config.force_static,
         quiet: config.quiet,


### PR DESCRIPTION
## Summary

The adaptive subsample scheduler picks N from a per-subsample drift budget, which captures slow trajectory drift but loses high-frequency content (e.g. PSD-derived reaction-wheel residuals at tens to hundreds of Hz). Jitter that wiggles within a single subsample window aliases instead of contributing motion blur, and shows up as a sharp star where it should show up as a smear.

This PR decouples **scene-state cadence** from **PSF-stamp cadence**: each subsample is divided into M PSF stamps, one orientation query per stamp, flux/M deposited per stamp.

## What changed

- \`SubsampleSchedule\` grows a \`stamps_per_sample: usize\` field. The N sub-orientations still drive scene-state refresh (per-star flux, in-field star slice, zodiacal mean). Each subsample is then divided into M PSF stamps; each stamp queries the trajectory at its own midpoint and deposits \`flux/M\` electrons at the per-time projected pixel position. **\`M=1\` reproduces the original renderer exactly.**
- New \`SubsampleSchedule::adaptive_with_stamps\` constructor picks \`M\` from an optional finer per-stamp drift budget. Existing \`adaptive\` delegates with \`max_drift_per_stamp_px = None\`.
- \`MotionBlurConfig.max_drift_per_stamp_px: Option<f64>\` (default \`None\`) and matching field on \`TrajectoryRenderConfig\` plumb the budget down.
- New CLI: \`--max-drift-per-stamp-px <PX>\`. Unset = today's behavior; set ~10× tighter than \`--max-drift-per-sample-px\` to capture high-freq jitter.
- \`render_tile\`'s inner loop iterates over stamp midpoints inside each subsample. Per-subsample per-star flux is held in a small local map so the M stamps share one flux integration instead of re-locking the global cache M times.

## Determinism

**No new RNG**. Stamp times are deterministic from \`(frame_start, exposure, n, stamps_per_sample)\`; per-stamp positions come from \`trajectory.orientation_at\` (deterministic SLERP); the single Poisson + read-noise draw still runs once on the accumulated mean image using the existing \`tile_seed(base_seed, frame_idx, sensor_idx)\` derivation. Output is byte-identical across runs for fixed \`(base_seed, frame_idx, sensor_idx, max_drift_per_stamp_px)\` — pinned by \`test_per_stamp_render_is_deterministic\`.

## Behavior change

- **Default unchanged**: \`--max-drift-per-stamp-px\` defaults to unset; \`MotionBlurConfig.max_drift_per_stamp_px\` defaults to \`None\`. All existing callers and renders are bit-identical.
- **When the flag is set**: M scales with \`(per-subsample drift) / (per-stamp budget)\`. For typical 250 ms exposures with a 0.01 px stamp budget on PSD-derived jitter, M lands around 100-500. Renders are slower but actually correct on high-freq content.

## Tests

- \`stamp_times_default_is_one_per_subsample\` / \`stamp_times_subdivide_subsample_window\` — midpoint arithmetic for both M=1 and M=4.
- \`adaptive_with_stamps_picks_m_from_per_subsample_drift\` / \`none_collapses_to_m_1\` / \`static_trajectory_gives_m_1\` — the M-picking branches.
- \`per_stamp_render_is_deterministic\` — end-to-end byte equality across two runs of the same \`(seed, M>1)\` tile on a moving trajectory.
- \`per_stamp_changes_render_vs_per_subsample\` — same trajectory + seed with M=1 vs M from a fine budget produces different output (proves the inner loop isn't a no-op).

## Test plan
- [x] \`cargo fmt\`
- [x] \`cargo clippy --lib -- -W clippy::all\` — no new warnings
- [x] \`cargo test\` — 247 lib tests passing (was 240; +7 new, no failures)
- [ ] End-to-end smoke against PSD-derived trajectory using the LOS-PSD converter (PR #58 sibling) — left as the natural next-step verification once both land

## Follow-ups (out of scope here)

- Unify the seed-domain separation (the magic xor at \`motion_blur.rs:537\` for the read-noise RNG). Tracked separately; not load-bearing for this change.
- v2 stack's \`roi_render\` will pick up a parallel knob when it merges to main; conflict resolution at merge time.