### PR TITLE
Spencer array: surveyed centers + reticle at boresight projection

### DIFF
--- a/simulator/src/hardware/sensor_array.rs
+++ b/simulator/src/hardware/sensor_array.rs
@@ -199,36 +199,30 @@ impl SensorArray {
 }
 
 pub static SPENCER_ARRAY_PLAN: Lazy<SensorArray> = Lazy::new(|| {
-    SensorArray::new(vec![
-        PositionedSensor {
-            sensor: IMX455.clone(),
-            position: SensorPosition {
-                x_mm: -61.0,
-                y_mm: 27.01,
-            },
-        },
-        PositionedSensor {
-            sensor: IMX455.clone(),
-            position: SensorPosition {
-                x_mm: -26.5,
-                y_mm: 71.01,
-            },
-        },
-        PositionedSensor {
-            sensor: IMX455.clone(),
-            position: SensorPosition {
-                x_mm: 61.0,
-                y_mm: 27.01,
-            },
-        },
-        PositionedSensor {
-            sensor: IMX455.clone(),
-            position: SensorPosition {
-                x_mm: 26.5,
-                y_mm: 71.01,
-            },
-        },
-    ])
+    /// Outer (low-y) pair |x| offset, mm.
+    const OUTER_X_MM: f64 = 61.0;
+    /// Inner (high-y) pair |x| offset, mm.
+    const INNER_X_MM: f64 = 26.5;
+    /// Outer pair y offset (low row), mm.
+    const OUTER_Y_MM: f64 = 27.01;
+    /// Inner pair y offset (high row), mm.
+    const INNER_Y_MM: f64 = 71.01;
+
+    let centres = [
+        (-OUTER_X_MM, OUTER_Y_MM),
+        (-INNER_X_MM, INNER_Y_MM),
+        (OUTER_X_MM, OUTER_Y_MM),
+        (INNER_X_MM, INNER_Y_MM),
+    ];
+    SensorArray::new(
+        centres
+            .into_iter()
+            .map(|(x_mm, y_mm)| PositionedSensor {
+                sensor: IMX455.clone(),
+                position: SensorPosition { x_mm, y_mm },
+            })
+            .collect(),
+    )
 });
 
 #[cfg(test)]

