### PR TITLE
deps: bump imageproc 0.25.0 → 0.25.1 (clears 3 RUSTSEC advisories)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1740,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "imageproc"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2393fb7808960751a52e8a154f67e7dd3f8a2ef9bd80d1553078a7b4e8ed3f0d"
+checksum = "602b4e8a4cc3e98372b766cd184ab532999bc0e839b7469e759511ccabc65d77"
 dependencies = [
  "ab_glyph",
  "approx",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -52,7 +52,7 @@ plotters = { version = "0.3", default-features = false, features = [
 ] }
 chrono = "0.4.41"
 ab_glyph = "0.2"           # TTF glyph rasterization for context-view labels
-imageproc = { version = "0.25", default-features = false } # draw_text_mut over `image`
+imageproc = { version = "0.25.1", default-features = false } # draw_text_mut over `image`
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false, features = [


### PR DESCRIPTION
## Summary
\`cargo audit\` flagged three RUSTSEC unsoundness advisories against \`imageproc 0.25.0\`:

- **RUSTSEC-2026-0115** (GHSA-5qv7-j6w5-fr4m) — Fragile bounds check when sampling from image
- **RUSTSEC-2026-0116** (GHSA-w5p8-4jcx-2j6r) — Improper check of an invariant resulting in incorrect bounds checks
- **RUSTSEC-2026-0117** (GHSA-qg8r-f7x3-25f7) — Fragile bounds check when sampling from image

All three are categorized "memory-exposure" and patched in \`>= 0.25.1, < 0.26.0\`. We use \`imageproc\` directly (\`draw_text_mut\` for context-view labels), so the upgrade is in scope. Pinning to \`0.25.1\` keeps API compatibility — no source changes needed.

## Net diff
\`Cargo.toml\`: \`"0.25"\` → \`"0.25.1"\` (1 line). \`Cargo.lock\`: 1 entry, 0.25.0 → 0.25.1.

## Test plan
- [x] \`cargo build -p simulator --release\`
- [x] \`cargo test -p simulator --lib --release\` — 274/274 pass
- [x] \`cargo audit\` — 3 imageproc advisories cleared (8 → 5 warnings remaining; the rest are transitive \`unmaintained\`/\`yanked\` from \`bincode\`, \`core2\`, \`paste\`, \`number_prefix\` deep in upstream chains — those need fixes upstream).