### PR TITLE
context_render: dotted ellipse overlay for in-FOV NSA galaxies

### DIFF
--- a/simulator/src/bin/motion_simulator.rs
+++ b/simulator/src/bin/motion_simulator.rs
@@ -866,8 +866,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // NSA galaxies (optional). Pre-projected once at the envelope
     // centre — the per-tile renderer uses the same per-sensor list
     // for every frame. See `sims::nsa_galaxies` for the loader
-    // documentation.
-    let per_sensor_galaxies: Vec<Vec<simulator::scene_galaxy::GalaxyInFrame>> = if args.galaxies {
+    // documentation. `galaxies_in_field` is a flat sky-position list
+    // for the context-view ellipse overlay (it covers galaxies that
+    // land in sensor gaps too).
+    let (per_sensor_galaxies, galaxies_in_field) = if args.galaxies {
         let path = args
             .galaxy_catalog
             .clone()
@@ -876,15 +878,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Use the envelope diameter / 2 as a generous FOV radius
         // around the trajectory centre. The loader applies its own
         // padding on top.
-        simulator::sims::nsa_galaxies::load_and_route_nsa_galaxies(
+        let per_sensor = simulator::sims::nsa_galaxies::load_and_route_nsa_galaxies(
             &path,
             &envelope_center,
             &focal_plane,
             envelope_diameter * 0.5,
             &cfg,
-        )?
+        )?;
+        let in_field = simulator::sims::nsa_galaxies::load_galaxies_in_fov(
+            &path,
+            &envelope_center,
+            envelope_diameter * 0.5,
+            &cfg,
+        )?;
+        (per_sensor, in_field)
     } else {
-        vec![Vec::new(); focal_plane.array.sensor_count()]
+        (
+            vec![Vec::new(); focal_plane.array.sensor_count()],
+            Vec::new(),
+        )
     };
 
     let output_path = Path::new(&args.output_dir);
@@ -952,8 +964,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .map(|(idx, t)| -> Result<(), String> {
                 let orientation = trajectory.orientation_at(*t).map_err(|e| e.to_string())?;
                 let path = context_dir.join(format!("frame_{idx:06}.png"));
-                render_context_frame(&orientation, &stars, &focal_plane, &ctx_cfg, &path)
-                    .map_err(|e| e.to_string())
+                render_context_frame(
+                    &orientation,
+                    &stars,
+                    &galaxies_in_field,
+                    &focal_plane,
+                    &ctx_cfg,
+                    &path,
+                )
+                .map_err(|e| e.to_string())
             })
             .collect();
         for r in results {

--- a/simulator/src/sims/context_render.rs
+++ b/simulator/src/sims/context_render.rs
@@ -22,8 +22,11 @@ use shared::units::LengthExt;
 use starfield::catalogs::StarData;
 
 use crate::hardware::satellite::FocalPlaneConfig;
+use crate::sims::nsa_galaxies::GalaxyInField;
 use crate::sims::orientation::boresight_of;
 use crate::sims::trajectory::TrajectoryError;
+
+const RAD_TO_ARCSEC: f64 = 206_264.806_247_096_4;
 
 type RgbImage = ImageBuffer<Rgb<u8>, Vec<u8>>;
 
@@ -84,9 +87,16 @@ impl Default for ContextRenderConfig {
 }
 
 /// Render a single context-view frame to `output_path`.
+///
+/// `galaxies` is a sky-position+ellipse-only list of NSA galaxies in
+/// the focal-plane envelope. Each entry is marked with a yellow dotted
+/// ellipse sized at the galaxy's Sérsic half-light radius so the
+/// preview shows where extended sources will land relative to the
+/// silicon. Pass an empty slice to skip the overlay.
 pub fn render_context_frame(
     orientation: &UnitQuaternion<f64>,
     stars: &[StarData],
+    galaxies: &[GalaxyInField],
     fp: &FocalPlaneConfig,
     config: &ContextRenderConfig,
     output_path: &Path,
@@ -155,6 +165,46 @@ pub fn render_context_frame(
         // the star to hit a detector.
         if fp.array.mm_to_pixel(x_mm, y_mm).is_some() {
             draw_availability_ring(&mut img, (px, py), star.magnitude, config);
+        }
+    }
+
+    // Galaxy overlays: dotted ellipses at the Sérsic half-light radius.
+    // Drawn before the sensor outlines so the green box stays on top
+    // (helps eyeballing which galaxies actually clip a detector).
+    if !galaxies.is_empty() {
+        let arcsec_per_mm = fp.plate_scale_rad_per_mm() * RAD_TO_ARCSEC;
+        let yellow = Rgb([255, 200, 60]);
+        for g in galaxies {
+            let Some((x_mm, y_mm)) = fp.sky_to_mm(&g.position, orientation) else {
+                continue;
+            };
+            let (cx, cy) = mm_to_px(x_mm, y_mm);
+            // Convert θ_eff (arcsec) → mm at the focal plane → context px.
+            let semi_major_mm = g.theta_half_arcsec / arcsec_per_mm;
+            let a_px = semi_major_mm / mm_per_px;
+            let b_px = a_px * g.axis_ratio;
+            // Wider canvas slack than stars: an off-centre ellipse may
+            // still poke partway into the canvas.
+            let slack = (a_px.max(b_px) + 4.0).ceil();
+            if cx + slack < 0.0
+                || cx - slack > width as f64
+                || cy + slack < 0.0
+                || cy - slack > height as f64
+            {
+                continue;
+            }
+            // NSA position angle is east-of-north on sky. The focal
+            // plane has +y mm = north (up in the canvas after the
+            // y-flip in `mm_to_px`), so rotating the ellipse's parametric
+            // axes by `pa` gives the correct on-canvas orientation.
+            draw_dotted_ellipse(
+                &mut img,
+                (cx, cy),
+                a_px,
+                b_px,
+                g.position_angle_deg.to_radians(),
+                yellow,
+            );
         }
     }
 
@@ -413,6 +463,59 @@ fn draw_circle(img: &mut RgbImage, center: (i32, i32), r: i32, color: Rgb<u8>) {
     }
 }
 
+/// Draw a dashed (dotted) outline of an ellipse with semi-axes
+/// `a_px` (along the rotated x axis) and `b_px` (along y), rotated by
+/// `pa_rad`. The arc is sampled in `n` parametric segments, each
+/// segment plotted as a 2x2 block so the dashes stay visible at 4K
+/// canvas density. Every other segment is left empty for the dash.
+///
+/// Falls through silently if either semi-axis is below 1 px — there's
+/// nothing to draw at sub-pixel scale.
+fn draw_dotted_ellipse(
+    img: &mut RgbImage,
+    center: (f64, f64),
+    a_px: f64,
+    b_px: f64,
+    pa_rad: f64,
+    color: Rgb<u8>,
+) {
+    let max_axis = a_px.max(b_px);
+    if max_axis < 1.0 {
+        return;
+    }
+    let (cx, cy) = center;
+    let (sin_pa, cos_pa) = pa_rad.sin_cos();
+    // ~one parametric step per outline pixel keeps the dashes from
+    // bunching at the apex of an elongated ellipse.
+    let n = (std::f64::consts::TAU * max_axis).ceil().max(48.0) as usize;
+    let (w, h) = (img.width() as i32, img.height() as i32);
+    for i in 0..n {
+        // Dotted: two-on, two-off pattern.
+        if (i / 2) % 2 == 1 {
+            continue;
+        }
+        let t = (i as f64) * std::f64::consts::TAU / n as f64;
+        let (st, ct) = t.sin_cos();
+        let lx = a_px * ct;
+        let ly = b_px * st;
+        // Rotate by `pa`, then flip the vertical contribution because
+        // image y points down while focal-plane y points up.
+        let dx = lx * cos_pa - ly * sin_pa;
+        let dy_canvas = -(lx * sin_pa + ly * cos_pa);
+        let x = (cx + dx).round() as i32;
+        let y = (cy + dy_canvas).round() as i32;
+        for oy in 0..=1 {
+            for ox in 0..=1 {
+                let px = x + ox;
+                let py = y + oy;
+                if px >= 0 && px < w && py >= 0 && py < h {
+                    img.put_pixel(px as u32, py as u32, color);
+                }
+            }
+        }
+    }
+}
+
 /// Mark a star with a colored ring based on how bright it is: deep blue for
 /// tracking-grade (≤ `tracking_mag_limit`), light blue for astrometry-only
 /// (between tracking and `astrometry_mag_limit`), nothing for dimmer.
@@ -490,7 +593,7 @@ mod tests {
             height: 256,
             ..Default::default()
         };
-        render_context_frame(&orient, &[], &fp, &cfg, &path).unwrap();
+        render_context_frame(&orient, &[], &[], &fp, &cfg, &path).unwrap();
         assert!(path.is_file(), "context PNG must exist");
         let meta = std::fs::metadata(&path).unwrap();
         assert!(meta.len() > 100, "context PNG is suspiciously small");
@@ -511,7 +614,7 @@ mod tests {
             height: 256,
             ..Default::default()
         };
-        render_context_frame(&orient, &[], &fp, &cfg, &path).unwrap();
+        render_context_frame(&orient, &[], &[], &fp, &cfg, &path).unwrap();
         let img = image::open(&path).unwrap().into_rgb8();
         let non_black = img.pixels().filter(|p| p.0 != [0, 0, 0]).count();
         assert!(

--- a/simulator/src/sims/nsa_galaxies.rs
+++ b/simulator/src/sims/nsa_galaxies.rs
@@ -129,6 +129,66 @@ pub fn default_nsa_path() -> PathBuf {
     cache_dir().join("nsa").join("nsa_v0_1_2.fits")
 }
 
+/// Lightweight galaxy descriptor: sky position + Sérsic ellipse
+/// parameters. Carries only what the context-view ellipse renderer
+/// needs (no fluxes, no `SersicSplat`), so the per-galaxy cost stays
+/// flat at a handful of `f64`s for the in-FOV catalog scan.
+#[derive(Debug, Clone, Copy)]
+pub struct GalaxyInField {
+    pub position: Equatorial,
+    pub theta_half_arcsec: f64,
+    pub axis_ratio: f64,
+    pub position_angle_deg: f64,
+}
+
+/// Load NSA from `path` (downloading if absent), filter to the angular
+/// box around `pointing` plus `config.fov_pad_deg`, drop pathological
+/// fits, and return a flat list of `GalaxyInField` entries.
+///
+/// Mirrors the in-FOV pre-filter in [`load_and_route_nsa_galaxies`] but
+/// stops short of per-sensor projection — the context-view renderer
+/// wants every galaxy in the focal-plane envelope, including ones that
+/// land in a sensor gap, so it can mark them with a dotted ellipse.
+pub fn load_galaxies_in_fov(
+    path: &Path,
+    pointing: &Equatorial,
+    fov_radius_deg: f64,
+    config: &GalaxyLoaderConfig,
+) -> Result<Vec<GalaxyInField>, Box<dyn std::error::Error>> {
+    let path = if path.exists() {
+        path.to_path_buf()
+    } else {
+        info!("NSA FITS missing at {}; downloading...", path.display());
+        starfield_nsa::download_nsa()?
+    };
+    let cat = NsaCatalog::from_fits_file(&path)?;
+    let cos_dec0 = pointing.dec_degrees().to_radians().cos();
+    let half_box_deg = fov_radius_deg + config.fov_pad_deg;
+    let out: Vec<GalaxyInField> = cat
+        .stars()
+        .filter(|e| {
+            let dra = (e.ra - pointing.ra_degrees()) * cos_dec0;
+            let ddec = e.dec - pointing.dec_degrees();
+            dra.abs() < half_box_deg && ddec.abs() < half_box_deg
+        })
+        .filter(|e| is_well_fit(e, config.min_n, config.max_n, config.max_theta_eff))
+        .map(|e| GalaxyInField {
+            position: Equatorial::from_degrees(e.ra, e.dec),
+            theta_half_arcsec: e.sersic_th50 as f64,
+            axis_ratio: e.sersic_ba as f64,
+            position_angle_deg: e.sersic_phi as f64,
+        })
+        .collect();
+    info!(
+        "{} NSA galaxies in {:.2}° box around ({:.4}, {:.4}) for context overlay",
+        out.len(),
+        half_box_deg * 2.0,
+        pointing.ra_degrees(),
+        pointing.dec_degrees()
+    );
+    Ok(out)
+}
+
 /// Load NSA from `path` (downloading via the NYU mirror if absent),
 /// filter to the field of view around `pointing` plus `fov_pad_deg`
 /// of slack, drop pathological fits, and project to per-sensor


### PR DESCRIPTION
## Summary
Adds yellow dashed ellipse markers per galaxy in the focal-plane envelope (sized at θ_eff, oriented at the NSA position angle) so the context-view preview shows extended-source coverage relative to the silicon — including galaxies that fall in the sensor gaps. Pre-render verification of NSA coverage is now eyeball-friendly: you can see at a glance which galaxies hit a detector vs. which miss into a gap.

### Changes
- `nsa_galaxies::GalaxyInField` — lightweight sky+ellipse descriptor (no flux, no `SersicSplat`).
- `nsa_galaxies::load_galaxies_in_fov` — mirrors the in-FOV pre-filter used by the per-sensor router but stops short of sensor projection, so gaps are covered.
- `render_context_frame` gains a `galaxies: &[GalaxyInField]` param. Each entry is projected through `sky_to_mm`, scaled to canvas pixels via the focal-plane plate scale, and drawn with a 2-on / 2-off dashed ellipse outline for visibility against the dense star background. Empty slice = pre-existing behaviour.
- `motion_simulator` populates the new list when `--galaxies` is on and threads it into the per-frame context render.

### Visual
Smoke-rendered at Perseus Cluster (RA 49.95°, Dec +40.83°, 273 NSA galaxies in box). Yellow dashed ellipses are visible on top of stars inside the green sensor outlines AND in the gaps; aspect ratio + orientation match the NSA Sérsic fits.

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -- -W clippy::all`
- [x] `cargo test -p simulator --lib --release context_render` (3/3 — existing tests updated to pass `&[]` for the new param)
- [x] Smoke render: `motion_simulator --galaxies --array-format spencer --context-only` at Perseus produced the expected overlay.