### PR TITLE
gaia_dr3: cone-restrict the Hipparcos supplement injection

### DIFF
--- a/simulator/src/sims/gaia_dr3.rs
+++ b/simulator/src/sims/gaia_dr3.rs
@@ -51,10 +51,29 @@ pub fn materialize_cone_augmented(
     let cone = Cone::from_degrees(centre.ra_degrees(), centre.dec_degrees(), radius_deg);
     let mem = lazy.materialize_cone(cone, mag_limit)?;
     let mut cat = Dr3Catalog(mem);
-    let n_added = cat.augment_missing(mag_limit)?;
+    // Hipparcos supplement injection, restricted to the cone. The
+    // upstream `Dr3Catalog::augment_missing` inserts every supplement
+    // row whose `fitted_g_mag` is brighter than `mag_limit` regardless
+    // of sky position, which dumps ~15 k stars sky-wide for a typical
+    // mag-19 limit; the loop below uses the same parser + entry
+    // converter but adds the cone-containment test before each insert.
+    let supplement = starfield_gaia::dr3::supplement::parse_embedded_supplement()?;
+    let mut n_added = 0usize;
+    for row in &supplement {
+        if row.fitted_g_mag > mag_limit {
+            continue;
+        }
+        if !cone.contains_radec_deg(row.ra, row.dec) {
+            continue;
+        }
+        cat.insert(starfield_gaia::dr3::supplement::supplement_row_to_entry(
+            row,
+        ));
+        n_added += 1;
+    }
     info!(
         "Gaia DR3 catalog: cone-loaded + augmented with {n_added} Hipparcos \
-         bright-star supplement rows (mag_limit = {mag_limit:.2})"
+         bright-star supplement rows in cone (mag_limit = {mag_limit:.2})"
     );
     Ok((cat, n_added))
 }


### PR DESCRIPTION
## Summary
Upstream \`Dr3Catalog::augment_missing(mag_limit)\` inserts **every** embedded Hipparcos supplement row brighter than \`mag_limit\`, regardless of sky position. For a typical mag-19 limit that injects ~15k bright stars sky-wide, of which ~all live outside the per-render cone and get silently dropped at projection time.

Replace the call with a manual loop that uses the same upstream parser + entry converter (\`parse_embedded_supplement\` / \`supplement_row_to_entry\`) but adds a \`Cone::contains_radec_deg\` test before each insert.

### Numbers (smoke render at Perseus Cluster, cone radius 0.823°)
| | before | after |
|---|---|---|
| Hipparcos rows added | 15,166 | **0** |
| Total cached stars | 35,378 | 20,212 |

No behavioural difference at projection time — those 15k extra rows were already being filtered out per-frame; savings are upstream (parser work, hash insert cost, ~15k entries' worth of memory). At low-density galactic-pole fields the in-cone count will usually still be 0; at low-b fields it will be a handful.

## Test plan
- [x] \`cargo fmt\`
- [x] \`cargo clippy -- -W clippy::all\`
- [x] \`cargo build -p simulator --release\`
- [x] Smoke render at Perseus: log shows \`augmented with 0 Hipparcos bright-star supplement rows in cone\` and the cached-stars total drops by ~15k.