--- a/simulator/src/hardware/sensor_array.rs
+++ b/simulator/src/hardware/sensor_array.rs
@@ -199,41 +199,33 @@ impl SensorArray {
 }
 
 pub static SPENCER_ARRAY_PLAN: Lazy<SensorArray> = Lazy::new(|| {
-    let x1 = 27.5;
-    let y1 = 20.0;
-
-    let x2 = 58.75;
-    let y2 = -23.75;
-
-    let spencer_y_offset = 50.0;
-
     SensorArray::new(vec![
         PositionedSensor {
             sensor: IMX455.clone(),
             position: SensorPosition {
-                x_mm: x1,
-                y_mm: y1 + spencer_y_offset,
+                x_mm: -61.0,
+                y_mm: 27.01,
             },
         },
         PositionedSensor {
             sensor: IMX455.clone(),
             position: SensorPosition {
-                x_mm: -x1,
-                y_mm: y1 + spencer_y_offset,
+                x_mm: -26.5,
+                y_mm: 71.01,
             },
         },
         PositionedSensor {
             sensor: IMX455.clone(),
             position: SensorPosition {
-                x_mm: x2,
-                y_mm: y2 + spencer_y_offset,
+                x_mm: 61.0,
+                y_mm: 27.01,
             },
         },
         PositionedSensor {
             sensor: IMX455.clone(),
             position: SensorPosition {
-                x_mm: -x2,
-                y_mm: y2 + spencer_y_offset,
+                x_mm: 26.5,
+                y_mm: 71.01,
             },
         },
     ])

--- a/simulator/src/sims/context_render.rs
+++ b/simulator/src/sims/context_render.rs
@@ -2,10 +2,13 @@
 //!
 //! Produces an RGB8 PNG per trajectory frame showing the star field, the
 //! focal-plane sensor outlines, and a reticle at the boresight. The view
-//! is rendered in body-frame millimeters: the boresight sits at image
-//! center, sensors are drawn at their fixed `(x_mm, y_mm)` positions, and
-//! stars are projected through the orientation so they appear to swirl
-//! around the instrument as the telescope rotates.
+//! is rendered in body-frame millimeters: the focal-plane AABB is centred
+//! in the canvas (so the silicon fills the frame regardless of asymmetric
+//! offsets), sensors are drawn at their fixed `(x_mm, y_mm)` positions,
+//! and the red reticle marks the boresight projection at the focal-plane
+//! origin — which sits off canvas-centre when the array is offset from
+//! the optical axis. Stars are projected through the orientation so they
+//! appear to swirl around the instrument as the telescope rotates.
 //!
 //! Star sizes are inflated well above their physical PSF so they remain
 //! visible at the coarse pixel pitch of the 4K context image. Brighter
@@ -114,8 +117,12 @@ pub fn render_context_frame(
     let center_x_px = width as f64 / 2.0;
     let center_y_px = height as f64 / 2.0;
 
-    // `sky_to_mm` returns coordinates anchored so that the boresight lands
-    // at the AABB center. Subtract it so image center == boresight.
+    // Anchor the projection on the AABB center so the silicon fills the
+    // canvas regardless of where the boresight (mm origin) sits relative
+    // to it. The reticle is drawn at `mm_to_px(0.0, 0.0)` below, so it
+    // lands at the true boresight projection — which need not coincide
+    // with the image center when the array is offset from the optical
+    // axis (e.g. the Spencer mosaic).
     let (abc_x, abc_y) = (
         (aabb_min_x + aabb_max_x) / 2.0,
         (aabb_min_y + aabb_max_y) / 2.0,
@@ -184,16 +191,17 @@ pub fn render_context_frame(
         }
     }
 
-    // Reticle at image center. Since we render in body frame, the reticle
-    // arms naturally align with the instrument axes and rotate with the
-    // star field as the telescope rolls. Base the arm length on the
-    // shorter image dimension so aspect-ratio changes don't inflate it.
+    // Reticle at the boresight projection. Since we render in body frame,
+    // the reticle arms naturally align with the instrument axes and rotate
+    // with the star field as the telescope rolls. Base the arm length on
+    // the shorter image dimension so aspect-ratio changes don't inflate it.
     let red = Rgb([255, 90, 90]);
     let short_side = width.min(height) as i32;
     let arm_len = short_side / 40;
     let gap = short_side / 200;
-    let cx_i = center_x_px as i32;
-    let cy_i = center_y_px as i32;
+    let (bore_px, bore_py) = mm_to_px(0.0, 0.0);
+    let cx_i = bore_px.round() as i32;
+    let cy_i = bore_py.round() as i32;
     draw_reticle(&mut img, (cx_i, cy_i), arm_len.max(8), gap.max(2), red);
 
     // Reticle labels — stacked above the right-shooting horizontal arm,


### PR DESCRIPTION
## Summary
- Replaces the parametric `SPENCER_ARRAY_PLAN` centers with the surveyed values: outer pair at `x = ±61 mm`, inner pair at `x = ±26.5 mm`, both rows offset to `y = 27.01` and `71.01 mm` respectively. All four sensors live on the `+y` side of the optical axis.
- Fixes the context-view reticle. It was hard-pinned to image-center pixels, but `mm_to_px` anchors the projection on the AABB center, so on the new asymmetric layout the boresight (focal-plane origin) projected ~50 mm away from where the cross was drawn. The reticle now goes through `mm_to_px(0.0, 0.0)` and lands at the true boresight projection regardless of how the array sits relative to the optical axis. Module doc updated to describe the actual behaviour.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -- -W clippy::all`
- [x] `cargo test -p simulator --lib --release context_render` (3/3)
- [x] `cargo test -p simulator --lib --release sensor_array` (8/8)
- [x] Visual: re-ran `motion_simulator --array-format spencer --context-only` at Coma; the reticle now sits at the bottom-centre of the canvas (correct, since all silicon is at `+y`), with the four green sensor outlines above it.