### PR TITLE
motion_blur: in-place + parallel combined_mean

### DIFF
--- a/simulator/src/sims/motion_blur.rs
+++ b/simulator/src/sims/motion_blur.rs
@@ -235,11 +235,21 @@ impl SensorAccumulator {
         );
     }
 
-    /// Returns the combined mean-electron image = star mean + zodiacal
-    /// uniform + dark-current uniform (pre-Poisson).
-    pub fn combined_mean(&self, zodiacal_per_px: f64, dark_per_px: f64) -> Array2<f64> {
+    /// Consume the accumulator and return the combined mean-electron image
+    /// = star mean + zodiacal uniform + dark-current uniform (pre-Poisson).
+    ///
+    /// The accumulator's existing `star_mean_electrons` buffer is reused —
+    /// no second 488 MB allocation, no read-then-write of a fresh array.
+    /// The scalar background is added in place via rayon-parallel
+    /// element-wise iteration (ndarray's `rayon` feature is enabled).
+    pub fn into_combined_mean(mut self, zodiacal_per_px: f64, dark_per_px: f64) -> Array2<f64> {
         let bg = (zodiacal_per_px + dark_per_px).max(0.0);
-        &self.star_mean_electrons + bg
+        if bg > 0.0 {
+            self.star_mean_electrons
+                .par_iter_mut()
+                .for_each(|pixel| *pixel += bg);
+        }
+        self.star_mean_electrons
     }
 }
 
@@ -569,7 +579,7 @@ fn render_tile(
 
     // Build unified Poisson mean image and draw.
     let t_combined_mean = Instant::now();
-    let mean_image = accumulator.combined_mean(plan.zodiacal_per_px[sensor_idx], dark_mean);
+    let mean_image = accumulator.into_combined_mean(plan.zodiacal_per_px[sensor_idx], dark_mean);
     let ms_combined_mean = t_combined_mean.elapsed().as_millis();
 
     let t_poisson = Instant::now();
@@ -1193,7 +1203,7 @@ mod tests {
     fn test_sensor_accumulator_combined_mean() {
         let mut acc = SensorAccumulator::zero(4, 4);
         acc.star_mean_electrons[[1, 1]] = 5.0;
-        let combined = acc.combined_mean(2.0, 1.0);
+        let combined = acc.into_combined_mean(2.0, 1.0);
         assert_eq!(combined[[0, 0]], 3.0); // 0 + 2 + 1
         assert_eq!(combined[[1, 1]], 8.0); // 5 + 2 + 1
     }


### PR DESCRIPTION
## Summary

Rename `SensorAccumulator::combined_mean` → `into_combined_mean` and take `mut self` instead of `&self`. The new method:

- Reuses the existing `star_mean_electrons` 488 MB buffer instead of allocating a fresh output array.
- Adds the `(zodiacal + dark)` scalar background **in place** via `par_iter_mut` (ndarray's `rayon` feature is already enabled).
- Returns the mutated buffer directly.

The accumulator was already dropped immediately after this call at the sole caller (`render_tile`), so by-value is the natural shape. Same `into_*` consume-self convention used in the apply_*_noise rewrite from #87.

## Per-tile timing on 61 MP IMX455 (single force-static frame to RAM)

| phase | before this PR | after | Δ |
|---|---:|---:|---:|
| **combined_mean** | **202 ms** | **51 ms** | **-75%** |
| poisson | 28 | 24 | — |
| read_noise | 28 | 24 | — |
| quantize | 162 | 175 | — |
| png_save | 810 | 807 | — |
| **compute total** (no PNG) | **420 ms** | **274 ms** | **-35%** |

The 4× speedup on `combined_mean` comes from killing the 488 MB output allocation + cutting memory traffic in half + spreading the scalar add across cores. We don't quite hit the ~25 ms ceiling that the noise stages enjoy because the simpler `+= bg` op gets less work-per-chunk to amortise rayon overhead — but 4× for a few lines is a fair trade.

## End-to-end win

Stacking this on top of #87 and the upstream cfl-foundations work, the per-tile compute total went from the original baseline **831 ms → 274 ms** — about **3× faster** for a 61 MP frame to RAM with the catalog preloaded.

Next bottleneck on the compute side is `quantize` at 175 ms (still single-threaded f64 → u16). After that it's `png_save` at ~810 ms (single-threaded zlib).

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy -p simulator -- -W clippy::all` — no new warnings
- [x] `cargo test --release -p simulator --lib` — 274/274 pass (including the existing `test_sensor_accumulator_combined_mean` updated for the new signature)
- [x] End-to-end `motion_simulator --force-static` benchmark on `/dev/shm` confirms the phase-timing numbers above