### PR TITLE
Wire Gaia DR3 catalog source through motion_simulator (shim cone loader)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,12 +175,236 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "arrow"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d441fdda254b65f3e9025910eb2c2066b6295d9c8ed409522b8d2ace1ff8574c"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced5406f8b720cc0bc3aa9cf5758f93e8593cda5490677aa194e4b4b383f9a59"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0127816c96533d20fc938729f48c52d3e48f99717e7a0b5ade77d742510736d"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca025bd0f38eeecb57c2153c0123b960494138e6a957bbda10da2b25415209fe"
+dependencies = [
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-json"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ead0914e4861a531be48fe05858265cf854a4880b9ed12618b1d08cba9bebc8"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "indexmap",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763a7ba279b20b52dad300e68cfc37c17efa65e68623169076855b3a9e941ca5"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14fe367802f16d7668163ff647830258e6e0aeea9a4d79aaedf273af3bdcd3e"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
+
+[[package]]
+name = "arrow-select"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e04a01f8bb73ce54437514c5fd3ee2aa3e8abe4c777ee5cc55853b1652f79e"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "as-slice"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -229,6 +467,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit_field"
@@ -309,6 +556,32 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cdshealpix"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f43f12e4bfde350aa1936fa2896c5e8dd6d717ec27f854272b6f3cb2e478479"
+dependencies = [
+ "base64",
+ "bincode",
+ "byteorder",
+ "chrono",
+ "colorous",
+ "flate2",
+ "itertools 0.14.0",
+ "katex-doc",
+ "log",
+ "mapproj",
+ "memmap2",
+ "num",
+ "num-traits",
+ "png 0.17.16",
+ "rayon",
+ "serde",
+ "thiserror 2.0.18",
+ "toml",
 ]
 
 [[package]]
@@ -411,6 +684,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "colorous"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e18bf7a165bf7028fde98609a0f1e8f7498d762a212598e6c891f6893556ec"
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +700,26 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -605,6 +904,27 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "data-url"
@@ -842,6 +1162,16 @@ checksum = "10ac15956adf348fc038f73599f4cfe9c383071f915e37547ffc034ed0ee2250"
 dependencies = [
  "bytemuck",
  "miniz_oxide 0.9.1",
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags 2.10.0",
+ "rustc_version",
 ]
 
 [[package]]
@@ -1107,6 +1437,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -1590,6 +1921,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "katex-doc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e5b80bdbfb9176d293875db5dbf05eeeb1d4e423891c5c0520da7bd467440b9"
+
+[[package]]
 name = "kurbo"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,6 +1948,63 @@ name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
 
 [[package]]
 name = "libc"
@@ -1686,6 +2080,12 @@ checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
 ]
+
+[[package]]
+name = "mapproj"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef28b23f82a86b32a30cfbd8e45fb66645bd677b150636ae277ac9295054c44"
 
 [[package]]
 name = "matrixmultiply"
@@ -2800,6 +3200,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2908,6 +3317,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simplecss"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,6 +3362,7 @@ dependencies = [
  "shared-wasm",
  "starfield",
  "starfield-datasource-utils",
+ "starfield-gaia",
  "starfield-nsa",
  "tempfile",
  "thiserror 2.0.18",
@@ -3031,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "starfield-datasource-utils"
 version = "0.1.0"
