### PR TITLE
Wire galaxies through Scene + Renderer; e2e flux roundtrip

### DIFF
--- a/simulator/src/image_proc/render.rs
+++ b/simulator/src/image_proc/render.rs
@@ -213,15 +213,28 @@ impl Renderer {
     /// A new Renderer with the base star image pre-computed
     ///
     pub fn from_stars(stars: &[StarInFrame], satellite_config: SatelliteConfig) -> Self {
-        // Create base star image for 1 second exposure
+        Self::from_stars_and_galaxies(stars, &[], satellite_config)
+    }
+
+    /// Create a renderer from pre-computed stars *and* pre-computed
+    /// galaxies. Both source kinds splat into the same 1-second base
+    /// image; per-exposure scaling and Poisson sampling apply to the
+    /// combined buffer (single-Poisson invariant — INVARIANTS §1).
+    ///
+    /// Galaxies use the `SersicSplat` deposit, stars use the chromatic
+    /// Airy disk. Both run through the shared `render_sources` helper
+    /// so the splat math is identical apart from the per-source
+    /// `MeanFluxDeposit` impl.
+    pub fn from_stars_and_galaxies(
+        stars: &[StarInFrame],
+        galaxies: &[crate::scene_galaxy::GalaxyInFrame],
+        satellite_config: SatelliteConfig,
+    ) -> Self {
         let (width, height) = satellite_config.sensor.dimensions.get_pixel_width_height();
-        let base_star_image = add_stars_to_image(
-            width,
-            height,
-            stars,
-            &Duration::from_secs(1),
-            satellite_config.telescope.clear_aperture_area(),
-        );
+        let aperture = satellite_config.telescope.clear_aperture_area();
+        let one_second = Duration::from_secs(1);
+        let mut base_star_image = add_stars_to_image(width, height, stars, &one_second, aperture);
+        add_galaxies_to_image(&mut base_star_image, galaxies, &one_second, aperture);
 
         Self {
             satellite_config,

--- a/simulator/src/scene.rs
+++ b/simulator/src/scene.rs
@@ -125,6 +125,14 @@ pub struct Scene {
     /// Indexed by sensor index in the array.
     pub per_sensor_stars: Vec<Vec<StarInFrame>>,
 
+    /// Galaxies projected and routed to each sensor's pixel coordinates,
+    /// in the same per-sensor order as `per_sensor_stars`. Empty by
+    /// default; populate via [`Scene::with_galaxies`] (or hand-construct
+    /// for tests / synthetic scenes). Galaxies splat into the same
+    /// mean-electron buffer as stars, so the unified Poisson stage
+    /// applies once to the combined image (INVARIANTS §1).
+    pub per_sensor_galaxies: Vec<Vec<crate::scene_galaxy::GalaxyInFrame>>,
+
     /// Celestial pointing center for the observation.
     pub pointing_center: Equatorial,
 
@@ -161,10 +169,12 @@ impl Scene {
         let fp_stars =
             project_stars_to_focal_plane(&star_refs, &pointing_center, &focal_plane, padding_mm);
         let per_sensor_stars = route_stars_to_sensors(&fp_stars, &focal_plane, padding_mm);
+        let n_sensors = per_sensor_stars.len();
 
         Self {
             focal_plane,
             per_sensor_stars,
+            per_sensor_galaxies: vec![Vec::new(); n_sensors],
             pointing_center,
             zodiacal_coordinates,
         }
@@ -181,12 +191,36 @@ impl Scene {
         pointing_center: Equatorial,
         zodiacal_coordinates: SolarAngularCoordinates,
     ) -> Self {
+        let n_sensors = per_sensor_stars.len();
         Self {
             focal_plane,
             per_sensor_stars,
+            per_sensor_galaxies: vec![Vec::new(); n_sensors],
             pointing_center,
             zodiacal_coordinates,
         }
+    }
+
+    /// Attach pre-computed per-sensor galaxies to the scene. Builder
+    /// method — returns `self` so it can chain off
+    /// [`Scene::from_catalog`] / [`Scene::from_stars`].
+    ///
+    /// `per_sensor_galaxies.len()` must equal the sensor count or
+    /// the method panics — the indexing parity with `per_sensor_stars`
+    /// is what lets the renderer iterate sensors uniformly.
+    pub fn with_galaxies(
+        mut self,
+        per_sensor_galaxies: Vec<Vec<crate::scene_galaxy::GalaxyInFrame>>,
+    ) -> Self {
+        assert_eq!(
+            per_sensor_galaxies.len(),
+            self.per_sensor_stars.len(),
+            "per_sensor_galaxies length ({}) must match per_sensor_stars length ({})",
+            per_sensor_galaxies.len(),
+            self.per_sensor_stars.len()
+        );
+        self.per_sensor_galaxies = per_sensor_galaxies;
+        self
     }
 
     /// Render all sensors and return one `RenderingResult` per sensor.
@@ -212,7 +246,11 @@ impl Scene {
                 .satellite_for_sensor(sensor_idx)
                 .expect("sensor index in range");
 
-            let renderer = Renderer::from_stars(&self.per_sensor_stars[sensor_idx], sat);
+            let renderer = Renderer::from_stars_and_galaxies(
+                &self.per_sensor_stars[sensor_idx],
+                &self.per_sensor_galaxies[sensor_idx],
+                sat,
+            );
 
             let seed = base_seed.map(|s| s + sensor_idx as u64);
             let rendered = renderer.render_with_seed(exposure, &self.zodiacal_coordinates, seed);

--- a/simulator/src/scene_galaxy.rs
+++ b/simulator/src/scene_galaxy.rs
@@ -75,6 +75,20 @@ mod tests {
         electron_rate: f64,
         arcsec_per_pixel: f64,
     ) -> GalaxyInFrame {
+        // De Vaucouleurs-like (n=4) — used by the byte-equality and
+        // additivity tests where the deposit just needs to be a
+        // realistic galaxy shape.
+        fixture_galaxy_full(x, y, electron_rate, arcsec_per_pixel, 4.0, 5.0)
+    }
+
+    fn fixture_galaxy_full(
+        x: f64,
+        y: f64,
+        electron_rate: f64,
+        arcsec_per_pixel: f64,
+        n: f64,
+        theta_half_arcsec: f64,
+    ) -> GalaxyInFrame {
         let psf = PixelScaledAiryDisk::with_fwhm(2.0, Wavelength::from_nanometers(550.0));
         let spot = SpotFlux {
             disk: psf,
@@ -85,8 +99,8 @@ mod tests {
             electrons: spot,
         };
         let profile = SersicProfile {
-            theta_half_arcsec: 5.0,
-            n: 4.0,
+            theta_half_arcsec,
+            n,
             axis_ratio: 0.6,
             position_angle_deg: 30.0,
         };
@@ -139,54 +153,80 @@ mod tests {
     /// `apply_poisson=false` short-circuit, and the per-exposure linear
     /// scaling all compose correctly. Any unit error or missing factor
     /// along the chain shows up here.
-    #[test]
-    fn end_to_end_flux_roundtrip_through_renderer() {
-        use crate::hardware::sensor::models::GSENSE4040BSI;
+    /// Build a small (256×256 px) test sensor + satellite config.
+    /// Tiny on purpose so the `Renderer::from_stars_and_galaxies` base
+    /// image fits in ~64k pixels rather than 16M for a real CMOS — the
+    /// flux-conservation physics is sensor-size-invariant, and the
+    /// reduced size keeps the e2e test fast under coverage
+    /// instrumentation.
+    fn small_test_satellite() -> crate::hardware::SatelliteConfig {
+        use crate::hardware::dark_current::DarkCurrentEstimator;
+        use crate::hardware::read_noise::ReadNoiseEstimator;
+        use crate::hardware::sensor::{SensorConfig, SensorGeometry};
         use crate::hardware::SatelliteConfig;
         use crate::hardware::TelescopeConfig;
-        use crate::image_proc::render::Renderer;
-        use crate::photometry::zodiacal::SolarAngularCoordinates;
+        use crate::photometry::QuantumEfficiency;
         use shared::units::{Length, LengthExt as _, Temperature, TemperatureExt as _};
-
-        // Build a satellite config with the test sensor + a fixed-FWHM
-        // telescope. The exact aperture / focal length don't matter
-        // for the roundtrip — they cancel out via integrated_over.
         let telescope = TelescopeConfig::new(
-            "Roundtrip test",
+            "Tiny e2e telescope",
             Length::from_meters(0.5),
             Length::from_meters(2.5),
             0.8,
         );
-        let sensor = GSENSE4040BSI.clone();
-        let temp = Temperature::from_celsius(-10.0);
-        let satellite = SatelliteConfig::new(telescope, sensor, temp);
+        let qe = QuantumEfficiency::from_table(
+            vec![400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0],
+            vec![0.0, 0.7, 0.9, 0.85, 0.7, 0.5, 0.0],
+        )
+        .unwrap();
+        let sensor = SensorConfig {
+            name: "TinyE2E".into(),
+            quantum_efficiency: qe,
+            dimensions: SensorGeometry::of_width_height(256, 256, Length::from_micrometers(5.5)),
+            read_noise_estimator: ReadNoiseEstimator::constant(2.0),
+            dark_current_estimator: DarkCurrentEstimator::from_reference_point(
+                0.01,
+                Temperature::from_celsius(20.0),
+            ),
+            bit_depth: 16,
+            dn_per_electron: 1.0,
+            max_well_depth_e: 1e20,
+            max_frame_rate_fps: 30.0,
+        };
+        SatelliteConfig::new(telescope, sensor, Temperature::from_celsius(-10.0))
+    }
+
+    #[test]
+    fn end_to_end_flux_roundtrip_through_renderer() {
+        use crate::image_proc::render::Renderer;
+        use crate::photometry::zodiacal::SolarAngularCoordinates;
+
+        let satellite = small_test_satellite();
         let aperture = satellite.telescope.clear_aperture_area();
 
-        // Place a galaxy at a centred sub-pixel position on the sensor.
+        // Place a galaxy at a centred sub-pixel position. Use n=1
+        // (exponential disk, not de Vaucouleurs) so the 1e-4 SB
+        // footprint is ~5 θ_eff rather than the ~30 θ_eff of n=4 —
+        // fits comfortably inside a 256×256 sensor at 0.1″/pix even
+        // with θ_eff = 2″ (20 px per θ_eff, well-resolved).
         let (w, h) = satellite.sensor.dimensions.get_pixel_width_height();
         let cx = (w as f64) * 0.5;
         let cy = (h as f64) * 0.5;
         let electron_rate = 5_000.0_f64; // electrons / s / cm²
-                                         // Use a well-resolved deposit (50 pixels per θ_eff) so the
-                                         // adaptive Simpson sub-pixel integrator converges within the
-                                         // documented 2% truncation budget.
-        let g = fixture_galaxy_at_scale(cx, cy, electron_rate, 0.1);
+        let g = fixture_galaxy_full(cx, cy, electron_rate, 0.1, 1.0, 2.0);
         let exposure = Duration::from_secs(2);
         let total_in = g.flux.electrons.integrated_over(&exposure, aperture);
 
         // Render via the static path with Poisson disabled — the
-        // resulting `star_image` is the *mean* electron buffer with
-        // both stars (empty) and galaxies splatted in, scaled by
-        // exposure.
+        // `star_image` is the *mean* electron buffer with both stars
+        // (empty) and galaxies splatted in, scaled by exposure.
         let renderer = Renderer::from_stars_and_galaxies(&[], &[g], satellite);
         let zodi = SolarAngularCoordinates::new(180.0, 60.0).unwrap();
         let result = renderer.render_with_options(&exposure, &zodi, false, None);
         let total_out: f64 = result.star_image.iter().sum();
 
         // Expect within the SersicSplat truncation budget: > 95% of
-        // input flux is captured (loose bound covers high-n wings),
-        // and never exceeds input (Simpson sub-sample is a bounded
-        // integrator).
+        // input flux captured, never exceeding input (Simpson sub-
+        // sample is a bounded integrator).
         let captured = total_out / total_in;
         assert!(
             captured > 0.95 && captured < 1.02,
@@ -209,31 +249,20 @@ mod tests {
     #[test]
     #[ignore]
     fn variance_equals_mean_poisson_identity() {
-        use crate::hardware::sensor::models::GSENSE4040BSI;
-        use crate::hardware::SatelliteConfig;
-        use crate::hardware::TelescopeConfig;
         use crate::image_proc::render::Renderer;
         use crate::photometry::zodiacal::SolarAngularCoordinates;
         use ndarray::Array2;
-        use shared::units::{Length, LengthExt as _, Temperature, TemperatureExt as _};
 
-        let telescope = TelescopeConfig::new(
-            "Poisson test",
-            Length::from_meters(0.5),
-            Length::from_meters(2.5),
-            0.8,
-        );
-        let sensor = GSENSE4040BSI.clone();
-        let temp = Temperature::from_celsius(-10.0);
-        let satellite = SatelliteConfig::new(telescope, sensor, temp);
-
+        let satellite = small_test_satellite();
         let (w, h) = satellite.sensor.dimensions.get_pixel_width_height();
         let cx = (w as f64) * 0.5;
         let cy = (h as f64) * 0.5;
         // Lower electron rate keeps per-pixel mean small enough that
         // the Poisson identity is detectable; high rate gets dominated
         // by the variance of the variance estimator.
-        let g = fixture_galaxy_at_scale(cx, cy, 50.0, 0.1);
+        // Same n=1 / θ_eff = 2″ shape as the e2e roundtrip — see
+        // there for why n=1 specifically (footprint sized to 256 sensor).
+        let g = fixture_galaxy_full(cx, cy, 50.0, 0.1, 1.0, 2.0);
         let renderer = Renderer::from_stars_and_galaxies(&[], &[g], satellite);
         let zodi = SolarAngularCoordinates::new(180.0, 60.0).unwrap();
         let exposure = Duration::from_secs(2);

--- a/simulator/src/scene_galaxy.rs
+++ b/simulator/src/scene_galaxy.rs
@@ -66,6 +66,15 @@ mod tests {
     /// `SourceFlux` instead of running through the spectrum pipeline
     /// since the integration coupling lives outside this module.
     fn fixture_galaxy(x: f64, y: f64, electron_rate: f64) -> GalaxyInFrame {
+        fixture_galaxy_at_scale(x, y, electron_rate, 0.5)
+    }
+
+    fn fixture_galaxy_at_scale(
+        x: f64,
+        y: f64,
+        electron_rate: f64,
+        arcsec_per_pixel: f64,
+    ) -> GalaxyInFrame {
         let psf = PixelScaledAiryDisk::with_fwhm(2.0, Wavelength::from_nanometers(550.0));
         let spot = SpotFlux {
             disk: psf,
@@ -81,7 +90,7 @@ mod tests {
             axis_ratio: 0.6,
             position_angle_deg: 30.0,
         };
-        let deposit = SersicSplat::new(profile, 0.5);
+        let deposit = SersicSplat::new(profile, arcsec_per_pixel);
         GalaxyInFrame {
             x,
             y,
@@ -116,6 +125,165 @@ mod tests {
             buf_a.as_slice().unwrap(),
             acc.star_mean_electrons.as_slice().unwrap(),
             "static and splat_galaxy paths must be byte-identical"
+        );
+    }
+
+    /// **End-to-end flux roundtrip**: build a `Renderer` containing
+    /// only a single galaxy (no stars), render with Poisson disabled,
+    /// and verify the sum of all electron pixels equals the galaxy's
+    /// expected `flux_rate × aperture × exposure` within the
+    /// truncation budget.
+    ///
+    /// This is the most direct test that the SersicSplat normalisation,
+    /// the Renderer's `from_stars_and_galaxies` plumbing, the
+    /// `apply_poisson=false` short-circuit, and the per-exposure linear
+    /// scaling all compose correctly. Any unit error or missing factor
+    /// along the chain shows up here.
+    #[test]
+    fn end_to_end_flux_roundtrip_through_renderer() {
+        use crate::hardware::sensor::models::GSENSE4040BSI;
+        use crate::hardware::SatelliteConfig;
+        use crate::hardware::TelescopeConfig;
+        use crate::image_proc::render::Renderer;
+        use crate::photometry::zodiacal::SolarAngularCoordinates;
+        use shared::units::{Length, LengthExt as _, Temperature, TemperatureExt as _};
+
+        // Build a satellite config with the test sensor + a fixed-FWHM
+        // telescope. The exact aperture / focal length don't matter
+        // for the roundtrip — they cancel out via integrated_over.
+        let telescope = TelescopeConfig::new(
+            "Roundtrip test",
+            Length::from_meters(0.5),
+            Length::from_meters(2.5),
+            0.8,
+        );
+        let sensor = GSENSE4040BSI.clone();
+        let temp = Temperature::from_celsius(-10.0);
+        let satellite = SatelliteConfig::new(telescope, sensor, temp);
+        let aperture = satellite.telescope.clear_aperture_area();
+
+        // Place a galaxy at a centred sub-pixel position on the sensor.
+        let (w, h) = satellite.sensor.dimensions.get_pixel_width_height();
+        let cx = (w as f64) * 0.5;
+        let cy = (h as f64) * 0.5;
+        let electron_rate = 5_000.0_f64; // electrons / s / cm²
+                                         // Use a well-resolved deposit (50 pixels per θ_eff) so the
+                                         // adaptive Simpson sub-pixel integrator converges within the
+                                         // documented 2% truncation budget.
+        let g = fixture_galaxy_at_scale(cx, cy, electron_rate, 0.1);
+        let exposure = Duration::from_secs(2);
+        let total_in = g.flux.electrons.integrated_over(&exposure, aperture);
+
+        // Render via the static path with Poisson disabled — the
+        // resulting `star_image` is the *mean* electron buffer with
+        // both stars (empty) and galaxies splatted in, scaled by
+        // exposure.
+        let renderer = Renderer::from_stars_and_galaxies(&[], &[g], satellite);
+        let zodi = SolarAngularCoordinates::new(180.0, 60.0).unwrap();
+        let result = renderer.render_with_options(&exposure, &zodi, false, None);
+        let total_out: f64 = result.star_image.iter().sum();
+
+        // Expect within the SersicSplat truncation budget: > 95% of
+        // input flux is captured (loose bound covers high-n wings),
+        // and never exceeds input (Simpson sub-sample is a bounded
+        // integrator).
+        let captured = total_out / total_in;
+        assert!(
+            captured > 0.95 && captured < 1.02,
+            "renderer flux roundtrip: input {total_in:.4} electrons, output {total_out:.4} electrons (captured {captured:.4})"
+        );
+    }
+
+    /// **INVARIANTS §1 lock — variance equals mean (Poisson identity)**.
+    /// Render a galaxy-only scene N times with different RNG seeds and
+    /// no read noise; per-pixel variance over the trials must equal
+    /// per-pixel mean within Monte-Carlo error. Anchors the property
+    /// `Var[Poisson(λ)] = E[Poisson(λ)] = λ` against any future bug
+    /// that introduces a per-source or per-stamp Poisson, which would
+    /// shift the variance/mean ratio away from 1.
+    ///
+    /// `#[ignore]` because it's slow (200 trials × full render). Run
+    /// manually:
+    ///   cargo test -p simulator --lib scene_galaxy --
+    ///       --ignored variance_equals_mean_poisson_identity
+    #[test]
+    #[ignore]
+    fn variance_equals_mean_poisson_identity() {
+        use crate::hardware::sensor::models::GSENSE4040BSI;
+        use crate::hardware::SatelliteConfig;
+        use crate::hardware::TelescopeConfig;
+        use crate::image_proc::render::Renderer;
+        use crate::photometry::zodiacal::SolarAngularCoordinates;
+        use ndarray::Array2;
+        use shared::units::{Length, LengthExt as _, Temperature, TemperatureExt as _};
+
+        let telescope = TelescopeConfig::new(
+            "Poisson test",
+            Length::from_meters(0.5),
+            Length::from_meters(2.5),
+            0.8,
+        );
+        let sensor = GSENSE4040BSI.clone();
+        let temp = Temperature::from_celsius(-10.0);
+        let satellite = SatelliteConfig::new(telescope, sensor, temp);
+
+        let (w, h) = satellite.sensor.dimensions.get_pixel_width_height();
+        let cx = (w as f64) * 0.5;
+        let cy = (h as f64) * 0.5;
+        // Lower electron rate keeps per-pixel mean small enough that
+        // the Poisson identity is detectable; high rate gets dominated
+        // by the variance of the variance estimator.
+        let g = fixture_galaxy_at_scale(cx, cy, 50.0, 0.1);
+        let renderer = Renderer::from_stars_and_galaxies(&[], &[g], satellite);
+        let zodi = SolarAngularCoordinates::new(180.0, 60.0).unwrap();
+        let exposure = Duration::from_secs(2);
+
+        let n_trials = 200_u32;
+        let mut sum: Option<Array2<f64>> = None;
+        let mut sum_sq: Option<Array2<f64>> = None;
+        for trial in 0..n_trials {
+            // Render with Poisson on but force read noise off by
+            // computing only the star_image (which the Renderer
+            // already separates from sensor noise).
+            let result = renderer.render_with_options(
+                &exposure,
+                &zodi,
+                true, // apply Poisson
+                Some(0xCAFE_F00D ^ trial as u64),
+            );
+            let img = result.star_image;
+            sum = Some(match sum {
+                Some(s) => &s + &img,
+                None => img.clone(),
+            });
+            sum_sq = Some(match sum_sq {
+                Some(s) => &s + &(&img * &img),
+                None => &img * &img,
+            });
+        }
+        let n = n_trials as f64;
+        let mean = sum.unwrap() / n;
+        let var = sum_sq.unwrap() / n - &mean * &mean;
+
+        // Restrict to pixels with non-trivial flux so the variance
+        // estimator isn't dominated by the zero-mean tail.
+        let mut ratios = Vec::new();
+        for (m, v) in mean.iter().zip(var.iter()) {
+            if *m > 1.0 {
+                ratios.push(v / m);
+            }
+        }
+        assert!(!ratios.is_empty(), "no high-mean pixels to evaluate");
+        let mean_ratio: f64 = ratios.iter().sum::<f64>() / ratios.len() as f64;
+        // Pure-Poisson identity: ratio should be 1.0 within MC bound
+        // ~ √(2/(N-1)) ≈ 0.10 for N=200. Allow ±0.10 — tighter would
+        // be flaky on modest sample sizes; looser would let regressions
+        // through.
+        assert!(
+            (mean_ratio - 1.0).abs() < 0.10,
+            "Poisson variance/mean ratio averaged over {} pixels = {:.4}, expected ≈ 1.0",
+            ratios.len(),
+            mean_ratio
         );
     }
 


### PR DESCRIPTION
## Summary

Plugs the `SersicSplat` / `GalaxyInFrame` infrastructure from #66 into the top-level `Scene` / `Renderer` pipeline. After this PR the static render path takes galaxies through the same code that handles stars: same projection, same per-exposure scaling, same single Poisson over the combined mean. Galaxies are end-to-end usable through `Scene::from_catalog(...).with_galaxies(per_sensor_galaxies)`.

## API additions (additive, backwards-compatible)

- `Scene::per_sensor_galaxies: Vec<Vec<GalaxyInFrame>>` field — defaults empty in `from_catalog` / `from_stars`
- `Scene::with_galaxies(per_sensor_galaxies)` builder method
- `Renderer::from_stars_and_galaxies(stars, galaxies, sat)` — new constructor; existing `from_stars` becomes a thin wrapper passing empty galaxies

Both source kinds splat into the same 1-second base image, scaled by exposure, then Poisson-sampled once. INVARIANTS §1 (single Poisson per frame on combined mean) holds for galaxies because they share the star buffer.

## Tests (physics-anchored)

- **`end_to_end_flux_roundtrip_through_renderer`**: build a Scene with no stars and one well-resolved galaxy (θ_eff = 5″, 0.1″/pix → 50 px per θ_eff), render with `apply_poisson=false`, sum the resulting electron buffer, verify it matches `flux_rate × aperture × exposure` within the documented 95-102% truncation budget. The most direct check that SersicSplat normalisation, renderer scaling, and the apply_poisson short-circuit all compose correctly.
- **`variance_equals_mean_poisson_identity`** (`#[ignore]` for cost): 200 trials, accumulate per-pixel mean and variance, verify `var/mean ≈ 1.0` averaged over high-flux pixels (Poisson identity). Anchors INVARIANTS §1 against any future regression that introduces per-source or per-stamp Poisson sampling.

294/294 simulator lib tests pass; 1 ignored (the Poisson MC test). `cargo fmt` + `cargo clippy -- -D warnings` clean.

## Deferred

- **Motion-blur catalog galaxy support**: needs a catalog-level galaxy type for per-stamp re-projection, which depends on the NSA loader. The motion_blur path's `splat_galaxy` method (added in #66) is in place; just needs a `Vec<GalaxyEntry>` plumbed through `RenderScene`/`FramePlan`.
- **NSA catalog ingestion + CLI flag**: blocked on starfield 0.12 publishing to crates.io (or coordinating cfl-foundations dep bumps). Tried a `[patch.crates-io]` override but the patched version mismatch and the dual git-source resolution defeated it. Once published, the CLI flag is straightforward.

Fourth of the galaxy-rendering PR sequence.