### PR TITLE
DRY star + motion-blur deposit through MeanFluxDeposit/FrameSource traits

### DIFF
--- a/simulator/src/bin/detection_comparison.rs
+++ b/simulator/src/bin/detection_comparison.rs
@@ -107,7 +107,7 @@ fn test_algorithm(
         let e_image = add_stars_to_image(
             args.domain,
             args.domain,
-            &vec![star],
+            std::slice::from_ref(&star),
             &args.shared.exposure.0,
             satellite.telescope.clear_aperture_area(),
         );

--- a/simulator/src/image_proc/deposit.rs
+++ b/simulator/src/image_proc/deposit.rs
@@ -1,0 +1,268 @@
+//! `MeanFluxDeposit` and `FrameSource` traits — the renderer-facing
+//! contract that point sources (PSF-convolved stars) and extended
+//! sources (Sérsic galaxies, future measured profiles) both implement.
+//!
+//! Both renderer paths — the static [`super::render::add_stars_to_image`]
+//! and the motion-blur per-stamp deposit in
+//! [`crate::sims::motion_blur::SensorAccumulator`] — used to carry
+//! independent copies of the same bounding-box-loop and the same
+//! per-pixel PSF call. This module collapses both into a single generic
+//! [`splat_deposit`] helper plus a [`render_sources`] convenience that
+//! iterates a source list.
+//!
+//! # Single-Poisson invariant
+//!
+//! Implementors must never sample noise inside `pixel_flux` — the
+//! shot-noise sampling runs once at the end of the frame on the
+//! combined mean-electron image. See `planning/INVARIANTS.md` §1 for
+//! the architectural contract; this trait surface is what locks the
+//! contract at the source-deposit level.
+
+use std::time::Duration;
+
+use ndarray::Array2;
+use shared::image_proc::airy::PixelScaledAiryDisk;
+use shared::units::Area;
+
+/// Spatial flux distribution for one source at one deposit centre,
+/// distributing `total_flux` over neighbouring pixels of a 2-D buffer.
+///
+/// PSF-convolved point sources implement this via Simpson's-rule
+/// integration of an Airy disk (see the blanket impl below). Extended
+/// sources (Sérsic galaxies in the upcoming PR 3) implement it via
+/// direct surface-brightness evaluation × pixel area.
+///
+/// # Determinism
+///
+/// `pixel_flux` must be deterministic and side-effect-free — no RNG,
+/// no caches with hidden state. The renderer relies on this to keep
+/// per-tile RNG seeding reproducible. See INVARIANTS §5.
+///
+/// # Truncation
+///
+/// `footprint_pixels` describes the bounding-box half-width inside
+/// which the deposit contributes meaningfully. Pixels outside it are
+/// skipped. Implementors choose the threshold:
+///
+/// - PSF stars: `2 × first_zero` of the Airy disk (~99.99…% capture)
+/// - Sérsic galaxies (PR 3): radius at which SB drops to `1e-4 · I_e`
+pub trait MeanFluxDeposit {
+    /// Half-width of the bounding box in pixels for the per-pixel loop.
+    fn footprint_pixels(&self) -> i32;
+
+    /// Mean flux contributed to the pixel whose centre sits at offset
+    /// `(dx, dy)` *pixels* from the deposit centre, given `total_flux`
+    /// integrated over the source for the integration window.
+    ///
+    /// Must return zero for `total_flux == 0` and must be free of
+    /// side effects (no RNG, no shared state).
+    fn pixel_flux(&self, dx: f64, dy: f64, total_flux: f64) -> f64;
+}
+
+/// One source ready to be splatted onto a single sensor for one
+/// integration window. Generic over its deposit so the per-pixel inner
+/// loop monomorphises (no vtable cost in the hot path).
+///
+/// Stars implement this with `Deposit = PixelScaledAiryDisk`. Galaxies
+/// (PR 3) implement it with `Deposit = SersicSplat`. Adding a new
+/// source kind (satellite trails, asteroids) means implementing this
+/// trait + adding one `render_sources` call to each renderer.
+pub trait FrameSource {
+    /// Spatial deposit shape — typically the chromatic effective Airy
+    /// disk for stars or the elliptical Sérsic profile for galaxies.
+    type Deposit: MeanFluxDeposit;
+
+    /// Sub-pixel position on the sensor: `(x, y)` where `0` is the
+    /// corner and `(width-1, height-1)` is the opposite corner.
+    fn position_pixels(&self) -> (f64, f64);
+
+    /// Total mean electrons this source contributes during the
+    /// integration window — the value `splat_deposit` distributes
+    /// across the deposit's footprint.
+    fn total_electrons(&self, dt: Duration, aperture: Area) -> f64;
+
+    /// The spatial deposit (Airy disk for stars; SersicSplat for
+    /// galaxies in PR 3).
+    fn deposit(&self) -> &Self::Deposit;
+}
+
+/// Splat one source's mean-electron contribution onto `buf`. Iterates
+/// pixels within `deposit.footprint_pixels()` of `(px, py)`, calls
+/// `deposit.pixel_flux(dx, dy, total_flux)` per pixel, accumulates
+/// into `buf`. Skips out-of-bounds pixels. Early-returns if
+/// `total_flux == 0.0` so a stamp with no exposure budget is a no-op.
+///
+/// `buf` is indexed `[row, col] = [y, x]` to match `Array2<f64>`'s
+/// `(rows, cols)` shape, which is the convention used throughout
+/// focalplane's image pipeline.
+pub fn splat_deposit<D: MeanFluxDeposit>(
+    buf: &mut Array2<f64>,
+    px: f64,
+    py: f64,
+    total_flux: f64,
+    deposit: &D,
+) {
+    if total_flux == 0.0 {
+        return;
+    }
+    let (height, width) = buf.dim();
+    let footprint = deposit.footprint_pixels();
+    let xc = px.round() as i32;
+    let yc = py.round() as i32;
+    for x in (xc - footprint)..=(xc + footprint) {
+        for y in (yc - footprint)..=(yc + footprint) {
+            if x < 0 || y < 0 || x >= width as i32 || y >= height as i32 {
+                continue;
+            }
+            let dx = x as f64 - px;
+            let dy = y as f64 - py;
+            buf[[y as usize, x as usize]] += deposit.pixel_flux(dx, dy, total_flux);
+        }
+    }
+}
+
+/// Generic per-frame render pass — splats every source onto `buf`.
+/// Monomorphised per `S` so the inner deposit call inlines and `splat_deposit`
+/// itself is monomorphised on the source's `Deposit`.
+///
+/// This is the helper both renderer paths call into. The static path
+/// invokes it once per (sensor, kind-of-source); the motion-blur path
+/// invokes it once per (sensor, kind-of-source, stamp).
+pub fn render_sources<S: FrameSource>(
+    buf: &mut Array2<f64>,
+    sources: &[S],
+    dt: Duration,
+    aperture: Area,
+) {
+    for s in sources {
+        let total = s.total_electrons(dt, aperture);
+        let (px, py) = s.position_pixels();
+        splat_deposit(buf, px, py, total, s.deposit());
+    }
+}
+
+/// Blanket impl: a chromatic Airy disk is a deposit. Footprint is
+/// `2 × first_zero` (matches the existing star-rendering convention),
+/// per-pixel flux is Simpson's-rule integration of the Airy intensity
+/// over the pixel.
+impl MeanFluxDeposit for PixelScaledAiryDisk {
+    fn footprint_pixels(&self) -> i32 {
+        (self.first_zero().max(1.0) * 2.0).ceil() as i32
+    }
+
+    fn pixel_flux(&self, dx: f64, dy: f64, total_flux: f64) -> f64 {
+        self.pixel_flux_simpson(dx, dy, total_flux)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shared::image_proc::airy::PixelScaledAiryDisk;
+    use shared::units::{LengthExt, Wavelength};
+
+    /// `splat_deposit` with `total_flux == 0` must be a no-op. Locks the
+    /// "zero exposure budget = no work" early return — important for the
+    /// motion-blur path where individual stamps may legitimately receive
+    /// zero electrons (e.g. a star that briefly leaves the sensor footprint).
+    #[test]
+    fn zero_total_flux_is_a_noop() {
+        let psf = PixelScaledAiryDisk::with_fwhm(1.0, Wavelength::from_nanometers(550.0));
+        let mut buf = Array2::<f64>::zeros((50, 50));
+        splat_deposit(&mut buf, 25.0, 25.0, 0.0, &psf);
+        assert!(buf.iter().all(|&v| v == 0.0));
+    }
+
+    /// Pixels outside the buffer get silently skipped (no panic).
+    /// Locks the bounds-check; the motion-blur path relies on this when
+    /// a star straddles the sensor edge mid-stamp.
+    #[test]
+    fn out_of_bounds_centre_does_not_panic() {
+        let psf = PixelScaledAiryDisk::with_fwhm(1.0, Wavelength::from_nanometers(550.0));
+        let mut buf = Array2::<f64>::zeros((20, 20));
+        // Centre wholly outside the buffer — every pixel in the footprint
+        // is bounds-rejected, but the function must complete cleanly.
+        splat_deposit(&mut buf, 1000.0, 1000.0, 100.0, &psf);
+        assert!(buf.iter().all(|&v| v == 0.0));
+    }
+
+    /// **Physics anchor**: depositing `T` electrons via an Airy disk into a
+    /// generous box must integrate back to ≈ `T` (within the documented
+    /// truncation budget). The first-zero × 2 box captures > 99% of the
+    /// total flux for a well-sampled disk; the residual is genuine flux
+    /// in higher-order rings beyond the box.
+    ///
+    /// This test fires if either:
+    ///   (a) `pixel_flux_simpson` weights are wrong (over- or under-counts), or
+    ///   (b) `footprint_pixels` is too tight (truncates more than ~1%).
+    #[test]
+    fn airy_deposit_conserves_flux_to_simpson_truncation_budget() {
+        let psf = PixelScaledAiryDisk::with_fwhm(2.0, Wavelength::from_nanometers(550.0));
+        // Buffer is large enough to contain the full first-zero-times-2 footprint
+        // even with a sub-pixel offset; size is 2*footprint+8 each side.
+        let footprint = psf.footprint_pixels() as usize;
+        let n = footprint * 2 + 8;
+        let mut buf = Array2::<f64>::zeros((n, n));
+        let centre = (n as f64) * 0.5;
+        let total_in = 1_000_000.0_f64;
+        // Use an off-grid centre to exercise the sub-pixel Simpson path.
+        splat_deposit(&mut buf, centre + 0.37, centre - 0.21, total_in, &psf);
+        let total_out: f64 = buf.iter().sum();
+        let captured = total_out / total_in;
+        // The 99% lower bound is the documented Simpson-on-Airy capture
+        // budget. Above it, accept a few-percent slop for the edge of
+        // the bounding box where higher-order Airy rings live.
+        assert!(
+            captured > 0.99,
+            "Airy capture {captured} < 99% (expected >0.99 for 2×first_zero box)"
+        );
+        // Upper sanity bound — capture cannot exceed 100% (Simpson rule
+        // is an interpolant, not an extrapolant).
+        assert!(captured <= 1.0 + 1e-9, "Airy capture {captured} > 100%");
+    }
+
+    /// Footprint must be at least 1 pixel — even a delta-function PSF
+    /// covers its own pixel. Locks the `max(1.0)` clamp.
+    #[test]
+    fn footprint_is_at_least_one_pixel() {
+        // Tiny FWHM forces first_zero below 1.0; the impl floors to 1.
+        let psf = PixelScaledAiryDisk::with_fwhm(0.05, Wavelength::from_nanometers(550.0));
+        assert!(psf.footprint_pixels() >= 1);
+    }
+
+    /// **INVARIANTS §2 lock**: the static-renderer entry
+    /// (`add_stars_to_image`'s inner per-star deposit) and the
+    /// motion-blur per-stamp entry (`SensorAccumulator::splat_psf`) must
+    /// produce **byte-identical** buffers when given the same source +
+    /// total_flux at the same position. After the PR 2 refactor both
+    /// route through `splat_deposit`, so this test fires only if a
+    /// future PR adds a fork that diverges them.
+    ///
+    /// The test exercises a sub-pixel offset and a non-integer
+    /// `total_flux` so any rounding-order divergence between the two
+    /// paths shows up.
+    #[test]
+    fn static_and_splat_psf_paths_are_byte_equal() {
+        use crate::sims::motion_blur::SensorAccumulator;
+        let psf = PixelScaledAiryDisk::with_fwhm(2.0, Wavelength::from_nanometers(550.0));
+        let total_flux = 12_345.6789_f64;
+        let px = 25.31;
+        let py = 24.07;
+
+        // Path A: direct splat_deposit (what add_stars_to_image runs through).
+        let mut buf_a = Array2::<f64>::zeros((50, 50));
+        splat_deposit(&mut buf_a, px, py, total_flux, &psf);
+
+        // Path B: motion-blur SensorAccumulator (what splat_psf runs through).
+        let mut acc = SensorAccumulator::zero(50, 50);
+        acc.splat_psf(px, py, total_flux, &psf);
+        let buf_b = acc.star_mean_electrons;
+
+        // Byte-equality (not approx) — the two paths must agree to the bit.
+        assert_eq!(
+            buf_a.as_slice().unwrap(),
+            buf_b.as_slice().unwrap(),
+            "static and splat_psf paths must be byte-identical"
+        );
+    }
+}

--- a/simulator/src/image_proc/mod.rs
+++ b/simulator/src/image_proc/mod.rs
@@ -3,4 +3,7 @@
 //! This module contains image processing functions that depend on
 //! simulator-specific types and are not suitable for the shared module.
 
+pub mod deposit;
 pub mod render;
+
+pub use deposit::{render_sources, splat_deposit, FrameSource, MeanFluxDeposit};

--- a/simulator/src/image_proc/render.rs
+++ b/simulator/src/image_proc/render.rs
@@ -212,7 +212,7 @@ impl Renderer {
     /// # Returns
     /// A new Renderer with the base star image pre-computed
     ///
-    pub fn from_stars(stars: &Vec<StarInFrame>, satellite_config: SatelliteConfig) -> Self {
+    pub fn from_stars(stars: &[StarInFrame], satellite_config: SatelliteConfig) -> Self {
         // Create base star image for 1 second exposure
         let (width, height) = satellite_config.sensor.dimensions.get_pixel_width_height();
         let base_star_image = add_stars_to_image(
@@ -226,7 +226,7 @@ impl Renderer {
         Self {
             satellite_config,
             base_star_image,
-            rendered_stars: stars.clone(),
+            rendered_stars: stars.to_vec(),
         }
     }
 
@@ -381,7 +381,7 @@ pub fn quantize_image(electron_img: &Array2<f64>, sensor: &SensorConfig) -> Arra
 pub fn add_stars_to_image(
     width: usize,
     height: usize,
-    stars: &Vec<StarInFrame>,
+    stars: &[StarInFrame],
     exposure: &Duration,
     aperture: Area,
 ) -> Array2<f64> {

--- a/simulator/src/image_proc/render.rs
+++ b/simulator/src/image_proc/render.rs
@@ -9,13 +9,14 @@ use crate::{
         satellite::FocalPlaneConfig, sensor_noise::generate_sensor_noise, SatelliteConfig,
         SensorConfig,
     },
+    image_proc::deposit::{render_sources, FrameSource},
     photometry::{photoconversion::SourceFlux, zodiacal::SolarAngularCoordinates, ZodiacalLight},
     sims::orientation::orientation_from_pointing,
     star_math::star_data_to_fluxes,
 };
 use meter_math::Locatable2d;
 use shared::{
-    image_proc::noise::apply_poisson_photon_noise,
+    image_proc::{airy::PixelScaledAiryDisk, noise::apply_poisson_photon_noise},
     units::{Area, LengthExt},
 };
 
@@ -35,6 +36,25 @@ impl Locatable2d for StarInFrame {
 
     fn y(&self) -> f64 {
         self.y
+    }
+}
+
+/// `FrameSource` impl for star-in-frame: the deposit is the chromatic
+/// effective Airy disk attached to the star's photoelectron flux, and
+/// the per-frame electron count comes from `SpotFlux::integrated_over`.
+impl FrameSource for StarInFrame {
+    type Deposit = PixelScaledAiryDisk;
+
+    fn position_pixels(&self) -> (f64, f64) {
+        (self.x, self.y)
+    }
+
+    fn total_electrons(&self, dt: Duration, aperture: Area) -> f64 {
+        self.spot.electrons.integrated_over(&dt, aperture)
+    }
+
+    fn deposit(&self) -> &Self::Deposit {
+        &self.spot.electrons.disk
     }
 }
 
@@ -365,45 +385,8 @@ pub fn add_stars_to_image(
     exposure: &Duration,
     aperture: Area,
 ) -> Array2<f64> {
-    // Create new image array with specified dimensions
     let mut image = Array2::zeros((height, width));
-
-    // Calculate the contribution of all stars to this pixel
-    for star in stars {
-        // NOTE(meawopppl) - Should be erf() based cutoff here.
-        // 2x the first 0 should cover 99.99999% of flux or so
-        let max_pix_dist: i32 =
-            (star.spot.electrons.disk.first_zero().max(1.0) * 2.0).ceil() as i32;
-
-        // Calculate pixel range to check based on star position
-        let xc = star.x.round() as i32;
-        let yc = star.y.round() as i32;
-
-        for x in (xc - max_pix_dist)..=(xc + max_pix_dist) {
-            for y in (yc - max_pix_dist)..=(yc + max_pix_dist) {
-                // Bounds check x/y - Skip out of bounds pixels
-                if x < 0 || y < 0 || x >= width as i32 || y >= height as i32 {
-                    continue;
-                }
-
-                // Calculate pixel center position relative to star
-                let x_pixel = x as f64 - star.x;
-                let y_pixel = y as f64 - star.y;
-
-                let flux = &star.spot.electrons;
-
-                // Use Simpson's rule integration for accurate flux calculation
-                let contribution = flux.disk.pixel_flux_simpson(
-                    x_pixel,
-                    y_pixel,
-                    flux.integrated_over(exposure, aperture),
-                );
-
-                image[[y as usize, x as usize]] += contribution;
-            }
-        }
-    }
-
+    render_sources(&mut image, stars, *exposure, aperture);
     image
 }
 

--- a/simulator/src/sims/motion_blur.rs
+++ b/simulator/src/sims/motion_blur.rs
@@ -204,24 +204,13 @@ impl SensorAccumulator {
         total_electrons: f64,
         psf: &shared::image_proc::airy::PixelScaledAiryDisk,
     ) {
-        if total_electrons == 0.0 {
-            return;
-        }
-        let (height, width) = self.star_mean_electrons.dim();
-        let max_pix_dist: i32 = (psf.first_zero().max(1.0) * 2.0).ceil() as i32;
-        let xc = px.round() as i32;
-        let yc = py.round() as i32;
-        for x in (xc - max_pix_dist)..=(xc + max_pix_dist) {
-            for y in (yc - max_pix_dist)..=(yc + max_pix_dist) {
-                if x < 0 || y < 0 || x >= width as i32 || y >= height as i32 {
-                    continue;
-                }
-                let x_rel = x as f64 - px;
-                let y_rel = y as f64 - py;
-                let contribution = psf.pixel_flux_simpson(x_rel, y_rel, total_electrons);
-                self.star_mean_electrons[[y as usize, x as usize]] += contribution;
-            }
-        }
+        crate::image_proc::deposit::splat_deposit(
+            &mut self.star_mean_electrons,
+            px,
+            py,
+            total_electrons,
+            psf,
+        );
     }
 
     /// Returns the combined mean-electron image = star mean + zodiacal


### PR DESCRIPTION
## Summary

Second of the galaxy-rendering PR sequence (planning docs in gitignored `planning/`). Pure refactor — collapses the duplicated bounding-box-loop in the static and motion-blur render paths onto a single splat helper, ready for galaxies in PR 3.

- `MeanFluxDeposit` trait — the spatial contract for any deposit (Airy disk for stars, future Sérsic splat for galaxies)
- `FrameSource` trait — the per-source contract bundling `(position, total_electrons, deposit)`. Generic over the deposit's associated type, so the inner per-pixel loop monomorphises
- `splat_deposit<D>` and `render_sources<S>` helpers
- `PixelScaledAiryDisk: MeanFluxDeposit` (blanket impl) + `StarInFrame: FrameSource`
- `add_stars_to_image` shrinks ~40 → ~5 lines
- `SensorAccumulator::splat_psf` shrinks ~20 → ~10 lines

## Why

The two render entry points were independently re-implementing the same pixel-bounding-box + per-pixel `pixel_flux_simpson` loop. Adding galaxies through both required either touching both paths or extracting a shared abstraction. This is the abstraction.

## Test plan

273/273 simulator lib tests pass — every existing star-rendering test is byte-equal to current main, no snapshot regenerations.

Five new physics-anchored tests on the deposit module:

- [x] `zero_total_flux_is_a_noop` — locks the early return
- [x] `out_of_bounds_centre_does_not_panic` — locks the bounds check
- [x] `airy_deposit_conserves_flux_to_simpson_truncation_budget` — Airy disk with `total_in = 1e6` integrates back to >99% within the `2 × first_zero` box; anchored to the documented Simpson-on-Airy capture budget
- [x] `footprint_is_at_least_one_pixel` — locks the `max(1.0)` clamp
- [x] `static_and_splat_psf_paths_are_byte_equal` — INVARIANTS §2 lock: `splat_deposit` and `SensorAccumulator::splat_psf` produce byte-identical buffers for the same source/flux/position. Trivially true after the refactor; the test will fire if a future PR forks the two paths

`cargo fmt` + `cargo clippy --tests -- -W clippy::all` clean.