### PR TITLE
photometry: clamp B-V before Ballesteros to fix #84 negative-T panic

### DIFF
--- a/simulator/src/photometry/stellar.rs
+++ b/simulator/src/photometry/stellar.rs
@@ -244,8 +244,21 @@ pub struct BlackbodyStellarSpectrum {
 /// # Usage
 /// Convert B-V color index to stellar effective temperature using
 /// Ballesteros (2012) empirical relationship for famous stars.
+/// Lower clamp on `b_v` before applying the Ballesteros formula.
+///
+/// Eq. 14 has poles at `b_v = -0.62/0.92 ≈ -0.674` and `b_v ≈ -1.848`
+/// — below the first pole the formula returns negative `T` and the
+/// downstream `BlackbodyStellarSpectrum::new` panics. Real Gaia DR3
+/// sources occasionally yield `b_v ≲ -0.7` after the BP-RP → B-V
+/// linear fit (hot O-stars, photometric outliers). Clamp at `-0.4` —
+/// the formula is only nominally calibrated down to about that B-V
+/// anyway, and `temperature_from_bv(-0.4) ≈ 21 700 K` already covers
+/// the physically reasonable hot end.
+const BV_CLAMP_MIN: f64 = -0.4;
+
 pub fn temperature_from_bv(b_v: f64) -> f64 {
     // equation 14 in the source above
+    let b_v = b_v.max(BV_CLAMP_MIN);
     4600.0 * (1.0 / (0.92 * b_v + 1.7) + (1.0 / (0.92 * b_v + 0.62)))
 }
 
@@ -741,5 +754,32 @@ mod tests {
         let blue = Band::from_nm_bounds(300.0, 400.0);
         assert!(o_bb_spec.irradiance(&blue) > g_bb_spec.irradiance(&blue));
         assert!(o_bb_spec.irradiance(&blue) > m_bb_spec.irradiance(&blue));
+    }
+
+    /// Regression for issue #84: Ballesteros (2012) eq. 14 has poles at
+    /// `b_v ≈ -0.674` and `-1.848`; below the first pole the raw
+    /// formula returns negative `T` and downstream
+    /// `BlackbodyStellarSpectrum::new` panics. The clamp on the input
+    /// must keep the returned temperature finite, positive, and within
+    /// the calibrated stellar range for any `b_v` Gaia DR3 might emit
+    /// (occasionally `< -1` after the BP-RP → B-V linear fit).
+    #[test]
+    fn temperature_from_bv_does_not_panic_on_extreme_blue() {
+        for b_v in [-0.5, -0.674, -0.7, -1.0, -1.848, -3.0, f64::NEG_INFINITY] {
+            let t = temperature_from_bv(b_v);
+            assert!(
+                t.is_finite() && t > 0.0,
+                "temperature_from_bv({b_v}) = {t} should be finite and positive"
+            );
+            // Sanity: clamp at b_v = -0.4 gives ≈ 21 700 K, well within
+            // the O-star regime (cap at 50 000 to catch a regression).
+            assert!(
+                (1_000.0..=50_000.0).contains(&t),
+                "temperature_from_bv({b_v}) = {t} K outside [1000, 50000]"
+            );
+            // BlackbodyStellarSpectrum::new panics on T <= 0; verify
+            // the constructor accepts the clamped result.
+            let _ = BlackbodyStellarSpectrum::new(t, 1.0);
+        }
     }
 }


### PR DESCRIPTION
## Summary
Fixes #84 — `motion_simulator --gaia-dr3` panics on roughly 0.6 % of full-sky renders with:

\`\`\`
thread 'main' panicked at simulator/src/photometry/stellar.rs:284:13:
Temperature must be positive, got: -5741381.400010549
\`\`\`

Eq. 14 of Ballesteros (2012) has poles at \`b_v ≈ -0.674\` and \`-1.848\`; below the first pole the formula returns negative \`T\`, which the downstream \`BlackbodyStellarSpectrum::new\` rejects with the panic above. After PR #75 wired per-source DR3 B-V via the BP-RP linear fit, occasional Gaia sources with \`b_v ≲ -0.7\` (hot O-stars or photometric outliers) have been killing the whole render.

## Fix
Clamp the input \`b_v\` to \`-0.4\` before applying the formula:

\`\`\`rust
let b_v = b_v.max(BV_CLAMP_MIN);  // BV_CLAMP_MIN = -0.4
4600.0 * (1.0 / (0.92 * b_v + 1.7) + (1.0 / (0.92 * b_v + 0.62)))
\`\`\`

The Ballesteros relation isn't calibrated below \`b_v ≈ -0.4\` anyway, and \`temperature_from_bv(-0.4) ≈ 21 700 K\` already covers any physically plausible hot end. Stars below the clamp render as if they were the bluest calibrated O star.

This is option (1) from issue #84's suggested-fixes list — minimum diff, preserves the analytic formula in its calibrated range.

## Test plan
- [x] \`cargo fmt\`
- [x] \`cargo clippy -- -W clippy::all\`
- [x] \`cargo test -p simulator --lib --release stellar::\` — 15 / 15 pass, including the new regression \`temperature_from_bv_does_not_panic_on_extreme_blue\` covering \`b_v\` down to \`-∞\`.

## Background
The bug surfaced during the 1000-case test-set regen for zodiacal (focalplane#83). Six of 1000 random pointings — all in the southern Milky Way / bulge region — tripped the panic; with this clamp they render cleanly.