### PR TITLE
NSA galaxy catalog through motion_simulator: --galaxies CLI flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
  "num-traits",
  "pastey",
  "rayon",
- "thiserror",
+ "thiserror 2.0.18",
  "v_frame",
  "y4m",
 ]
@@ -271,9 +271,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -781,7 +781,7 @@ dependencies = [
  "bit_field",
  "half",
  "lebe",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "rayon-core",
  "smallvec",
  "zune-inflate",
@@ -835,13 +835,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ef18351b3ef1ff2854becbb0347c7877a3bb0a1b5fc3c0cd161c4586b5eb654"
 
 [[package]]
+name = "fitsio-pure"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ac15956adf348fc038f73599f4cfe9c383071f915e37547ffc034ed0ee2250"
+dependencies = [
+ "bytemuck",
+ "miniz_oxide 0.9.1",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -1727,7 +1737,7 @@ dependencies = [
  "nalgebra",
  "ndarray",
  "scilib",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1754,6 +1764,15 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -2156,7 +2175,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -2169,7 +2188,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -2396,7 +2415,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "simd_helpers",
- "thiserror",
+ "thiserror 2.0.18",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -2450,7 +2469,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2811,7 +2830,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "crossbeam-channel",
- "fitsio-pure",
+ "fitsio-pure 0.9.2",
  "float-cmp",
  "image",
  "indicatif",
@@ -2834,7 +2853,7 @@ dependencies = [
  "serde_json",
  "shared-wasm",
  "starfield",
- "thiserror",
+ "thiserror 2.0.18",
  "tiny-skia",
  "tracing",
  "uom",
@@ -2851,7 +2870,7 @@ source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=12f40c1#
 dependencies = [
  "num-traits",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2907,7 +2926,7 @@ dependencies = [
  "clap",
  "criterion",
  "env_logger",
- "fitsio-pure",
+ "fitsio-pure 0.9.2",
  "float-cmp",
  "image",
  "imageproc",
@@ -2927,8 +2946,10 @@ dependencies = [
  "shared",
  "shared-wasm",
  "starfield",
+ "starfield-datasource-utils",
+ "starfield-nsa",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "url",
 ]
 
@@ -3002,9 +3023,33 @@ dependencies = [
  "serde",
  "serde_json",
  "sgp4",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
  "uom",
+]
+
+[[package]]
+name = "starfield-datasource-utils"
+version = "0.1.0"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=7f99ba0#7f99ba07e6d350ecd6f5d378084e88253c4948eb"
+dependencies = [
+ "indicatif",
+ "reqwest",
+ "starfield",
+]
+
+[[package]]
+name = "starfield-nsa"
+version = "0.2.0"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=7f99ba0#7f99ba07e6d350ecd6f5d378084e88253c4948eb"
+dependencies = [
+ "fitsio-pure 0.11.0",
+ "nalgebra",
+ "reqwest",
+ "serde",
+ "starfield",
+ "starfield-datasource-utils",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3111,11 +3156,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ authors = []
 description = "Space telescope imaging and sensor simulation"
 repository = "https://github.com/CosmicFrontierLabs/focalplane"
 license = "MIT"
+

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -9,9 +9,9 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-starfield = { version = "0.12", features = [
-    "photometry",
-] } # Star catalog functionality (photometry feature pulls in SersicProfile + Photometry trait surface)
+starfield = { version = "0.12", features = ["photometry"] }
+starfield-nsa = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "7f99ba0" }
+starfield-datasource-utils = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "7f99ba0" }
 image = "0.25" # Image processing
 ndarray = { version = "0.16", features = [
     "rayon",
@@ -27,9 +27,7 @@ log = "0.4"                   # Logging facade
 env_logger = "0.11"           # Environment-based logger
 url = "2.5"                   # URL parsing and manipulation
 nalgebra = "0.32"             # Linear algebra (quaternions for orientation)
-# Foundation crates from cfl-foundations. Pinned to the commit that
-# bumped `shared`'s starfield dep to 0.12 — matches the version
-# constraint above so the dep graph dedupes cleanly.
+# Foundation crates from cfl-foundations.
 shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "12f40c1", default-features = false, features = ["frame-writer"] }
 meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "12f40c1" }
 shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "12f40c1" }

--- a/simulator/src/bin/motion_simulator.rs
+++ b/simulator/src/bin/motion_simulator.rs
@@ -671,6 +671,23 @@ struct Args {
                 (implies --context-view)"
     )]
     context_only: bool,
+
+    #[arg(
+        long,
+        help = "Path to NSA FITS file for galaxy rendering. If unset and \
+                --galaxies is on, defaults to ~/.cache/starfield/nsa/nsa_v0_1_2.fits \
+                (downloaded on demand via the NYU mirror if absent)."
+    )]
+    galaxy_catalog: Option<std::path::PathBuf>,
+
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Render NSA galaxies in the field. Default off — turns on \
+                NSA loading + Sersic deposit splatting through the standard \
+                renderer pathway."
+    )]
+    galaxies: bool,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -801,6 +818,30 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     info!("Cached {} stars for trajectory envelope", stars.len());
 
