### PR TITLE
motion_blur, render: parallel + by-value noise pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2131,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "meter-math"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=b1d7f51#b1d7f5173f30be1ef25d199ab773946715882755"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=7936ec9#7936ec9722786850378eab3373491ae56c741189"
 dependencies = [
  "log",
  "nalgebra",
@@ -3234,7 +3234,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=b1d7f51#b1d7f5173f30be1ef25d199ab773946715882755"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=7936ec9#7936ec9722786850378eab3373491ae56c741189"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3275,7 +3275,7 @@ dependencies = [
 [[package]]
 name = "shared-wasm"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=b1d7f51#b1d7f5173f30be1ef25d199ab773946715882755"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=7936ec9#7936ec9722786850378eab3373491ae56c741189"
 dependencies = [
  "num-traits",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2131,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "meter-math"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=3fdfe23#3fdfe230e1cac2d30ce3ca0e18cdef6cba866a90"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=b1d7f51#b1d7f5173f30be1ef25d199ab773946715882755"
 dependencies = [
  "log",
  "nalgebra",
@@ -3234,7 +3234,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=3fdfe23#3fdfe230e1cac2d30ce3ca0e18cdef6cba866a90"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=b1d7f51#b1d7f5173f30be1ef25d199ab773946715882755"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3275,7 +3275,7 @@ dependencies = [
 [[package]]
 name = "shared-wasm"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=3fdfe23#3fdfe230e1cac2d30ce3ca0e18cdef6cba866a90"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=b1d7f51#b1d7f5173f30be1ef25d199ab773946715882755"
 dependencies = [
  "num-traits",
  "serde",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -29,9 +29,9 @@ env_logger = "0.11"           # Environment-based logger
 url = "2.5"                   # URL parsing and manipulation
 nalgebra = "0.32"             # Linear algebra (quaternions for orientation)
 # Foundation crates from cfl-foundations.
-shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "3fdfe23", default-features = false, features = ["frame-writer"] }
-meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "3fdfe23" }
-shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "3fdfe23" }
+shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "b1d7f51", default-features = false, features = ["frame-writer"] }
+meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "b1d7f51" }
+shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "b1d7f51" }
 
 rand = "0.9"
 rand_distr = "0.5"

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -29,9 +29,9 @@ env_logger = "0.11"           # Environment-based logger
 url = "2.5"                   # URL parsing and manipulation
 nalgebra = "0.32"             # Linear algebra (quaternions for orientation)
 # Foundation crates from cfl-foundations.
-shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "b1d7f51", default-features = false, features = ["frame-writer"] }
-meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "b1d7f51" }
-shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "b1d7f51" }
+shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "7936ec9", default-features = false, features = ["frame-writer"] }
+meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "7936ec9" }
+shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "7936ec9" }
 
 rand = "0.9"
 rand_distr = "0.5"

