### PR TITLE
trajectory: waypoint_with_offset for FSM offset composition

### DIFF
--- a/simulator/src/sims/trajectory.rs
+++ b/simulator/src/sims/trajectory.rs
@@ -254,6 +254,32 @@ impl Trajectory {
         Ok(boresight_of(&q))
     }
 
+    /// Look up the pose at time `t` and post-compose `delta` onto it,
+    /// returning the result as a [`Waypoint`] stamped at `t`.
+    ///
+    /// The composition is `base * delta` in nalgebra's convention,
+    /// where `base = self.orientation_at(t)?`. Applied to a vector `v`,
+    /// the resulting rotation is `base * (delta * v)`: `delta` rotates
+    /// first (interpreted as a body-frame offset), then `base` takes the
+    /// body-frame vector into world coordinates. This matches the
+    /// per-frame FSM offset injection used by the `scene-camera` ROI
+    /// pipeline, where the closed-loop controller supplies a small
+    /// body-frame angular offset between frames:
+    ///
+    /// ```text
+    /// pose_for_render = trajectory(t) ⊗ fsm_offset
+    /// ```
+    ///
+    /// The returned `Waypoint`'s `time` field equals the input `t`.
+    pub fn waypoint_with_offset(
+        &self,
+        t: Duration,
+        delta: UnitQuaternion<f64>,
+    ) -> Result<Waypoint, TrajectoryError> {
+        let base = self.orientation_at(t)?;
+        Ok(Waypoint::new(t, base * delta))
+    }
+
     /// Maximum angular distance (radians) between any waypoint
     /// orientation in `[t_start, t_end]` and a chosen `reference`
     /// orientation. Scans every waypoint inside the window plus the
@@ -837,6 +863,48 @@ mod tests {
         let err = traj
             .orientation_at(traj.end_time() + Duration::from_millis(1))
             .expect_err("non-periodic must error on out-of-range");
+        assert!(matches!(err, TrajectoryError::TimeOutOfRange(_, _, _)));
+    }
+
+    #[test]
+    fn waypoint_with_offset_post_composes_delta_onto_base() {
+        // Static trajectory so `orientation_at(mid)` is well-defined and
+        // unambiguous. Compose a 30 deg rotation about the body +Z axis
+        // and verify the result is bit-equal to base * delta with the
+        // input time preserved.
+        let pointing = make_pointing(10.0, 20.0);
+        let traj = Trajectory::from_endpoints(pointing, pointing, Duration::from_secs(10)).unwrap();
+        let mid = Duration::from_secs(5);
+        let base = traj.orientation_at(mid).unwrap();
+
+        let delta = UnitQuaternion::from_axis_angle(
+            &nalgebra::Vector3::z_axis(),
+            std::f64::consts::FRAC_PI_6, // 30 degrees
+        );
+        let expected = base * delta;
+
+        let wp = traj.waypoint_with_offset(mid, delta).unwrap();
+        assert_eq!(wp.time, mid);
+        assert_abs_diff_eq!(wp.orientation.angle_to(&expected), 0.0, epsilon = 1e-15);
+
+        // Sanity check: order matters. delta * base should not match
+        // unless base and delta commute (they do not here).
+        let wrong_order = delta * base;
+        assert!(wp.orientation.angle_to(&wrong_order) > 1e-6);
+    }
+
+    #[test]
+    fn waypoint_with_offset_propagates_out_of_range_error() {
+        let traj = Trajectory::from_endpoints(
+            make_pointing(0.0, 0.0),
+            make_pointing(1.0, 0.0),
+            Duration::from_secs(10),
+        )
+        .unwrap();
+        let delta = UnitQuaternion::identity();
+        let err = traj
+            .waypoint_with_offset(Duration::from_secs(11), delta)
+            .expect_err("out-of-range time must error");
         assert!(matches!(err, TrajectoryError::TimeOutOfRange(_, _, _)));
     }
 }


### PR DESCRIPTION
Closes #96.

## Summary

Adds `Trajectory::waypoint_with_offset(t, delta)`, a one-line convenience that looks up the interpolated pose at time `t` and post-composes a body-frame offset quaternion onto it, returning a `Waypoint` stamped at `t`. This is the injection point the `tracking-test-bench` `scene-camera` crate uses to fold the per-frame FSM-commanded angular offset into the rendered ROI pose:

```
pose_for_render = trajectory(t) ⊗ fsm_offset
```

## Composition order

The implementation is `base * delta`, where `base = self.orientation_at(t)?`. In nalgebra's convention, `q1 * q2` applied to a vector `v` produces `q1 * (q2 * v)` — so `delta` rotates first (interpreting it as a body-frame offset) and then `base` carries the body-frame vector into world coordinates. That matches the "FSM offset commanded in body frame, then body-to-world via spacecraft attitude" semantics in the issue. The test guards against accidentally flipping to `delta * base` by verifying the wrong-order product is measurably different for a non-commuting case.

## Return type rationale (`Result<Waypoint, _>` vs raw `Waypoint`)

The issue's signature sketch returns `Waypoint`, but `orientation_at` returns `Result<UnitQuaternion<f64>, TrajectoryError>` and the only way to silence that here would be `.unwrap()` or `.expect()`. Doing so would force every caller to pre-validate `t` against the trajectory bounds (which they can't always do cheaply for periodic/aperiodic cases), and would turn a recoverable out-of-range query into a panic deep inside the renderer.

Returning `Result<Waypoint, TrajectoryError>` keeps the helper composable with the rest of the trajectory API (`pointing_at`, `peak_excursion_rad`, etc.), lets callers propagate the error with `?`, and costs nothing for the happy path. If a future caller really wants the infallible form, they can wrap with `.expect("FSM tick within trajectory window")` at the call site where they own the invariant.

## Test plan

- [x] `waypoint_with_offset_post_composes_delta_onto_base`: static trajectory at the midpoint, 30° rotation about body +Z; verifies the result equals `base * delta` to machine precision (`angle_to < 1e-15`), verifies `wp.time == t`, and verifies `delta * base` differs measurably (composition order is asserted, not just coincidentally correct).
- [x] `waypoint_with_offset_propagates_out_of_range_error`: identity delta at `t = end + 1s` returns `Err(TimeOutOfRange)`, confirming the `?` propagation is wired correctly.
- [x] `cargo fmt`, `cargo clippy -p simulator -- -W clippy::all`, `cargo test -p simulator` all clean (290 passed).