### PR TITLE
gaia_dr3: hold a LazyLoadingCatalog<Dr3>; split open + materialize cone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "starfield-datasource-utils"
 version = "0.1.0"
-source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=2c6401a#2c6401aac7aba1ad4cc5116e9c43d295c94976a7"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=ea6ac48#ea6ac4824f5859d04914b70e7ab69b7c563b133f"
 dependencies = [
  "indicatif",
  "reqwest",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "starfield-gaia"
 version = "0.2.0"
-source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=2c6401a#2c6401aac7aba1ad4cc5116e9c43d295c94976a7"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=ea6ac48#ea6ac4824f5859d04914b70e7ab69b7c563b133f"
 dependencies = [
  "arrow",
  "cdshealpix",
@@ -3476,7 +3476,7 @@ dependencies = [
 [[package]]
 name = "starfield-nsa"
 version = "0.2.0"
-source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=2c6401a#2c6401aac7aba1ad4cc5116e9c43d295c94976a7"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=ea6ac48#ea6ac4824f5859d04914b70e7ab69b7c563b133f"
 dependencies = [
  "fitsio-pure 0.11.0",
  "nalgebra",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "starfield-datasource-utils"
 version = "0.1.0"
-source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=ea6ac48#ea6ac4824f5859d04914b70e7ab69b7c563b133f"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=efeac36#efeac36a907afd67639729e53916d38166dd133f"
 dependencies = [
  "indicatif",
  "reqwest",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "starfield-gaia"
 version = "0.2.0"
-source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=ea6ac48#ea6ac4824f5859d04914b70e7ab69b7c563b133f"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=efeac36#efeac36a907afd67639729e53916d38166dd133f"
 dependencies = [
  "arrow",
  "cdshealpix",
@@ -3476,7 +3476,7 @@ dependencies = [
 [[package]]
 name = "starfield-nsa"
 version = "0.2.0"
-source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=ea6ac48#ea6ac4824f5859d04914b70e7ab69b7c563b133f"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=efeac36#efeac36a907afd67639729e53916d38166dd133f"
 dependencies = [
  "fitsio-pure 0.11.0",
  "nalgebra",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "starfield-datasource-utils"
 version = "0.1.0"
-source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=efeac36#efeac36a907afd67639729e53916d38166dd133f"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=262051c#262051c9693a18bd35235711f4e8c0f8c0c4bf84"
 dependencies = [
  "indicatif",
  "reqwest",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "starfield-gaia"
 version = "0.2.0"
-source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=efeac36#efeac36a907afd67639729e53916d38166dd133f"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=262051c#262051c9693a18bd35235711f4e8c0f8c0c4bf84"
 dependencies = [
  "arrow",
  "cdshealpix",
@@ -3476,7 +3476,7 @@ dependencies = [
 [[package]]
 name = "starfield-nsa"
 version = "0.2.0"
-source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=efeac36#efeac36a907afd67639729e53916d38166dd133f"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=262051c#262051c9693a18bd35235711f4e8c0f8c0c4bf84"
 dependencies = [
  "fitsio-pure 0.11.0",
  "nalgebra",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -10,9 +10,9 @@ license.workspace = true
 
 [dependencies]
 starfield = { version = "0.12", features = ["photometry"] }
-starfield-nsa = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "ea6ac48" }
-starfield-gaia = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "ea6ac48" }
-starfield-datasource-utils = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "ea6ac48" }
+starfield-nsa = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "efeac36" }
+starfield-gaia = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "efeac36" }
+starfield-datasource-utils = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "efeac36" }
 image = "0.25" # Image processing
 ndarray = { version = "0.16", features = [
     "rayon",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -10,9 +10,9 @@ license.workspace = true
 
 [dependencies]
 starfield = { version = "0.12", features = ["photometry"] }
-starfield-nsa = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "2c6401a" }
-starfield-gaia = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "2c6401a" }
-starfield-datasource-utils = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "2c6401a" }
+starfield-nsa = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "ea6ac48" }
+starfield-gaia = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "ea6ac48" }
+starfield-datasource-utils = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "ea6ac48" }
 image = "0.25" # Image processing
 ndarray = { version = "0.16", features = [
     "rayon",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -10,9 +10,9 @@ license.workspace = true
 
 [dependencies]
 starfield = { version = "0.12", features = ["photometry"] }
-starfield-nsa = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "efeac36" }
-starfield-gaia = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "efeac36" }
-starfield-datasource-utils = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "efeac36" }
+starfield-nsa = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "262051c" }
+starfield-gaia = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "262051c" }
+starfield-datasource-utils = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "262051c" }
 image = "0.25" # Image processing
 ndarray = { version = "0.16", features = [
     "rayon",

--- a/simulator/src/bin/motion_simulator.rs
+++ b/simulator/src/bin/motion_simulator.rs
@@ -845,8 +845,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             excerpt_dir.display(),
             args.gaia_mag_limit
         );
-        let (cat, _augmented) = simulator::sims::gaia_dr3::load_dr3_cone_augmented(
-            &excerpt_dir,
+        let lazy = simulator::sims::gaia_dr3::open_dr3_excerpt(&excerpt_dir)?;
+        let (cat, _augmented) = simulator::sims::gaia_dr3::materialize_cone_augmented(
+            &lazy,
             envelope_center,
             envelope_diameter * 0.5,
             args.gaia_mag_limit,

--- a/simulator/src/sims/gaia_dr3.rs
+++ b/simulator/src/sims/gaia_dr3.rs
@@ -1,12 +1,14 @@
 //! Gaia DR3 catalog source for the renderer.
 //!
-//! Loads `Dr3Catalog` (from `starfield-gaia`) restricted to a circular
-//! sky region around the trajectory pointing, augments with the embedded
-//! Hipparcos bright-star supplement, and yields `StarData` rows the rest
-//! of the focalplane pipeline already consumes.
+//! Holds a `LazyLoadingCatalog<Dr3>` (from `starfield-gaia`) for the
+//! lifetime of a simulator run. The lazy handle reads only the excerpt
+//! directory's manifest at construction; each cone query opens just the
+//! HEALPix shards that intersect the cone, post-filters by exact
+//! great-circle distance, and augments with the embedded Hipparcos
+//! bright-star supplement so naked-eye stars dropped from the published
+//! Gaia catalog still render.
 //!
-//! Compared to the older `MinimalCatalog`-from-`to_mag_19.bin` path,
-//! every rendered star carries:
+//! Every rendered star carries:
 //!
 //! - per-source DR3 photometry (`phot_g_mean_mag`)
 //! - per-source `B-V` color derived from `BP-RP` via `Dr3Entry::b_v()`
@@ -14,64 +16,55 @@
 //!   `BlackbodyStellarSpectrum::from_gaia_bv_magnitude` gets a real
 //!   color rather than the `DEFAULT_BV` fallback
 //! - the bright-star Hipparcos supplement injected via
-//!   `Dr3Catalog::augment_missing` so naked-eye stars (G < ~3) that
-//!   were dropped from the published Gaia catalog still render
+//!   `Dr3Catalog::augment_missing` (G < ~3 stars dropped from Gaia)
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use log::info;
 use starfield::Equatorial;
 use starfield_datasource_utils::cache_dir;
-use starfield_gaia::{Cone, Dr3Catalog};
+use starfield_gaia::{Cone, Dr3, Dr3Catalog, GaiaCatalog, LazyLoadingCatalog};
 
 /// Default location of the healpix-sharded DR3 mag-20 excerpt.
 pub fn default_excerpt_dir() -> PathBuf {
     cache_dir().join("gaia-excerpts").join("dr3-mag20")
 }
 
-/// Load `Dr3Catalog` entries within `radius_deg` of `centre`, brighter
-/// than `mag_limit`, from a healpix-sharded excerpt directory.
-///
-/// Forwards to `Dr3Catalog::from_excerpt_dir_for_cone`, which uses the
-/// directory's manifest to identify the HEALPix level, computes the
-/// cone-coverage cells via cdshealpix, parses only those shard files,
-/// and post-filters rows by exact great-circle distance (HEALPix
-/// covering is conservative; boundary cells are trimmed back to the
-/// requested cone).
-pub fn load_dr3_in_cone(
-    excerpt_dir: &std::path::Path,
+/// Open a lazy view over a HEALPix-sharded DR3 excerpt directory. Reads
+/// only the manifest; no shard files are touched until a cone is
+/// requested. Errors out if the directory is not a one-file-per-cell
+/// HEALPix excerpt for the DR3 release.
+pub fn open_dr3_excerpt(
+    excerpt_dir: &Path,
+) -> Result<LazyLoadingCatalog<Dr3>, Box<dyn std::error::Error>> {
+    info!(
+        "Opening Gaia DR3 excerpt at {} (lazy; manifest only)",
+        excerpt_dir.display()
+    );
+    Ok(LazyLoadingCatalog::<Dr3>::open(excerpt_dir)?)
+}
+
+/// Materialize a cone from a lazy DR3 excerpt and augment it with the
+/// embedded Hipparcos bright-star supplement. Returns the augmented
+/// catalog ready for `StarCatalog::star_data()` iteration; the second
+/// element is the supplement-row count actually inserted (subject to
+/// `mag_limit`).
+pub fn materialize_cone_augmented(
+    lazy: &LazyLoadingCatalog<Dr3>,
     centre: Equatorial,
     radius_deg: f64,
     mag_limit: f64,
-) -> Result<Dr3Catalog, Box<dyn std::error::Error>> {
+) -> Result<(Dr3Catalog, usize), Box<dyn std::error::Error>> {
     info!(
-        "load_dr3_in_cone(dir={}, ra={:.4}, dec={:.4}, radius={:.4}°, mag_limit={:.2})",
-        excerpt_dir.display(),
+        "Materializing Gaia DR3 cone (ra={:.4}, dec={:.4}, radius={:.4}°, mag_limit={:.2})",
         centre.ra_degrees(),
         centre.dec_degrees(),
         radius_deg,
         mag_limit
     );
     let cone = Cone::from_degrees(centre.ra_degrees(), centre.dec_degrees(), radius_deg);
-    Ok(Dr3Catalog::from_excerpt_dir_for_cone(
-        excerpt_dir,
-        cone,
-        mag_limit,
-    )?)
-}
-
-/// Load a Gaia DR3 catalog cone + augment with the embedded Hipparcos
-/// bright-star supplement. Returns the augmented catalog ready for
-/// `StarCatalog::star_data()` iteration. The `n_added` count is the
-/// number of bright supplement rows actually inserted (subject to the
-/// same `mag_limit` gate).
-pub fn load_dr3_cone_augmented(
-    excerpt_dir: &std::path::Path,
-    centre: Equatorial,
-    radius_deg: f64,
-    mag_limit: f64,
-) -> Result<(Dr3Catalog, usize), Box<dyn std::error::Error>> {
-    let mut cat = load_dr3_in_cone(excerpt_dir, centre, radius_deg, mag_limit)?;
+    let mem = lazy.materialize_cone(cone, mag_limit)?;
+    let mut cat = Dr3Catalog(mem);
     let n_added = cat.augment_missing(mag_limit)?;
     info!(
         "Gaia DR3 catalog: cone-loaded + augmented with {n_added} Hipparcos \

--- a/simulator/src/sims/gaia_dr3.rs
+++ b/simulator/src/sims/gaia_dr3.rs
@@ -16,38 +16,28 @@
 //! - the bright-star Hipparcos supplement injected via
 //!   `Dr3Catalog::augment_missing` so naked-eye stars (G < ~3) that
 //!   were dropped from the published Gaia catalog still render
-//!
-//! The cone loader is currently a **shim** (`load_dr3_in_cone`); the
-//! upstream healpix-aware version will land in `starfield-gaia` shortly
-//! and replace the shim body without changing the call site.
 
 use std::path::PathBuf;
 
 use log::info;
 use starfield::Equatorial;
 use starfield_datasource_utils::cache_dir;
-use starfield_gaia::Dr3Catalog;
+use starfield_gaia::{Cone, Dr3Catalog};
 
 /// Default location of the healpix-sharded DR3 mag-20 excerpt.
 pub fn default_excerpt_dir() -> PathBuf {
     cache_dir().join("gaia-excerpts").join("dr3-mag20")
 }
 
-/// **Shim**: load Dr3Catalog entries within `radius_deg` of `centre`,
-/// brighter than `mag_limit`, from a healpix-sharded excerpt directory.
+/// Load `Dr3Catalog` entries within `radius_deg` of `centre`, brighter
+/// than `mag_limit`, from a healpix-sharded excerpt directory.
 ///
-/// The full implementation belongs upstream in `starfield-gaia`; once it
-/// lands as e.g. `Dr3Catalog::from_excerpt_dir_for_cone(...)` this
-/// function becomes a one-line forward. Until then the body is left
-/// unimplemented so any code path that depends on real DR3 data fails
-/// loudly instead of silently returning a partial set.
-///
-/// Caller contract is set so the swap-in is a one-line change:
-/// returns a `Dr3Catalog` containing every entry whose RA/Dec falls
-/// within the cone and whose `phot_g_mean_mag <= mag_limit`. Stars
-/// outside the cone but within shards that overlap it must already be
-/// filtered out by the loader (the renderer can rely on the returned
-/// catalog being exactly the set it needs to project).
+/// Forwards to `Dr3Catalog::from_excerpt_dir_for_cone`, which uses the
+/// directory's manifest to identify the HEALPix level, computes the
+/// cone-coverage cells via cdshealpix, parses only those shard files,
+/// and post-filters rows by exact great-circle distance (HEALPix
+/// covering is conservative; boundary cells are trimmed back to the
+/// requested cone).
 pub fn load_dr3_in_cone(
     excerpt_dir: &std::path::Path,
     centre: Equatorial,
@@ -55,22 +45,19 @@ pub fn load_dr3_in_cone(
     mag_limit: f64,
 ) -> Result<Dr3Catalog, Box<dyn std::error::Error>> {
     info!(
-        "load_dr3_in_cone(dir={}, ra={:.4}, dec={:.4}, radius={:.4}°, mag_limit={:.2}) — \
-         awaiting upstream cone loader",
+        "load_dr3_in_cone(dir={}, ra={:.4}, dec={:.4}, radius={:.4}°, mag_limit={:.2})",
         excerpt_dir.display(),
         centre.ra_degrees(),
         centre.dec_degrees(),
         radius_deg,
         mag_limit
     );
-    Err(format!(
-        "load_dr3_in_cone is currently a shim — the cone-loader function in `starfield-gaia` \
-         hasn't landed yet. Provide it (signature: `Dr3Catalog::from_excerpt_dir_for_cone(\
-         excerpt_dir, centre, radius_deg, mag_limit) -> Result<Dr3Catalog>`) and replace \
-         this function body with a single forward call. Excerpt dir tested: {}",
-        excerpt_dir.display()
-    )
-    .into())
+    let cone = Cone::from_degrees(centre.ra_degrees(), centre.dec_degrees(), radius_deg);
+    Ok(Dr3Catalog::from_excerpt_dir_for_cone(
+        excerpt_dir,
+        cone,
+        mag_limit,
+    )?)
 }
 
 /// Load a Gaia DR3 catalog cone + augment with the embedded Hipparcos


### PR DESCRIPTION
## Summary

Closes the gap PR #74 left behind. starfield-datasources [PR #45](https://github.com/OrbitalCommons/starfield-datasources/pull/45) (merged as `262051c`) lands the `GaiaCatalog<R>` trait + `LazyLoadingCatalog<Dr3>` backend the shim was waiting on.

The DR3 cone path now opens the excerpt dir as a lazy handle (manifest read + validated up front; no shard files touched until queried) and materializes the cone in a second step. The two-step shape is the long-term API: future consumers that want multiple cones (per-sensor projection, sliding windows) hold the `LazyLoadingCatalog<Dr3>` across calls rather than reopening per query.

## Changes

- **`sims::gaia_dr3`** rewritten:
  - `open_dr3_excerpt(path) -> LazyLoadingCatalog<Dr3>` — cheap, manifest-only. Errors out if the directory is hash-sharded, pre-PR-#42 mod-collapsed (kind=healpix but `num_shards < 12·4^level`), or written by a different release.
  - `materialize_cone_augmented(lazy, centre, radius, mag_limit) -> (Dr3Catalog, n_added)` — runs the cone query through `lazy.materialize_cone(...)`, wraps the result in `Dr3Catalog`, augments with the embedded Hipparcos bright-star supplement.
- **`motion_simulator.rs`** call site updated: open + materialize on separate lines.
- **Cargo pin** bump for `starfield-{nsa,gaia,datasource-utils}`: `2c6401a` → `262051c` (PR #45 squash-merge).

## How the upstream loader works

1. `LazyLoadingCatalog::open` reads the manifest, requires `kind: "healpix"` with `num_shards == 12·4^level` (the post-PR-#42 one-file-per-cell layout), and checks the recorded release matches `R`.
2. Each `entries_in_cone` call asks `cdshealpix::nested::cone_coverage_approx_flat(level, ra, dec, radius)` for the superset of cells touched by the cone.
3. Opens only those shard files (existing ones; empty cells leave no file behind), streams entries through the magnitude gate, and post-filters by exact great-circle distance against `cos(radius)` — HEALPix coverage is conservative so boundary cells overshoot.
4. No in-memory cache today; LRU is a follow-on if multi-cone workloads need it.

## Test plan

- [x] `cargo build -p simulator`
- [x] `cargo test -p simulator --lib` — 285 passed
- [x] `cargo fmt`
- [ ] End-to-end render with `--gaia-dr3 --gaia-excerpt-dir <dr3-mag20-bycell>` — pending the in-progress reshard from `dr3-mag20` (mod-collapsed, 128 shards) → `dr3-mag20-bycell` (one-file-per-cell, 12,288 shards). Until that finishes, the loader will refuse the legacy default dir; users should pass `--gaia-excerpt-dir` explicitly to point at the bycell directory.