--- a/simulator/src/image_proc/render.rs
+++ b/simulator/src/image_proc/render.rs
@@ -318,7 +318,7 @@ impl Renderer {
 
         // Apply Poisson arrival time statistics to star photons if requested
         let star_image = if apply_poisson {
-            apply_poisson_photon_noise(&scaled_star_image, rng_seed)
+            apply_poisson_photon_noise(scaled_star_image, rng_seed)
         } else {
             scaled_star_image
         };
@@ -339,7 +339,7 @@ impl Renderer {
 
         let zodiacal_image = if apply_poisson {
             let new_seed = rng_seed.map(|val| val + 1);
-            apply_poisson_photon_noise(&zodiacal_mean, new_seed)
+            apply_poisson_photon_noise(zodiacal_mean, new_seed)
         } else {
             zodiacal_mean
         };

--- a/simulator/src/sims/motion_blur.rs
+++ b/simulator/src/sims/motion_blur.rs
@@ -573,7 +573,7 @@ fn render_tile(
     let ms_combined_mean = t_combined_mean.elapsed().as_millis();
 
     let t_poisson = Instant::now();
-    let poisson_image = apply_poisson_photon_noise(&mean_image, Some(tile_seed ^ POISSON_DOMAIN));
+    let poisson_image = apply_poisson_photon_noise(mean_image, Some(tile_seed ^ POISSON_DOMAIN));
     let ms_poisson = t_poisson.elapsed().as_millis();
 
     // Gaussian read noise (electronics, not shot noise) applied afterwards.
@@ -585,7 +585,7 @@ fn render_tile(
         .max(0.0);
     let t_read_noise = Instant::now();
     let final_electrons = apply_gaussian_read_noise(
-        &poisson_image,
+        poisson_image,
         read_noise_rms,
         Some(tile_seed ^ READ_NOISE_DOMAIN),
     );

--- a/simulator/src/sims/motion_blur.rs
+++ b/simulator/src/sims/motion_blur.rs
@@ -39,10 +39,8 @@ use image::{ImageBuffer, Luma};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use log::{debug, info};
 use ndarray::Array2;
-use rand::{rngs::StdRng, SeedableRng};
-use rand_distr::{Distribution, Normal};
 use rayon::prelude::*;
-use shared::image_proc::noise::apply_poisson_photon_noise;
+use shared::image_proc::noise::{apply_gaussian_read_noise, apply_poisson_photon_noise};
 use shared::units::{AngleExt, LengthExt, TemperatureExt};
 use starfield::catalogs::StarData;
 use starfield::Equatorial;
@@ -509,6 +507,7 @@ fn render_tile(
     // value is stable across every stamp of the exposure.
     let mut local_flux: HashMap<u64, SourceFlux> = HashMap::new();
 
+    let t_splat_stars = Instant::now();
     for stamp_t in schedule.stamp_times(stamp_phase) {
         let t_clamped = stamp_t
             .min(scene.trajectory.end_time())
@@ -537,6 +536,7 @@ fn render_tile(
             accumulator.splat_psf(hit.0, hit.1, total_electrons, &flux.electrons.disk);
         }
     }
+    let ms_splat_stars = t_splat_stars.elapsed().as_millis();
 
     // Galaxies: pre-projected per-sensor (one position per render),
     // splatted at full-exposure flux so the unified Poisson stage
@@ -546,6 +546,7 @@ fn render_tile(
     // sub-pixel galaxy shift across the exposure is well below the
     // per-pixel noise floor of any plausible exposure. Static
     // trajectories (start == end) are exact.
+    let t_splat_galaxies = Instant::now();
     let galaxies = scene
         .per_sensor_galaxies
         .get(sensor_idx)
@@ -558,6 +559,7 @@ fn render_tile(
             .integrated_over(&schedule.exposure, aperture);
         accumulator.splat_galaxy(galaxy.x, galaxy.y, total_electrons, &galaxy.deposit);
     }
+    let ms_splat_galaxies = t_splat_galaxies.elapsed().as_millis();
 
     // Dark current: rate × full exposure, uniform over pixels.
     let dark_rate = satellite
@@ -566,8 +568,13 @@ fn render_tile(
     let dark_mean = (dark_rate * schedule.exposure.as_secs_f64()).max(0.0);
 
     // Build unified Poisson mean image and draw.
+    let t_combined_mean = Instant::now();
     let mean_image = accumulator.combined_mean(plan.zodiacal_per_px[sensor_idx], dark_mean);
+    let ms_combined_mean = t_combined_mean.elapsed().as_millis();
+
+    let t_poisson = Instant::now();
     let poisson_image = apply_poisson_photon_noise(&mean_image, Some(tile_seed ^ POISSON_DOMAIN));
+    let ms_poisson = t_poisson.elapsed().as_millis();
 
     // Gaussian read noise (electronics, not shot noise) applied afterwards.
     let read_noise_rms = satellite
@@ -576,17 +583,38 @@ fn render_tile(
         .estimate(satellite.temperature.as_celsius(), schedule.exposure)
         .unwrap_or(0.0)
         .max(0.0);
-    let final_electrons = if read_noise_rms > 0.0 {
-        let mut rng = StdRng::seed_from_u64(tile_seed ^ READ_NOISE_DOMAIN);
-        let normal =
-            Normal::new(0.0_f64, read_noise_rms).expect("read noise RMS must be non-negative");
-        poisson_image.mapv(|e| (e + normal.sample(&mut rng)).max(0.0))
-    } else {
-        poisson_image
-    };
+    let t_read_noise = Instant::now();
+    let final_electrons = apply_gaussian_read_noise(
+        &poisson_image,
+        read_noise_rms,
+        Some(tile_seed ^ READ_NOISE_DOMAIN),
+    );
+    let ms_read_noise = t_read_noise.elapsed().as_millis();
 
+    let t_quantize = Instant::now();
     let quantized = quantize_image(&final_electrons, &satellite.sensor);
-    save_u16_png(&quantized, output_path)
+    let ms_quantize = t_quantize.elapsed().as_millis();
+
+    let t_save = Instant::now();
+    let result = save_u16_png(&quantized, output_path);
+    let ms_save = t_save.elapsed().as_millis();
+
+    debug!(
+        "tile-phases frame={} sensor={} \
+         splat_stars={}ms splat_galaxies={}ms combined_mean={}ms \
+         poisson={}ms read_noise={}ms quantize={}ms png_save={}ms",
+        plan.idx,
+        sensor_idx,
+        ms_splat_stars,
+        ms_splat_galaxies,
+        ms_combined_mean,
+        ms_poisson,
+        ms_read_noise,
+        ms_quantize,
+        ms_save,
+    );
+
+    result
 }
 
 /// Render the full trajectory with motion blur, parallel over `(frame, sensor)`.


### PR DESCRIPTION
## Summary

- Bumps `cfl-foundations` to `b1d7f51` (which lands `apply_gaussian_read_noise` from CosmicFrontierLabs/cfl-foundations#12).
- Swaps the inline single-threaded `mapv` read-noise pass in `render_tile` for the new parallel helper. Same seeding (`tile_seed ^ READ_NOISE_DOMAIN`), same clamp-at-zero, same output for a given seed.
- Adds a `tile-phases` `debug!` line that splits per-tile time into `splat_stars / splat_galaxies / combined_mean / poisson / read_noise / quantize / png_save` — drop this in with `RUST_LOG=debug` to find the next bottleneck without re-instrumenting.

## Per-tile timings on a 61 MP IMX455 (force-static, Vega only)

| phase | before | after |
|---|---:|---:|
| splat_stars | 0 ms | 0 ms |
| combined_mean | ~290 ms | ~290 ms |
| poisson (parallel) | ~430 ms | ~430 ms |
| **read_noise** | **~1490 ms** | **~390 ms** |
| quantize | ~170 ms | ~170 ms |
| png_save | ~890 ms | ~890 ms |
| total (single tile) | ~3.3 s | ~2.2 s |

Read-noise drops by ~3.85×, landing it in the same range as the Poisson stage (both now run via `process_array_in_parallel_chunks` with 64-row blocks). PNG zlib save is now the dominant per-tile cost.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -p simulator -- -W clippy::all` — no new warnings
- [x] `cargo test --release -p simulator --lib motion_blur` — 29/29 pass, including the determinism + jitter-tone tests that exercise the read-noise path
- [x] End-to-end `motion_simulator --force-static` benchmark on `/dev/shm` confirms read-noise phase timing drops from ~1490 ms → ~390 ms