### PR TITLE
CLAUDE.md: forbid backwards-pointing comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ scripts/install-hooks.sh
 
 ## Code Style Guidelines
 - **Comments**: Avoid comments that reference pre-change conditions (e.g., "Changed from X", "Previously Y"). Comments should describe current state only.
+- **No backwards-pointing comments.** Don't explain what code used to do, why it was changed, what's been removed, or what shim was added to work around something. Don't justify a dep pin by what it bumped from or a refactor by what it replaced. Commit messages and PR descriptions are the right place for change history; code comments describe what *is*, not what *was*. If a comment isn't self-justifying as documentation of the current state — delete it. Imagine if every dep pin and every refactor left four lines of exposition behind it.
 - **Imports**: Group in order: std, external crates, local modules. Alphabetize within groups.
   - Avoid using wildcard imports like `use crate::*` - always be explicit.
   - Import types to avoid fully qualified paths (e.g., `use std::collections::VecDeque;` instead of `std::collections::VecDeque` inline).


### PR DESCRIPTION
Generalises the existing one-liner ('Avoid comments that reference pre-change conditions') into a broader guidance: code comments describe what *is*, not what *was*.

Catches the pattern of leaving multi-line exposition behind every dep pin or refactor (\"this used to be X, bumped because Y\", \"removed Z's workaround\", etc.) — that history belongs in commit messages and PR descriptions where it's discoverable via git log, not lifecycle-bound to the file forever.

Pure docs change, no source modification.