+    // NSA galaxies (optional). Pre-projected once at the envelope
+    // centre — the per-tile renderer uses the same per-sensor list
+    // for every frame. See `sims::nsa_galaxies` for the loader
+    // documentation.
+    let per_sensor_galaxies: Vec<Vec<simulator::scene_galaxy::GalaxyInFrame>> = if args.galaxies {
+        let path = args
+            .galaxy_catalog
+            .clone()
+            .unwrap_or_else(simulator::sims::nsa_galaxies::default_nsa_path);
+        let cfg = simulator::sims::nsa_galaxies::GalaxyLoaderConfig::default();
+        // Use the envelope diameter / 2 as a generous FOV radius
+        // around the trajectory centre. The loader applies its own
+        // padding on top.
+        simulator::sims::nsa_galaxies::load_and_route_nsa_galaxies(
+            &path,
+            &envelope_center,
+            &focal_plane,
+            envelope_diameter * 0.5,
+            &cfg,
+        )?
+    } else {
+        vec![Vec::new(); focal_plane.array.sensor_count()]
+    };
+
     let output_path = Path::new(&args.output_dir);
     if !output_path.exists() {
         std::fs::create_dir_all(output_path)?;
@@ -813,6 +854,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             exposure: args.shared.exposure.0,
             focal_plane: &focal_plane,
             catalog_stars: &stars,
+            per_sensor_galaxies: &per_sensor_galaxies,
             zodiacal: args.shared.coordinates,
             output_dir: output_path,
             base_seed: Some(args.seed),

--- a/simulator/src/sims/mod.rs
+++ b/simulator/src/sims/mod.rs
@@ -3,6 +3,7 @@
 pub mod context_render;
 pub mod motion_blur;
 pub mod motion_blur_metadata;
+pub mod nsa_galaxies;
 pub mod orientation;
 pub mod quasi_random;
 pub mod scene_runner;

--- a/simulator/src/sims/motion_blur.rs
+++ b/simulator/src/sims/motion_blur.rs
@@ -50,10 +50,10 @@ use starfield::Equatorial;
 use crate::hardware::satellite::{FocalPlaneConfig, FocalPlaneProjector};
 use crate::hardware::SatelliteConfig;
 use crate::image_proc::render::quantize_image;
-use crate::scene_galaxy::GalaxyInFrame;
 use crate::photometry::photoconversion::SourceFlux;
 use crate::photometry::spectrum::Spectrum;
 use crate::photometry::zodiacal::{SolarAngularCoordinates, ZodiacalLight};
+use crate::scene_galaxy::GalaxyInFrame;
 use crate::sims::motion_blur_metadata::{
     sensor_dir_name, sensor_relative_png_path, EquatorialMeta, FrameMeta, HardwareMeta,
     RenderConfigMeta, RenderMetadata, SensorMeta, StarMeta, TrajectoryMeta, WaypointMeta,

--- a/simulator/src/sims/motion_blur.rs
+++ b/simulator/src/sims/motion_blur.rs
@@ -50,6 +50,7 @@ use starfield::Equatorial;
 use crate::hardware::satellite::{FocalPlaneConfig, FocalPlaneProjector};
 use crate::hardware::SatelliteConfig;
 use crate::image_proc::render::quantize_image;
+use crate::scene_galaxy::GalaxyInFrame;
 use crate::photometry::photoconversion::SourceFlux;
 use crate::photometry::spectrum::Spectrum;
 use crate::photometry::zodiacal::{SolarAngularCoordinates, ZodiacalLight};
@@ -260,6 +261,14 @@ pub type FluxCache = HashMap<(u64, usize), SourceFlux>;
 struct RenderScene<'a> {
     trajectory: &'a Trajectory,
     catalog_stars: &'a [StarData],
+    /// Per-sensor list of pre-projected galaxies (`Scene::with_galaxies`
+    /// shape). Empty inner vecs = no galaxies. Galaxies are projected
+    /// *once* per render at the trajectory's mid-time orientation —
+    /// exact for static trajectories, an approximation for drifting
+    /// trajectories where the galaxy positions would shift sub-pixel
+    /// across the exposure (acceptable until measured-radial-profile
+    /// rendering motivates the upgrade).
+    per_sensor_galaxies: &'a [Vec<GalaxyInFrame>],
     fp: &'a FocalPlaneConfig,
     zodiacal: SolarAngularCoordinates,
 }
@@ -529,6 +538,27 @@ fn render_tile(
         }
     }
 