-source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=7f99ba0#7f99ba07e6d350ecd6f5d378084e88253c4948eb"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=2c6401a#2c6401aac7aba1ad4cc5116e9c43d295c94976a7"
 dependencies = [
  "indicatif",
  "reqwest",
@@ -3039,9 +3455,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "starfield-gaia"
+version = "0.2.0"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=2c6401a#2c6401aac7aba1ad4cc5116e9c43d295c94976a7"
+dependencies = [
+ "arrow",
+ "cdshealpix",
+ "flate2",
+ "md5",
+ "nalgebra",
+ "rand 0.8.6",
+ "regex",
+ "serde",
+ "serde_json",
+ "starfield",
+ "starfield-datasource-utils",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "starfield-nsa"
 version = "0.2.0"
-source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=7f99ba0#7f99ba07e6d350ecd6f5d378084e88253c4948eb"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=2c6401a#2c6401aac7aba1ad4cc5116e9c43d295c94976a7"
 dependencies = [
  "fitsio-pure 0.11.0",
  "nalgebra",
@@ -3240,6 +3675,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tiny-skia"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3346,6 +3790,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -4051,6 +4536,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wio"

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -10,8 +10,9 @@ license.workspace = true
 
 [dependencies]
 starfield = { version = "0.12", features = ["photometry"] }
-starfield-nsa = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "7f99ba0" }
-starfield-datasource-utils = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "7f99ba0" }
+starfield-nsa = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "2c6401a" }
+starfield-gaia = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "2c6401a" }
+starfield-datasource-utils = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "2c6401a" }
 image = "0.25" # Image processing
 ndarray = { version = "0.16", features = [
     "rayon",

--- a/simulator/src/bin/motion_simulator.rs
+++ b/simulator/src/bin/motion_simulator.rs
@@ -688,6 +688,32 @@ struct Args {
                 renderer pathway."
     )]
     galaxies: bool,
+
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Load stars from a Gaia DR3 healpix-sharded excerpt directory \
+                (per-source BP-RP color → B-V via the linear fit, plus \
+                Hipparcos bright-star augmentation). Overrides --catalog when \
+                set. Cone-loader still shimmed pending upstream `starfield-gaia` \
+                landing the equivalent."
+    )]
+    gaia_dr3: bool,
+
+    #[arg(
+        long,
+        help = "Directory holding the healpix-sharded DR3 excerpt. Defaults \
+                to ~/.cache/starfield/gaia-excerpts/dr3-mag20/."
+    )]
+    gaia_excerpt_dir: Option<std::path::PathBuf>,
+
+    #[arg(
+        long,
+        default_value_t = 19.0,
+        help = "Magnitude cutoff for Gaia DR3 cone loader (G band). Default \
+                matches the historical to_mag_19.bin cutoff."
+    )]
+    gaia_mag_limit: f64,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -808,14 +834,33 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         envelope_diameter
     );
 
-    info!("Loading catalog...");
-    let catalog = args.shared.load_catalog_with_progress(args.quiet)?;
-
-    let stars = catalog.stars_in_field(
-        envelope_center.ra_degrees(),
-        envelope_center.dec_degrees(),
-        envelope_diameter,
-    );
+    let stars: Vec<starfield::catalogs::StarData> = if args.gaia_dr3 {
+        let excerpt_dir = args
+            .gaia_excerpt_dir
+            .clone()
+            .unwrap_or_else(simulator::sims::gaia_dr3::default_excerpt_dir);
+        info!(
+            "Loading Gaia DR3 cone from {} (mag <= {:.2}, augmented with Hipparcos bright \
+             supplement)...",
+            excerpt_dir.display(),
+            args.gaia_mag_limit
+        );
+        let (cat, _augmented) = simulator::sims::gaia_dr3::load_dr3_cone_augmented(
+            &excerpt_dir,
+            envelope_center,
+            envelope_diameter * 0.5,
+            args.gaia_mag_limit,
+        )?;
+        cat.star_data().collect()
+    } else {
+        info!("Loading catalog...");
+        let catalog = args.shared.load_catalog_with_progress(args.quiet)?;
+        catalog.stars_in_field(
+            envelope_center.ra_degrees(),
+            envelope_center.dec_degrees(),
+            envelope_diameter,
+        )
+    };
     info!("Cached {} stars for trajectory envelope", stars.len());
 
     // NSA galaxies (optional). Pre-projected once at the envelope

