### PR TITLE
Bump cfl-foundations to pick up FITS writer fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2131,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "meter-math"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=12f40c1#12f40c19703502dee206407835599119dba6da67"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=3fdfe23#3fdfe230e1cac2d30ce3ca0e18cdef6cba866a90"
 dependencies = [
  "log",
  "nalgebra",
@@ -3234,7 +3234,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=12f40c1#12f40c19703502dee206407835599119dba6da67"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=3fdfe23#3fdfe230e1cac2d30ce3ca0e18cdef6cba866a90"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3275,7 +3275,7 @@ dependencies = [
 [[package]]
 name = "shared-wasm"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=12f40c1#12f40c19703502dee206407835599119dba6da67"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=3fdfe23#3fdfe230e1cac2d30ce3ca0e18cdef6cba866a90"
 dependencies = [
  "num-traits",
  "serde",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -29,9 +29,9 @@ env_logger = "0.11"           # Environment-based logger
 url = "2.5"                   # URL parsing and manipulation
 nalgebra = "0.32"             # Linear algebra (quaternions for orientation)
 # Foundation crates from cfl-foundations.
-shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "12f40c1", default-features = false, features = ["frame-writer"] }
-meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "12f40c1" }
-shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "12f40c1" }
+shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "3fdfe23", default-features = false, features = ["frame-writer"] }
+meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "3fdfe23" }
+shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "3fdfe23" }
 
 rand = "0.9"
 rand_distr = "0.5"


### PR DESCRIPTION
## Summary

- Bumps the `cfl-foundations` rev pin from `12f40c1` → `3fdfe23` to pick up [CosmicFrontierLabs/cfl-foundations#11](https://github.com/CosmicFrontierLabs/cfl-foundations/pull/11), which fixes the FITS writer to emit rows in bottom-up order (NAXIS2 increasing upward, origin bottom-left).
- After this lands, standard tools (astropy, ds9, AstroImageJ) display `sensor_shootout` output right-side-up without any compensating flip on the consumer side.
- Downstream consumers that currently vertical-flip on read (e.g. `zodiacal/src/main.rs:304-313`) should drop their flip in a follow-up — this also eliminates the +0.129" Dec systematic that was hiding sub-mas-class solver precision on even-height images.

## Test plan

- [x] `cargo update` for the three pinned crates (`shared`, `meter-math`, `shared-wasm`)
- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo test --workspace` — 287 tests pass, 0 failures

Refs #77.