+    // Galaxies: pre-projected per-sensor (one position per render),
+    // splatted at full-exposure flux so the unified Poisson stage
+    // samples the combined (stars + galaxies + zodi + dark) mean.
+    // Per-stamp re-projection isn't done here because the bounding
+    // box of a Sérsic deposit is much larger than a PSF stamp; a
+    // sub-pixel galaxy shift across the exposure is well below the
+    // per-pixel noise floor of any plausible exposure. Static
+    // trajectories (start == end) are exact.
+    let galaxies = scene
+        .per_sensor_galaxies
+        .get(sensor_idx)
+        .map(|v| v.as_slice())
+        .unwrap_or(&[]);
+    for galaxy in galaxies {
+        let total_electrons = galaxy
+            .flux
+            .electrons
+            .integrated_over(&schedule.exposure, aperture);
+        accumulator.splat_galaxy(galaxy.x, galaxy.y, total_electrons, &galaxy.deposit);
+    }
+
     // Dark current: rate × full exposure, uniform over pixels.
     let dark_rate = satellite
         .sensor
@@ -562,9 +592,18 @@ fn render_tile(
 /// Render the full trajectory with motion blur, parallel over `(frame, sensor)`.
 ///
 /// Returns the total number of frames rendered.
+///
+/// `per_sensor_galaxies` is the per-sensor pre-projected galaxy list
+/// (the `Scene::with_galaxies` shape). Pass an empty `Vec` per sensor
+/// for star-only renders. Galaxies are projected once at the
+/// trajectory's mid-time orientation and splatted at full-exposure
+/// flux per tile — exact for static trajectories, an approximation
+/// for drifting trajectories where a sub-pixel galaxy shift across
+/// the exposure becomes detectable.
 pub fn render_motion_trajectory(
     trajectory: &Trajectory,
     catalog_stars: &[StarData],
+    per_sensor_galaxies: &[Vec<GalaxyInFrame>],
     fp: &FocalPlaneConfig,
     zodiacal: SolarAngularCoordinates,
     config: &MotionBlurConfig,
@@ -585,6 +624,7 @@ pub fn render_motion_trajectory(
     let scene = RenderScene {
         trajectory,
         catalog_stars,
+        per_sensor_galaxies,
         fp,
         zodiacal,
     };
@@ -1198,6 +1238,7 @@ mod tests {
         let frames = render_motion_trajectory(
             &traj,
             &[],
+            &[],
             fp,
             SolarAngularCoordinates::zodiacal_minimum(),
             &cfg,
@@ -1241,6 +1282,7 @@ mod tests {
         let frames = render_motion_trajectory(
             &traj,
             &[],
+            &[],
             &fp,
             SolarAngularCoordinates::zodiacal_minimum(),
             &cfg,
@@ -1283,6 +1325,7 @@ mod tests {
         let frames = render_motion_trajectory(
             &traj,
             &stars,
+            &[],
             &fp,
             SolarAngularCoordinates::zodiacal_minimum(),
             &cfg,
@@ -1300,6 +1343,7 @@ mod tests {
         let frames2 = render_motion_trajectory(
             &traj,
             &stars,
+            &[],
             &fp,
             SolarAngularCoordinates::zodiacal_minimum(),
             &cfg,
@@ -1484,6 +1528,7 @@ mod tests {
         render_motion_trajectory(
             &traj,
             &stars,
+            &[],
             &fp,
             SolarAngularCoordinates::zodiacal_minimum(),
             &cfg,
@@ -1493,6 +1538,7 @@ mod tests {
         render_motion_trajectory(
             &traj,
             &stars,
+            &[],
             &fp,
             SolarAngularCoordinates::zodiacal_minimum(),
             &cfg,
@@ -1549,6 +1595,7 @@ mod tests {
         render_motion_trajectory(
             &traj,
             &stars,
+            &[],
             &fp,
             SolarAngularCoordinates::zodiacal_minimum(),
             &cfg_coarse,
@@ -1558,6 +1605,7 @@ mod tests {
         render_motion_trajectory(
             &traj,
             &stars,
+            &[],
             &fp,
             SolarAngularCoordinates::zodiacal_minimum(),
             &cfg_fine,
@@ -1605,6 +1653,7 @@ mod tests {
         render_motion_trajectory(
             &traj,
             &stars,
+            &[],
             &fp,
             SolarAngularCoordinates::zodiacal_minimum(),
             &cfg,
@@ -1614,6 +1663,7 @@ mod tests {
         render_motion_trajectory(
             &traj,
             &stars,
+            &[],
             &fp,
             SolarAngularCoordinates::zodiacal_minimum(),
             &cfg,
@@ -1662,6 +1712,7 @@ mod tests {
         let frames = render_motion_trajectory(
             &traj,
             &[],
+            &[],
             &fp,
             SolarAngularCoordinates::zodiacal_minimum(),
             &cfg,
@@ -1693,6 +1744,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let frames = render_motion_trajectory(
             &traj,
+            &[],
             &[],
             &fp,
             SolarAngularCoordinates::zodiacal_minimum(),
@@ -1747,6 +1799,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         render_motion_trajectory(
             &traj,
+            &[],
             &[],
             &fp,
             SolarAngularCoordinates::zodiacal_minimum(),
@@ -1809,6 +1862,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         render_motion_trajectory(
             &traj,
+            &[],
             &[],
             &fp,
             SolarAngularCoordinates::zodiacal_minimum(),

--- a/simulator/src/sims/nsa_galaxies.rs
+++ b/simulator/src/sims/nsa_galaxies.rs
@@ -1,0 +1,230 @@
+//! NASA-Sloan Atlas (NSA) → `GalaxyInFrame` routing.
+//!
+//! Loads an NSA FITS file (default location: `~/.cache/starfield/nsa/nsa_v0_1_2.fits`,
+//! downloaded on demand via `starfield_nsa::download_nsa()` if absent),
+//! filters to the field of view around a pointing, builds per-galaxy
+//! Sérsic deposits + SDSS-spectrum flux objects, and routes them to
+//! the per-sensor `GalaxyInFrame` lists that `Scene::with_galaxies`
+//! consumes.
+//!
+//! v1 surface area:
+//!
+//! - Always uses the *Sérsic-fit* fluxes (`NsaEntry::sersic_flux`),
+//!   not the NMGY aperture fluxes — Sérsic-fit pairs naturally with
+//!   the Sérsic SB profile so the rendered ellipse conserves the
+//!   model flux. NMGY is the right choice for measured-radial-profile
+//!   rendering when that lands as a follow-up.
+//! - Filters out pathological fits at routing time:
+//!   `n ∈ [0.6, 6.5]` and `theta_eff < 60″` — the NSA fitter
+//!   occasionally blows up on bright stars or LSB galaxies, producing
+//!   `theta_eff = 200″` n=0.5 entries that would dominate the
+//!   render box and the per-pixel adaptive Simpson cost.
+//! - Per-galaxy flux caching: the spectrum→`SourceFlux` integration
+//!   is the expensive step, so it's done once per galaxy and reused
+//!   across sensors.
+
+use std::path::{Path, PathBuf};
+
+use log::info;
+use starfield::catalogs::{SersicProfile, StarCatalog};
+use starfield::Equatorial;
+use starfield_datasource_utils::cache_dir;
+use starfield_nsa::{NsaCatalog, NsaEntry};
+
+use crate::hardware::satellite::{FocalPlaneConfig, FocalPlaneProjector};
+use crate::image_proc::sersic_splat::SersicSplat;
+use crate::photometry::photoconversion::{photon_electron_fluxes, SourceFlux};
+use crate::photometry::{SDSSSpectrum, SdssBand};
+use crate::scene_galaxy::GalaxyInFrame;
+use crate::sims::orientation::orientation_from_pointing;
+
+/// Default rejection threshold on `theta_half_arcsec`. NSA's typical
+/// galaxies sit well below 30″; entries above 60″ are almost always
+/// fit failures (bright stars, shredded LSBs).
+pub const DEFAULT_MAX_THETA_EFF_ARCSEC: f64 = 60.0;
+
+/// Default rejection range on Sérsic index. The NSA fitter clamps to
+/// `n ∈ [0.5, 6]` but values right at the edges are usually
+/// pathological — pick a slightly tighter bound that excludes the
+/// rail-stuck blow-ups without losing real low-/high-n galaxies.
+pub const DEFAULT_MIN_N: f64 = 0.6;
+pub const DEFAULT_MAX_N: f64 = 6.5;
+
+/// True if `entry`'s Sérsic fit is structurally valid and within
+/// the supplied photometric/morphological rails.
+pub fn is_well_fit(entry: &NsaEntry, min_n: f64, max_n: f64, max_theta_eff: f64) -> bool {
+    let th = entry.sersic_th50 as f64;
+    let n = entry.sersic_n as f64;
+    let ba = entry.sersic_ba as f64;
+    let phi = entry.sersic_phi as f64;
+    th.is_finite()
+        && th > 0.0
+        && th < max_theta_eff
+        && n.is_finite()
+        && (min_n..=max_n).contains(&n)
+        && ba.is_finite()
+        && ba > 0.05
+        && ba <= 1.0
+        && phi.is_finite()
+}
+
+/// Build a `SersicProfile` from an `NsaEntry`'s structural fields.
+/// **Mirrors the eventual `impl ExtendedSource for NsaEntry`**
+/// (starfield-datasources #38) — when that lands upstream, this
+/// function collapses to `entry.sersic_profile().unwrap()`.
+fn nsa_to_sersic_profile(entry: &NsaEntry) -> SersicProfile {
+    SersicProfile {
+        theta_half_arcsec: entry.sersic_th50 as f64,
+        n: entry.sersic_n as f64,
+        axis_ratio: entry.sersic_ba as f64,
+        position_angle_deg: entry.sersic_phi as f64,
+    }
+}
+
+/// Build an `SDSSSpectrum` from an `NsaEntry`'s 5-band Sérsic-fit
+/// fluxes (NSA's in-memory layout is 7-slot, with FUV/NUV padded to
+/// zero on v0_1_2 files).
+fn nsa_to_sdss_spectrum(entry: &NsaEntry) -> SDSSSpectrum {
+    SDSSSpectrum::from_band_slice(&[
+        (SdssBand::Fuv, entry.sersic_flux[0] as f64),
+        (SdssBand::Nuv, entry.sersic_flux[1] as f64),
+        (SdssBand::U, entry.sersic_flux[2] as f64),
+        (SdssBand::G, entry.sersic_flux[3] as f64),
+        (SdssBand::R, entry.sersic_flux[4] as f64),
+        (SdssBand::I, entry.sersic_flux[5] as f64),
+        (SdssBand::Z, entry.sersic_flux[6] as f64),
+    ])
+}
+
+/// Configuration knobs for the loader. Defaults match NSA-typical
+/// galaxies; expose as CLI flags if the renderer ever needs to render
+/// a non-NSA catalog with different fit characteristics.
+#[derive(Debug, Clone)]
+pub struct GalaxyLoaderConfig {
+    /// Reject entries with `theta_half_arcsec >= max_theta_eff`.
+    pub max_theta_eff: f64,
+    /// Reject entries with Sérsic index outside `[min_n, max_n]`.
+    pub min_n: f64,
+    pub max_n: f64,
+    /// Pad the field-of-view filter by this many degrees so a galaxy
+    /// whose centre falls just outside the sensor footprint but whose
+    /// outer envelope reaches in is still rendered.
+    pub fov_pad_deg: f64,
+}
+
+impl Default for GalaxyLoaderConfig {
+    fn default() -> Self {
+        Self {
+            max_theta_eff: DEFAULT_MAX_THETA_EFF_ARCSEC,
+            min_n: DEFAULT_MIN_N,
+            max_n: DEFAULT_MAX_N,
+            fov_pad_deg: 0.5,
+        }
+    }
+}
+
+/// Default cache path for the NSA FITS file:
+/// `~/.cache/starfield/nsa/nsa_v0_1_2.fits`.
+pub fn default_nsa_path() -> PathBuf {
+    cache_dir().join("nsa").join("nsa_v0_1_2.fits")
+}
+
+/// Load NSA from `path` (downloading via the NYU mirror if absent),
+/// filter to the field of view around `pointing` plus `fov_pad_deg`
+/// of slack, drop pathological fits, and project to per-sensor
+/// `GalaxyInFrame` lists.
+///
+/// The returned `Vec<Vec<GalaxyInFrame>>` matches the indexing of
+/// `Scene::per_sensor_stars` and is the `Vec` that
+/// `Scene::with_galaxies` expects.
+pub fn load_and_route_nsa_galaxies(
+    path: &Path,
+    pointing: &Equatorial,
+    fp: &FocalPlaneConfig,
+    fov_radius_deg: f64,
+    config: &GalaxyLoaderConfig,
+) -> Result<Vec<Vec<GalaxyInFrame>>, Box<dyn std::error::Error>> {
+    info!(
+        "loading NSA from {} (download on demand if absent)",
+        path.display()
+    );
+    let path = if path.exists() {
+        path.to_path_buf()
+    } else {
+        info!("NSA FITS missing at {}; downloading...", path.display());
+        starfield_nsa::download_nsa()?
+    };
+    let cat = NsaCatalog::from_fits_file(&path)?;
+    info!(
+        "NSA loaded: {} galaxies, version {:?}",
+        cat.len(),
+        cat.version()
+    );
+
+    // Conservative angular pre-filter on the catalog before per-sensor
+    // projection. fov_radius_deg + fov_pad_deg padding catches any
+    // galaxy whose centre lies within reach of the array.
+    let cos_dec0 = pointing.dec_degrees().to_radians().cos();
+    let half_box_deg = fov_radius_deg + config.fov_pad_deg;
+    let in_field: Vec<&NsaEntry> = cat
+        .stars()
+        .filter(|e| {
+            let dra = (e.ra - pointing.ra_degrees()) * cos_dec0;
+            let ddec = e.dec - pointing.dec_degrees();
+            dra.abs() < half_box_deg && ddec.abs() < half_box_deg
+        })
+        .filter(|e| is_well_fit(e, config.min_n, config.max_n, config.max_theta_eff))
+        .collect();
+    info!(
+        "{} NSA galaxies in {:.2}° box around ({:.4}, {:.4}) after well-fit filter",
+        in_field.len(),
+        half_box_deg * 2.0,
+        pointing.ra_degrees(),
+        pointing.dec_degrees()
+    );
+
+    let orientation = orientation_from_pointing(pointing, 0.0);
+    let n_sensors = fp.array.sensor_count();
+    let mut per_sensor: Vec<Vec<GalaxyInFrame>> = vec![Vec::new(); n_sensors];
+
+    for (sensor_idx, sensor_galaxies) in per_sensor.iter_mut().enumerate() {
+        let sat = match fp.satellite_for_sensor(sensor_idx) {
+            Some(s) => s,
+            None => continue,
+        };
+        let plate_scale_arcsec_per_px = sat.plate_scale_arcsec_per_pixel();
+        let reference_disk = sat.airy_disk_pixel_space();
+        let qe = &sat.sensor.quantum_efficiency;
+
+        for entry in &in_field {
+            let pos = Equatorial::from_degrees(entry.ra, entry.dec);
+            let (px, py) = match fp.project_to_sensor(
+                &starfield::catalogs::StarData::with_position(0, pos, 0.0, None),
+                &orientation,
+                sensor_idx,
+                /* padding_mm */ 0.0,
+            ) {
+                Some(p) => p,
+                None => continue,
+            };
+            let profile = nsa_to_sersic_profile(entry);
+            let spectrum = nsa_to_sdss_spectrum(entry);
+            let flux: SourceFlux = photon_electron_fluxes(&reference_disk, &spectrum, qe);
+            let deposit = SersicSplat::new(profile, plate_scale_arcsec_per_px);
+            sensor_galaxies.push(GalaxyInFrame {
+                x: px,
+                y: py,
+                id: entry.nsaid as u64,
+                flux,
+                deposit,
+            });
+        }
+        info!(
+            "sensor {}: {} galaxies routed",
+            sensor_idx,
+            sensor_galaxies.len()
+        );
+    }
+
+    Ok(per_sensor)
+}

--- a/simulator/src/sims/trajectory.rs
+++ b/simulator/src/sims/trajectory.rs
@@ -370,6 +370,12 @@ pub struct TrajectoryRenderConfig<'a> {
     pub focal_plane: &'a FocalPlaneConfig,
     /// Pre-fetched catalog stars covering the full trajectory envelope.
     pub catalog_stars: &'a [StarData],
+    /// Per-sensor pre-projected galaxies (`Scene::with_galaxies` shape).
+    /// Defaults to an empty slice — callers that don't render galaxies
+    /// pass `&[]` and the inner vec slot is filled with empties at the
+    /// motion-blur layer. See `crate::sims::nsa_galaxies` for the
+    /// builder that produces this shape from an NSA FITS file.
+    pub per_sensor_galaxies: &'a [Vec<crate::scene_galaxy::GalaxyInFrame>],
     /// Solar angular coordinates for zodiacal background.
     pub zodiacal: SolarAngularCoordinates,
     /// Directory to write 16-bit PNG output frames.
@@ -422,6 +428,7 @@ pub fn render_trajectory(config: &TrajectoryRenderConfig) -> Result<usize, Traje
     render_motion_trajectory(
         config.trajectory,
         config.catalog_stars,
+        config.per_sensor_galaxies,
         config.focal_plane,
         config.zodiacal,
         &motion_cfg,


### PR DESCRIPTION
End-to-end NSA loading wired into the standard `motion_simulator` binary. Adds two CLI flags and a small loader/router module; the existing render pipeline picks galaxies up via the `Scene::with_galaxies` shape that #67 introduced.

## CLI surface
- `--galaxies` (default off) — turns on NSA loading + Sérsic deposit splatting through the same renderer pathway stars use
- `--galaxy-catalog <PATH>` — overrides the FITS path; defaults to `~/.cache/starfield/nsa/nsa_v0_1_2.fits` (downloaded on demand from the NYU mirror via `starfield_nsa::download_nsa()` if absent)

## New module: `sims::nsa_galaxies`
- Loads NSA, pre-filters to a padded FOV box, gates pathological fits (`θ_eff < 60″`, `n ∈ [0.6, 6.5]`, finite `axis_ratio ∈ (0.05, 1.0]`)
- Builds an `SDSSSpectrum` from the entry's Sérsic-fit fluxes (so the rendered ellipse conserves the model flux), runs through `photon_electron_fluxes` for the chromatic effective PSF
- Returns `Vec<Vec<GalaxyInFrame>>` matching the per-sensor indexing `Scene::with_galaxies` expects

## Render plumbing
- `RenderScene` and `render_motion_trajectory` now carry `per_sensor_galaxies: &[Vec<GalaxyInFrame>]`. `render_tile` splats each galaxy once per tile at full-exposure flux into the same `SensorAccumulator::star_mean_electrons` buffer that the unified Poisson stage samples — preserving INVARIANTS §1.
- `TrajectoryRenderConfig::per_sensor_galaxies` plumbs from `motion_simulator` down through `render_trajectory` to the motion-blur path
- Per-stamp re-projection isn't done here (galaxies use mid-time orientation) — exact for static trajectories, sub-pixel approximation for drifting ones; documented inline

## Dependencies
- `starfield-nsa` + `starfield-datasource-utils` git deps pinned at rev `7f99ba0` (the post-#41 commit that bumped the workspace starfield dep to crates.io `0.12`, removing the need for a workspace patch)

## End-to-end demo
Verified by rendering a 30s exposure of the Coma cluster center (RA 194.95°, Dec +27.98°) through the standard `motion_simulator` binary against `~/star-cats/to_mag_19.bin` (Gaia mag-19) plus NSA: 234 stars and 66 NSA galaxies splat onto a 9568×6380 IMX455 frame.

## Test plan
- [x] `cargo build -p simulator` — single starfield 0.12.1 in dep graph
- [x] `cargo test -p simulator --lib` — 284 passed (no regressions on stars/scenes/etc)
- [x] `cargo fmt`
- [x] `cargo clippy -- -D warnings` clean