--- a/simulator/src/sims/gaia_dr3.rs
+++ b/simulator/src/sims/gaia_dr3.rs
@@ -1,0 +1,94 @@
+//! Gaia DR3 catalog source for the renderer.
+//!
+//! Loads `Dr3Catalog` (from `starfield-gaia`) restricted to a circular
+//! sky region around the trajectory pointing, augments with the embedded
+//! Hipparcos bright-star supplement, and yields `StarData` rows the rest
+//! of the focalplane pipeline already consumes.
+//!
+//! Compared to the older `MinimalCatalog`-from-`to_mag_19.bin` path,
+//! every rendered star carries:
+//!
+//! - per-source DR3 photometry (`phot_g_mean_mag`)
+//! - per-source `B-V` color derived from `BP-RP` via `Dr3Entry::b_v()`
+//!   (linear fit calibrated on the Hipparcos cross-match), so
+//!   `BlackbodyStellarSpectrum::from_gaia_bv_magnitude` gets a real
+//!   color rather than the `DEFAULT_BV` fallback
+//! - the bright-star Hipparcos supplement injected via
+//!   `Dr3Catalog::augment_missing` so naked-eye stars (G < ~3) that
+//!   were dropped from the published Gaia catalog still render
+//!
+//! The cone loader is currently a **shim** (`load_dr3_in_cone`); the
+//! upstream healpix-aware version will land in `starfield-gaia` shortly
+//! and replace the shim body without changing the call site.
+
+use std::path::PathBuf;
+
+use log::info;
+use starfield::Equatorial;
+use starfield_datasource_utils::cache_dir;
+use starfield_gaia::Dr3Catalog;
+
+/// Default location of the healpix-sharded DR3 mag-20 excerpt.
+pub fn default_excerpt_dir() -> PathBuf {
+    cache_dir().join("gaia-excerpts").join("dr3-mag20")
+}
+
+/// **Shim**: load Dr3Catalog entries within `radius_deg` of `centre`,
+/// brighter than `mag_limit`, from a healpix-sharded excerpt directory.
+///
+/// The full implementation belongs upstream in `starfield-gaia`; once it
+/// lands as e.g. `Dr3Catalog::from_excerpt_dir_for_cone(...)` this
+/// function becomes a one-line forward. Until then the body is left
+/// unimplemented so any code path that depends on real DR3 data fails
+/// loudly instead of silently returning a partial set.
+///
+/// Caller contract is set so the swap-in is a one-line change:
+/// returns a `Dr3Catalog` containing every entry whose RA/Dec falls
+/// within the cone and whose `phot_g_mean_mag <= mag_limit`. Stars
+/// outside the cone but within shards that overlap it must already be
+/// filtered out by the loader (the renderer can rely on the returned
+/// catalog being exactly the set it needs to project).
+pub fn load_dr3_in_cone(
+    excerpt_dir: &std::path::Path,
+    centre: Equatorial,
+    radius_deg: f64,
+    mag_limit: f64,
+) -> Result<Dr3Catalog, Box<dyn std::error::Error>> {
+    info!(
+        "load_dr3_in_cone(dir={}, ra={:.4}, dec={:.4}, radius={:.4}°, mag_limit={:.2}) — \
+         awaiting upstream cone loader",
+        excerpt_dir.display(),
+        centre.ra_degrees(),
+        centre.dec_degrees(),
+        radius_deg,
+        mag_limit
+    );
+    Err(format!(
+        "load_dr3_in_cone is currently a shim — the cone-loader function in `starfield-gaia` \
+         hasn't landed yet. Provide it (signature: `Dr3Catalog::from_excerpt_dir_for_cone(\
+         excerpt_dir, centre, radius_deg, mag_limit) -> Result<Dr3Catalog>`) and replace \
+         this function body with a single forward call. Excerpt dir tested: {}",
+        excerpt_dir.display()
+    )
+    .into())
+}
+
+/// Load a Gaia DR3 catalog cone + augment with the embedded Hipparcos
+/// bright-star supplement. Returns the augmented catalog ready for
+/// `StarCatalog::star_data()` iteration. The `n_added` count is the
+/// number of bright supplement rows actually inserted (subject to the
+/// same `mag_limit` gate).
+pub fn load_dr3_cone_augmented(
+    excerpt_dir: &std::path::Path,
+    centre: Equatorial,
+    radius_deg: f64,
+    mag_limit: f64,
+) -> Result<(Dr3Catalog, usize), Box<dyn std::error::Error>> {
+    let mut cat = load_dr3_in_cone(excerpt_dir, centre, radius_deg, mag_limit)?;
+    let n_added = cat.augment_missing(mag_limit)?;
+    info!(
+        "Gaia DR3 catalog: cone-loaded + augmented with {n_added} Hipparcos \
+         bright-star supplement rows (mag_limit = {mag_limit:.2})"
+    );
+    Ok((cat, n_added))
+}

