### PR TITLE
gaia_dr3: inline open_dr3_excerpt + de-stale --gaia-dr3 help text

### DIFF
--- a/simulator/src/bin/motion_simulator.rs
+++ b/simulator/src/bin/motion_simulator.rs
@@ -14,6 +14,7 @@ use simulator::star_math::field_diameter_for_array;
 use simulator::units::{AngleExt, LengthExt, TemperatureExt};
 use starfield::catalogs::StarCatalog;
 use starfield::Equatorial;
+use starfield_gaia::{Dr3, LazyLoadingCatalog};
 use std::path::Path;
 use std::time::Instant;
 
@@ -695,8 +696,7 @@ struct Args {
         help = "Load stars from a Gaia DR3 healpix-sharded excerpt directory \
                 (per-source BP-RP color → B-V via the linear fit, plus \
                 Hipparcos bright-star augmentation). Overrides --catalog when \
-                set. Cone-loader still shimmed pending upstream `starfield-gaia` \
-                landing the equivalent."
+                set."
     )]
     gaia_dr3: bool,
 
@@ -845,7 +845,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             excerpt_dir.display(),
             args.gaia_mag_limit
         );
-        let lazy = simulator::sims::gaia_dr3::open_dr3_excerpt(&excerpt_dir)?;
+        let lazy = LazyLoadingCatalog::<Dr3>::open(&excerpt_dir)?;
         let (cat, _augmented) = simulator::sims::gaia_dr3::materialize_cone_augmented(
             &lazy,
             envelope_center,

--- a/simulator/src/sims/gaia_dr3.rs
+++ b/simulator/src/sims/gaia_dr3.rs
@@ -18,7 +18,7 @@
 //! - the bright-star Hipparcos supplement injected via
 //!   `Dr3Catalog::augment_missing` (G < ~3 stars dropped from Gaia)
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use log::info;
 use starfield::Equatorial;
@@ -28,20 +28,6 @@ use starfield_gaia::{Cone, Dr3, Dr3Catalog, GaiaCatalog, LazyLoadingCatalog};
 /// Default location of the healpix-sharded DR3 mag-20 excerpt.
 pub fn default_excerpt_dir() -> PathBuf {
     cache_dir().join("gaia-excerpts").join("dr3-mag20")
-}
-
-/// Open a lazy view over a HEALPix-sharded DR3 excerpt directory. Reads
-/// only the manifest; no shard files are touched until a cone is
-/// requested. Errors out if the directory is not a one-file-per-cell
-/// HEALPix excerpt for the DR3 release.
-pub fn open_dr3_excerpt(
-    excerpt_dir: &Path,
-) -> Result<LazyLoadingCatalog<Dr3>, Box<dyn std::error::Error>> {
-    info!(
-        "Opening Gaia DR3 excerpt at {} (lazy; manifest only)",
-        excerpt_dir.display()
-    );
-    Ok(LazyLoadingCatalog::<Dr3>::open(excerpt_dir)?)
 }
 
 /// Materialize a cone from a lazy DR3 excerpt and augment it with the


### PR DESCRIPTION
## Summary
Minor follow-ups to PR #75 / #74 now that the upstream cone loader has landed:

- **Inline `open_dr3_excerpt`**: it was a one-line wrapper around `LazyLoadingCatalog::<Dr3>::open(...)` with one extra log line, called from exactly one place. `motion_simulator` now imports `starfield_gaia::{Dr3, LazyLoadingCatalog}` and opens the excerpt directly. The pre-existing \`\"Loading Gaia DR3 cone...\"\` info log immediately above already covers the user-visible action, so nothing's lost.
- **De-stale the `--gaia-dr3` help text**: drops the *\"Cone-loader still shimmed pending upstream `starfield-gaia` landing the equivalent\"* wording that was true at the time but now describes the past. Per CLAUDE.md, code should describe what *is*, not what *was*.

Net diff: 4 insertions, 18 deletions.

## Test plan
- [x] \`cargo fmt\`
- [x] \`cargo clippy -- -W clippy::all\`
- [x] \`cargo test -p simulator --lib --release\` — 273 passed, 0 failed.