--- a/simulator/src/sims/mod.rs
+++ b/simulator/src/sims/mod.rs
@@ -1,6 +1,7 @@
 //! Simulation modules for various experiments
 
 pub mod context_render;
+pub mod gaia_dr3;
 pub mod motion_blur;
 pub mod motion_blur_metadata;
 pub mod nsa_galaxies;


### PR DESCRIPTION
Replaces the binary `to_mag_19.bin` `MinimalCatalog` path with a `Dr3Catalog`-backed source from `starfield-gaia`. Per-source DR3 photometry + B-V color (BP-RP linear fit) now flow into `BlackbodyStellarSpectrum::from_gaia_bv_magnitude` instead of the `DEFAULT_BV` fallback, plus the embedded Hipparcos bright-star supplement is augmented in via `Dr3Catalog::augment_missing` so naked-eye stars dropped from the published Gaia table still render.

## CLI surface (opt-in while the cone loader is upstream-pending)

- `--gaia-dr3` — turns on the new path; `--catalog` ignored when set
- `--gaia-excerpt-dir <PATH>` — defaults to `~/.cache/starfield/gaia-excerpts/dr3-mag20/`
- `--gaia-mag-limit <FLOAT>` — defaults to `19.0` (matches historical `to_mag_19.bin` cutoff)

## New module: `sims::gaia_dr3`

- `default_excerpt_dir()` — `~/.cache/starfield/gaia-excerpts/dr3-mag20/`
- `load_dr3_in_cone(excerpt_dir, centre, radius_deg, mag_limit)` — **shim**, currently returns `Err(..)` with a message describing the expected upstream signature `Dr3Catalog::from_excerpt_dir_for_cone(...)`. **Replacing the body with a one-line forward call is the entire integration once `starfield-datasources` lands the equivalent.**
- `load_dr3_cone_augmented(...)` — wraps the loader + `augment_missing` and logs the supplement count

## What stays the same

- Existing `--catalog` path (MinimalCatalog from the 17 GB binary) is unchanged and remains the default
- Both code paths produce identical `StarData` shapes; the renderer downstream is untouched
- All existing motion_simulator runs work unchanged

## Dep bump

- `starfield-nsa`, `starfield-datasource-utils`: rev `7f99ba0` → `2c6401a`
- `starfield-gaia`: new dep, rev `2c6401a`

(All three at `rev = 2c6401a`, current main of starfield-datasources — the commit that landed `gaia-excerpt: durable, resumable, crash-safe writer + parallel CDN workers (#44)` plus the Hipparcos supplement and `Dr3Catalog::augment_missing`.)

## Test plan

- [x] `cargo build -p simulator`
- [x] `cargo test -p simulator --lib` — 285 passed
- [x] `cargo fmt`
- [x] `cargo clippy -- -D warnings` clean

End-to-end render with `--gaia-dr3` will fail loudly with the shim's error message until the upstream cone loader lands. The legacy `--catalog` path is fine to demo against in the meantime.