### PR TITLE
motion_blur: add render_one_frame_roi for live ROI rendering

### DIFF
--- a/simulator/benches/render.rs
+++ b/simulator/benches/render.rs
@@ -1,11 +1,17 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use ndarray::Array2;
 use shared::image_proc::airy::PixelScaledAiryDisk;
+use shared::image_proc::detection::AABB;
 use shared::units::{LengthExt, Temperature, TemperatureExt, Wavelength};
+use simulator::hardware::satellite::FocalPlaneConfig;
 use simulator::hardware::sensor::models::IMX455;
 use simulator::hardware::SatelliteConfig;
 use simulator::image_proc::render::{add_stars_to_image, quantize_image, StarInFrame};
 use simulator::photometry::photoconversion::{SourceFlux, SpotFlux};
+use simulator::photometry::zodiacal::SolarAngularCoordinates;
+use simulator::sims::motion_blur::{render_one_frame, render_one_frame_roi, MotionBlurConfig};
+use simulator::sims::orientation::orientation_from_pointing;
+use simulator::sims::trajectory::{Trajectory, Waypoint};
 use starfield::catalogs::StarData;
 use starfield::Equatorial;
 use std::time::Duration;
@@ -129,10 +135,121 @@ fn bench_renderer_render(c: &mut Criterion) {
     });
 }
 
+/// Build a single-sensor focal plane on a representative IMX455-class
+/// detector for the ROI vs full-frame benchmark. Resolution is the
+/// full 9568x6380 native frame.
+fn bench_focal_plane() -> FocalPlaneConfig {
+    let telescope = simulator::hardware::telescope::TelescopeConfig::new(
+        "Bench Telescope".to_string(),
+        shared::units::Length::from_meters(0.5),
+        shared::units::Length::from_meters(5.0),
+        0.9,
+    );
+    let sat = SatelliteConfig::new(telescope, IMX455.clone(), Temperature::from_celsius(-10.0));
+    FocalPlaneConfig::from_satellite(&sat)
+}
+
+fn bench_catalog(center: Equatorial, count: usize) -> Vec<StarData> {
+    (0..count)
+        .map(|i| {
+            let ra = center.ra_degrees() + ((i as f64 * 0.013) % 1.0 - 0.5) * 0.5;
+            let dec = center.dec_degrees() + ((i as f64 * 0.017) % 1.0 - 0.5) * 0.3;
+            StarData {
+                id: i as u64,
+                magnitude: 8.0 + (i as f64 % 4.0),
+                position: Equatorial::from_degrees(ra, dec),
+                b_v: Some(0.6),
+            }
+        })
+        .collect()
+}
+
+/// Compare `render_one_frame` (full 9568x6380) against
+/// `render_one_frame_roi` for a 1024x1024 ROI on the same sensor.
+/// Reports times so callers can read off the speedup ratio. Per
+/// project convention this bench does **not** assert any timing —
+/// CI is variable; the bench is for visibility.
+fn bench_render_one_frame_full_vs_roi(c: &mut Criterion) {
+    let fp = bench_focal_plane();
+    let center = Equatorial::from_degrees(56.75, 24.12);
+    let stars = bench_catalog(center, 200);
+    let traj = Trajectory::new(vec![
+        Waypoint::new(Duration::ZERO, orientation_from_pointing(&center, 0.0)),
+        Waypoint::new(
+            Duration::from_secs(10),
+            orientation_from_pointing(&center, 0.0),
+        ),
+    ])
+    .expect("static trajectory");
+    let cfg = MotionBlurConfig {
+        timestep: Duration::from_secs(1),
+        exposure: Duration::from_secs(1),
+        max_drift_per_stamp_px: 0.1,
+        base_seed: Some(0xCAFE_F00D),
+        force_static: true,
+        quiet: true,
+        ..Default::default()
+    };
+    let zodi = SolarAngularCoordinates::zodiacal_minimum();
+    let sensor_idx = 0_usize;
+
+    // Center the ROI in the middle of the 9568x6380 sensor.
+    let sat = fp.satellite_for_sensor(sensor_idx).unwrap();
+    let (sensor_w, sensor_h) = sat.sensor.dimensions.get_pixel_width_height();
+    let roi_side = 1024_usize;
+    let min_row = (sensor_h - roi_side) / 2;
+    let min_col = (sensor_w - roi_side) / 2;
+    let roi = AABB::from_coords(
+        min_row,
+        min_col,
+        min_row + roi_side - 1,
+        min_col + roi_side - 1,
+    );
+
+    let mut group = c.benchmark_group("render_one_frame_roi");
+    group.sample_size(10);
+    group.bench_function("full_9568x6380", |b| {
+        b.iter(|| {
+            render_one_frame(
+                black_box(&traj),
+                black_box(&stars),
+                black_box(&[]),
+                black_box(&fp),
+                black_box(zodi),
+                black_box(Duration::ZERO),
+                black_box(0),
+                black_box(&cfg),
+                None,
+            )
+            .expect("render_one_frame")
+        })
+    });
+    group.bench_function("roi_1024x1024", |b| {
+        b.iter(|| {
+            render_one_frame_roi(
+                black_box(&traj),
+                black_box(&stars),
+                black_box(&[]),
+                black_box(&fp),
+                black_box(zodi),
+                black_box(Duration::ZERO),
+                black_box(0),
+                black_box(&cfg),
+                None,
+                black_box(roi),
+                black_box(sensor_idx),
+            )
+            .expect("render_one_frame_roi")
+        })
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_add_stars_to_image,
     bench_quantize_image,
     bench_renderer_render,
+    bench_render_one_frame_full_vs_roi,
 );
 criterion_main!(benches);

--- a/simulator/src/sims/motion_blur.rs
+++ b/simulator/src/sims/motion_blur.rs
@@ -40,6 +40,7 @@ use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use log::{debug, info};
 use ndarray::Array2;
 use rayon::prelude::*;
+use shared::image_proc::detection::AABB;
 use shared::image_proc::noise::{apply_gaussian_read_noise, apply_poisson_photon_noise};
 use shared::units::{AngleExt, LengthExt, TemperatureExt};
 use starfield::catalogs::StarData;
@@ -47,6 +48,7 @@ use starfield::Equatorial;
 
 use crate::hardware::satellite::{FocalPlaneConfig, FocalPlaneProjector};
 use crate::hardware::SatelliteConfig;
+use crate::image_proc::deposit::MeanFluxDeposit;
 use crate::image_proc::render::quantize_image;
 use crate::photometry::photoconversion::SourceFlux;
 use crate::photometry::spectrum::Spectrum;
@@ -497,7 +499,68 @@ fn render_tile_array(
     tile_seed: u64,
 ) -> Result<Array2<u16>, TrajectoryError> {
     let (width, height) = satellite.sensor.dimensions.get_pixel_width_height();
-    let mut accumulator = SensorAccumulator::zero(width, height);
+    if width == 0 || height == 0 {
+        return Ok(Array2::<u16>::zeros((height, width)));
+    }
+    let full_roi = AABB::from_coords(0, 0, height - 1, width - 1);
+    render_tile_array_roi(
+        scene, plan, sensor_idx, flux_cache, satellite, tile_seed, full_roi,
+    )
+}
+
+/// Output of [`build_tile_mean_image`]: the pre-noise mean-electron
+/// image for a tile ROI plus the elapsed-time breakdown for the
+/// caller's debug log.
+struct MeanImageResult {
+    mean_image: Array2<f64>,
+    roi_w: usize,
+    roi_h: usize,
+    ms_splat_stars: u128,
+    ms_splat_galaxies: u128,
+    ms_combined_mean: u128,
+}
+
+/// Build the pre-noise mean-electron image for one tile's `roi` —
+/// splats stars across the stamp schedule, splats galaxies once,
+/// folds in the per-tile zodiacal and dark-current scalars. The
+/// returned `Array2<f64>` is shaped `(roi_height, roi_width)` with the
+/// pixel at `(0, 0)` corresponding to sensor pixel
+/// `(roi.min_row, roi.min_col)`.
+///
+/// Stars and galaxies whose entire footprint AABB falls outside the
+/// ROI are skipped (perf, no math effect). Partial-overlap deposits
+/// land via the standard `splat_deposit` bounds check, which clips at
+/// the ROI buffer's edge.
+fn build_tile_mean_image(
+    scene: &RenderScene,
+    plan: &FramePlan,
+    sensor_idx: usize,
+    flux_cache: &Arc<Mutex<FluxCache>>,
+    satellite: &SatelliteConfig,
+    tile_seed: u64,
+    roi: AABB,
+) -> Result<MeanImageResult, TrajectoryError> {
+    let (sensor_w, sensor_h) = satellite.sensor.dimensions.get_pixel_width_height();
+    if sensor_w == 0
+        || sensor_h == 0
+        || roi.max_row >= sensor_h
+        || roi.max_col >= sensor_w
+        || roi.min_row > roi.max_row
+        || roi.min_col > roi.max_col
+    {
+        return Err(TrajectoryError::RoiOutOfBounds {
+            roi: roi.to_tuple(),
+            sensor_idx,
+            width: sensor_w,
+            height: sensor_h,
+        });
+    }
+    let roi_w = roi.max_col - roi.min_col + 1;
+    let roi_h = roi.max_row - roi.min_row + 1;
+    let x_off = roi.min_col as f64;
+    let y_off = roi.min_row as f64;
+
+    let mut accumulator = SensorAccumulator::zero(roi_w, roi_h);
     let aperture = satellite.telescope.clear_aperture_area();
 
     let schedule = &plan.schedule;
@@ -538,11 +601,28 @@ fn render_tile_array(
                     .or_insert_with(|| star_data_to_fluxes(star, satellite))
                     .clone()
             });
+            // Skip stars whose entire PSF footprint falls outside the
+            // ROI extent — the splat would write nothing once shifted
+            // into ROI-local coordinates, so the per-pixel Simpson loop
+            // is a pure cost.
+            let footprint = flux.electrons.disk.footprint_pixels() as f64;
+            if hit.0 + footprint < x_off
+                || hit.0 - footprint >= x_off + roi_w as f64
+                || hit.1 + footprint < y_off
+                || hit.1 - footprint >= y_off + roi_h as f64
+            {
+                continue;
+            }
             // Per-stamp electron contribution: flux rate × per-stamp
             // dt (= exposure / stamps_per_exposure) × aperture. Sum
             // over all stamps reproduces the full exposure budget.
             let total_electrons = flux.electrons.integrated_over(&dt, aperture) * stamp_weight;
-            accumulator.splat_psf(hit.0, hit.1, total_electrons, &flux.electrons.disk);
+            accumulator.splat_psf(
+                hit.0 - x_off,
+                hit.1 - y_off,
+                total_electrons,
+                &flux.electrons.disk,
+            );
         }
     }
     let ms_splat_stars = t_splat_stars.elapsed().as_millis();
@@ -562,11 +642,24 @@ fn render_tile_array(
         .map(|v| v.as_slice())
         .unwrap_or(&[]);
     for galaxy in galaxies {
+        let footprint = galaxy.deposit.footprint_pixels() as f64;
+        if galaxy.x + footprint < x_off
+            || galaxy.x - footprint >= x_off + roi_w as f64
+            || galaxy.y + footprint < y_off
+            || galaxy.y - footprint >= y_off + roi_h as f64
+        {
+            continue;
+        }
         let total_electrons = galaxy
             .flux
             .electrons
             .integrated_over(&schedule.exposure, aperture);
-        accumulator.splat_galaxy(galaxy.x, galaxy.y, total_electrons, &galaxy.deposit);
+        accumulator.splat_galaxy(
+            galaxy.x - x_off,
+            galaxy.y - y_off,
+            total_electrons,
+            &galaxy.deposit,
+        );
     }
     let ms_splat_galaxies = t_splat_galaxies.elapsed().as_millis();
 
@@ -576,10 +669,59 @@ fn render_tile_array(
         .dark_current_at_temperature(satellite.temperature);
     let dark_mean = (dark_rate * schedule.exposure.as_secs_f64()).max(0.0);
 
-    // Build unified Poisson mean image and draw.
+    // Build unified Poisson mean image.
     let t_combined_mean = Instant::now();
     let mean_image = accumulator.into_combined_mean(plan.zodiacal_per_px[sensor_idx], dark_mean);
     let ms_combined_mean = t_combined_mean.elapsed().as_millis();
+
+    Ok(MeanImageResult {
+        mean_image,
+        roi_w,
+        roi_h,
+        ms_splat_stars,
+        ms_splat_galaxies,
+        ms_combined_mean,
+    })
+}
+
+/// Render the subset of a `(frame, sensor)` tile that falls inside `roi`.
+///
+/// Produces an `Array2<u16>` shaped `(roi_height, roi_width)`. The
+/// pixel at `(0, 0)` of the returned array corresponds to sensor pixel
+/// `(roi.min_row, roi.min_col)`.
+///
+/// `roi` uses inclusive bounds in sensor (row, col) coordinates and must
+/// be entirely inside the sensor extent. Stars and galaxies are filtered
+/// against the ROI extent inflated by the PSF/Sérsic footprint so any
+/// source whose deposit can touch the ROI is splatted; partial-overlap
+/// deposits clip at the ROI edge.
+///
+/// **Bit-equality contract**: when `roi` covers the full sensor, the
+/// quantized output is byte-identical to [`render_tile_array`] for the
+/// same `(scene, plan, sensor_idx, tile_seed)`. For a smaller `roi` the
+/// pre-noise mean-electron image is byte-identical to the corresponding
+/// slice of the full-sensor mean, but the Poisson and Gaussian noise
+/// streams differ because the shared parallel-chunk noise sampler keys
+/// its per-row-chunk RNG off the buffer's row count.
+fn render_tile_array_roi(
+    scene: &RenderScene,
+    plan: &FramePlan,
+    sensor_idx: usize,
+    flux_cache: &Arc<Mutex<FluxCache>>,
+    satellite: &SatelliteConfig,
+    tile_seed: u64,
+    roi: AABB,
+) -> Result<Array2<u16>, TrajectoryError> {
+    let MeanImageResult {
+        mean_image,
+        roi_w,
+        roi_h,
+        ms_splat_stars,
+        ms_splat_galaxies,
+        ms_combined_mean,
+    } = build_tile_mean_image(
+        scene, plan, sensor_idx, flux_cache, satellite, tile_seed, roi,
+    )?;
 
     let t_poisson = Instant::now();
     let poisson_image = apply_poisson_photon_noise(mean_image, Some(tile_seed ^ POISSON_DOMAIN));
@@ -589,7 +731,7 @@ fn render_tile_array(
     let read_noise_rms = satellite
         .sensor
         .read_noise_estimator
-        .estimate(satellite.temperature.as_celsius(), schedule.exposure)
+        .estimate(satellite.temperature.as_celsius(), plan.schedule.exposure)
         .unwrap_or(0.0)
         .max(0.0);
     let t_read_noise = Instant::now();
@@ -605,11 +747,15 @@ fn render_tile_array(
     let ms_quantize = t_quantize.elapsed().as_millis();
 
     debug!(
-        "tile-phases frame={} sensor={} \
+        "tile-phases frame={} sensor={} roi=({},{})+{}x{} \
          splat_stars={}ms splat_galaxies={}ms combined_mean={}ms \
          poisson={}ms read_noise={}ms quantize={}ms",
         plan.idx,
         sensor_idx,
+        roi.min_col,
+        roi.min_row,
+        roi_w,
+        roi_h,
         ms_splat_stars,
         ms_splat_galaxies,
         ms_combined_mean,
@@ -820,6 +966,73 @@ pub fn render_one_frame(
         .into_iter()
         .map(|i| i.expect("sensor index covered"))
         .collect())
+}
+
+/// Render the `roi` slice of a single `(frame, sensor)` into a quantized
+/// `Array2<u16>` shaped `(roi_height, roi_width)`.
+///
+/// Live-render counterpart to [`render_one_frame`] for callers that
+/// only need a sub-region of one sensor — e.g. an FSM-offset
+/// region-of-interest at full frame rate without paying full-sensor
+/// stamping and noise-sampling cost. The pixel at `(0, 0)` of the
+/// returned array corresponds to sensor pixel
+/// `(roi.min_row, roi.min_col)`.
+///
+/// `roi` is in sensor pixel coordinates with inclusive bounds and must
+/// be entirely contained in the sensor at `sensor_idx`. The returned
+/// image has dimensions `(roi.max_row - roi.min_row + 1,
+/// roi.max_col - roi.min_col + 1)`.
+///
+/// `sensor_idx` selects which sensor on the focal plane the ROI lies
+/// on. Out-of-range indices return [`TrajectoryError::NoSensors`].
+///
+/// # Bit-equality
+///
+/// - When `roi` covers the full sensor extent the output equals
+///   `render_one_frame(...)[sensor_idx]` **byte-for-byte**: the
+///   accumulator and noise buffers have the same shape as the
+///   full-sensor render so every chunk-keyed RNG stream visits the
+///   same pixels in the same order.
+/// - For a smaller `roi` the **pre-noise mean-electron image** is
+///   bit-identical to the corresponding slice of a full-frame render.
+///   The post-noise quantized output diverges because the
+///   `process_array_in_parallel_chunks` sampler used by
+///   `apply_poisson_photon_noise` and `apply_gaussian_read_noise`
+///   keys its per-row-chunk seed off the array's row count, so a
+///   smaller buffer produces a different RNG sequence even with the
+///   same base seed.
+#[allow(clippy::too_many_arguments)]
+pub fn render_one_frame_roi(
+    trajectory: &Trajectory,
+    catalog_stars: &[StarData],
+    per_sensor_galaxies: &[Vec<GalaxyInFrame>],
+    fp: &FocalPlaneConfig,
+    zodiacal: SolarAngularCoordinates,
+    frame_start: Duration,
+    frame_idx: usize,
+    config: &MotionBlurConfig,
+    flux_cache: Option<Arc<Mutex<FluxCache>>>,
+    roi: AABB,
+    sensor_idx: usize,
+) -> Result<Array2<u16>, TrajectoryError> {
+    let ctx = RenderContext::from_focal_plane(fp)?;
+    if sensor_idx >= ctx.satellites.len() {
+        return Err(TrajectoryError::NoSensors);
+    }
+    let scene = RenderScene {
+        trajectory,
+        catalog_stars,
+        per_sensor_galaxies,
+        fp,
+        zodiacal,
+    };
+    let zlight = ZodiacalLight::new();
+    let plan = plan_frame(&scene, &ctx, &zlight, frame_idx, frame_start, config)?;
+    let cache = flux_cache.unwrap_or_else(|| Arc::new(Mutex::new(HashMap::new())));
+    let base_seed = config.base_seed.unwrap_or(0xDEADBEEF_DEADBEEF);
+    let sat = &ctx.satellites[sensor_idx];
+    let seed = tile_seed(base_seed, frame_idx, sensor_idx);
+    render_tile_array_roi(&scene, &plan, sensor_idx, &cache, sat, seed, roi)
 }
 
 /// Render the full trajectory with motion blur, parallel over `(frame, sensor)`.
@@ -1908,6 +2121,208 @@ mod tests {
         assert_eq!(
             one[0], png_arr,
             "render_one_frame must produce the same pixels render_motion_trajectory writes"
+        );
+    }
+
+    /// Standard fixture for the ROI bit-equality tests: tiny focal plane,
+    /// a handful of well-placed stars, deterministic seed.
+    fn roi_test_fixture() -> (
+        FocalPlaneConfig,
+        Vec<StarData>,
+        Trajectory,
+        MotionBlurConfig,
+    ) {
+        let fp = tiny_fp();
+        let pointing = Equatorial::from_degrees(45.0, 30.0);
+        let stars: Vec<StarData> = (0..6)
+            .map(|i| StarData {
+                id: i as u64,
+                magnitude: 7.0 + i as f64 * 0.1,
+                position: Equatorial::from_degrees(
+                    pointing.ra_degrees() + 0.0008 * (i as f64 - 2.5),
+                    pointing.dec_degrees() + 0.0005 * (i as f64 - 1.5),
+                ),
+                b_v: Some(0.6),
+            })
+            .collect();
+        let traj = static_trajectory();
+        let cfg = MotionBlurConfig {
+            timestep: Duration::from_secs(1),
+            exposure: Duration::from_secs(1),
+            max_drift_per_stamp_px: 0.1,
+            base_seed: Some(0x0FC8_BEEF),
+            force_static: false,
+            quiet: true,
+            ..Default::default()
+        };
+        (fp, stars, traj, cfg)
+    }
+
+    #[test]
+    fn test_render_one_frame_roi_full_sensor_is_byte_equal() {
+        // ROI covering the entire sensor must produce a byte-identical
+        // image to render_one_frame's output for that sensor. The
+        // accumulator and noise buffers are identically shaped between
+        // the two paths, so the chunk-keyed RNG streams advance through
+        // the same pixels in the same order.
+        let (fp, stars, traj, cfg) = roi_test_fixture();
+        let full = render_one_frame(
+            &traj,
+            &stars,
+            &[],
+            &fp,
+            SolarAngularCoordinates::zodiacal_minimum(),
+            Duration::ZERO,
+            0,
+            &cfg,
+            None,
+        )
+        .unwrap();
+
+        let sat = fp.satellite_for_sensor(0).unwrap();
+        let (w, h) = sat.sensor.dimensions.get_pixel_width_height();
+        let roi = AABB::from_coords(0, 0, h - 1, w - 1);
+        let roi_image = render_one_frame_roi(
+            &traj,
+            &stars,
+            &[],
+            &fp,
+            SolarAngularCoordinates::zodiacal_minimum(),
+            Duration::ZERO,
+            0,
+            &cfg,
+            None,
+            roi,
+            0,
+        )
+        .unwrap();
+
+        assert_eq!(roi_image.dim(), (h, w));
+        assert_eq!(
+            roi_image, full[0],
+            "full-sensor ROI must be byte-equal to render_one_frame[sensor_idx]"
+        );
+    }
+
+    #[test]
+    fn test_render_one_frame_roi_subset_mean_matches_full_slice() {
+        // Sub-region ROI: the pre-noise mean-electron image must equal the
+        // corresponding slice of the full-sensor mean byte-for-byte. The
+        // quantized post-noise output cannot be checked directly because
+        // the chunk-keyed noise sampler advances differently on a smaller
+        // buffer (see render_one_frame_roi docs).
+        let (fp, stars, traj, cfg) = roi_test_fixture();
+        let ctx = RenderContext::from_focal_plane(&fp).unwrap();
+        let scene = RenderScene {
+            trajectory: &traj,
+            catalog_stars: &stars,
+            per_sensor_galaxies: &[],
+            fp: &fp,
+            zodiacal: SolarAngularCoordinates::zodiacal_minimum(),
+        };
+        let zlight = ZodiacalLight::new();
+        let plan = plan_frame(&scene, &ctx, &zlight, 0, Duration::ZERO, &cfg).unwrap();
+        let cache: Arc<Mutex<FluxCache>> = Arc::new(Mutex::new(HashMap::new()));
+        let sensor_idx = 0;
+        let sat = &ctx.satellites[sensor_idx];
+        let seed = tile_seed(cfg.base_seed.unwrap(), 0, sensor_idx);
+
+        let (w, h) = sat.sensor.dimensions.get_pixel_width_height();
+        let full_mean = build_tile_mean_image(
+            &scene,
+            &plan,
+            sensor_idx,
+            &cache,
+            sat,
+            seed,
+            AABB::from_coords(0, 0, h - 1, w - 1),
+        )
+        .unwrap()
+        .mean_image;
+
+        // A 24x24 ROI offset into the interior of the 64x64 sensor.
+        let roi = AABB::from_coords(12, 14, 35, 37);
+        let roi_w = roi.max_col - roi.min_col + 1;
+        let roi_h = roi.max_row - roi.min_row + 1;
+        let roi_mean = build_tile_mean_image(&scene, &plan, sensor_idx, &cache, sat, seed, roi)
+            .unwrap()
+            .mean_image;
+
+        assert_eq!(roi_mean.dim(), (roi_h, roi_w));
+        for r in 0..roi_h {
+            for c in 0..roi_w {
+                let full_val = full_mean[[roi.min_row + r, roi.min_col + c]];
+                let roi_val = roi_mean[[r, c]];
+                assert_eq!(
+                    roi_val.to_bits(),
+                    full_val.to_bits(),
+                    "mean-image pixel ({r},{c}) (sensor {},{}) diverged: roi={roi_val} full={full_val}",
+                    roi.min_row + r,
+                    roi.min_col + c,
+                );
+            }
+        }
+
+        // Sanity check the quantized output too: dimension and dtype only.
+        let roi_image = render_one_frame_roi(
+            &traj,
+            &stars,
+            &[],
+            &fp,
+            SolarAngularCoordinates::zodiacal_minimum(),
+            Duration::ZERO,
+            0,
+            &cfg,
+            None,
+            roi,
+            sensor_idx,
+        )
+        .unwrap();
+        assert_eq!(roi_image.dim(), (roi_h, roi_w));
+    }
+
+    #[test]
+    fn test_render_one_frame_roi_rejects_out_of_bounds() {
+        let (fp, stars, traj, cfg) = roi_test_fixture();
+        let sat = fp.satellite_for_sensor(0).unwrap();
+        let (w, h) = sat.sensor.dimensions.get_pixel_width_height();
+        let oob = AABB::from_coords(0, 0, h, w); // max equal to dim -> out of bounds (inclusive)
+        let err = render_one_frame_roi(
+            &traj,
+            &stars,
+            &[],
+            &fp,
+            SolarAngularCoordinates::zodiacal_minimum(),
+            Duration::ZERO,
+            0,
+            &cfg,
+            None,
+            oob,
+            0,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, TrajectoryError::RoiOutOfBounds { .. }),
+            "expected RoiOutOfBounds, got {err:?}"
+        );
+
+        let bad_sensor = render_one_frame_roi(
+            &traj,
+            &stars,
+            &[],
+            &fp,
+            SolarAngularCoordinates::zodiacal_minimum(),
+            Duration::ZERO,
+            0,
+            &cfg,
+            None,
+            AABB::from_coords(0, 0, h - 1, w - 1),
+            99,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(bad_sensor, TrajectoryError::NoSensors),
+            "expected NoSensors for sensor_idx out of range, got {bad_sensor:?}"
         );
     }
 

--- a/simulator/src/sims/trajectory.rs
+++ b/simulator/src/sims/trajectory.rs
@@ -40,6 +40,14 @@ pub enum TrajectoryError {
     #[error("focal plane has no sensors")]
     NoSensors,
 
+    #[error("ROI {roi:?} out of bounds for sensor {sensor_idx} ({width}x{height})")]
+    RoiOutOfBounds {
+        roi: (usize, usize, usize, usize),
+        sensor_idx: usize,
+        width: usize,
+        height: usize,
+    },
+
     #[error("image write error: {0}")]
     ImageWrite(String),
 }


### PR DESCRIPTION
Closes #92

## Summary

Adds `render_one_frame_roi` — a sibling of `render_one_frame` that live-renders the subset of a single sensor inside a caller-supplied ROI, sized for the tracking-test-bench `scene-camera` 4 fps FSM-offset path. Rendering the full 9568x6380 sensor every tick burns the entire 250ms budget on pixels we discard; ROI rendering recovers ~6x on a representative 1024x1024 window.

## ROI gating strategy

- **Star filter**: each star's PSF footprint AABB (from `MeanFluxDeposit::footprint_pixels`) is tested against the ROI. Stars whose footprint cannot touch the ROI are skipped after projection — avoids the per-pixel Simpson loop for the off-ROI majority. Partial-overlap stars are splatted at shifted `(px - roi.min_col, py - roi.min_row)` into the ROI-sized accumulator; `splat_deposit`'s existing bounds check clips at the buffer edge.
- **Galaxy filter**: identical AABB test on `SersicSplat::footprint_pixels`, identical shifted-coordinate splat with edge clipping.
- **Background**: zodi-per-pixel and dark-per-pixel are scalars over the sensor, so they fold into the ROI-sized accumulator unchanged.
- **Output buffer**: `Array2::<u16>::zeros((roi_h, roi_w))`. The noise samplers and `quantize_image` run on the ROI buffer rather than the full sensor.

## AABB type choice

Reused `shared::image_proc::detection::AABB` rather than introducing a new `RoiBox`. The struct already exists in the foundations crate with the right shape (inclusive `min_row/min_col/max_row/max_col`, row/col convention matching `Array2<f64>`), is `Copy`, and integrates with the rest of the detection pipeline if future callers want to thread detected objects back into render ROIs. The issue's `AABB` naming maps directly.

## Bit-equality results

Two tests in `simulator::sims::motion_blur::tests`:

- `test_render_one_frame_roi_full_sensor_is_byte_equal`: `roi == full sensor extent` produces a `u16` array byte-identical to `render_one_frame(...)[sensor_idx]`. Passes.
- `test_render_one_frame_roi_subset_mean_matches_full_slice`: 24x24 sub-ROI on a 64x64 sensor, the pre-noise mean-electron image is byte-identical to the corresponding slice of the full-sensor mean. Passes.

The smaller-ROI quantized output is **not** byte-equal to the full-frame slice and this is unavoidable: `shared::process_array_in_parallel_chunks` (used by `apply_poisson_photon_noise` and `apply_gaussian_read_noise`) seeds each per-row-chunk RNG as `seed + chunk_idx`. Different array row counts produce different chunk boundaries and therefore different RNG sequences for the same `tile_seed`. The function-level docs spell this out, and a third test (`test_render_one_frame_roi_rejects_out_of_bounds`) covers the new `TrajectoryError::RoiOutOfBounds` variant.

## Benchmark numbers (local cfl-test-bench, criterion median of 10 samples)

| variant | resolution | median time |
| --- | --- | --- |
| `render_one_frame` full | 9568x6380 | **223.5 ms** |
| `render_one_frame_roi`  | 1024x1024 | **35.6 ms** |

ROI is ~6.3x faster and well below the 50 ms target; full-frame is just over 250 ms which is exactly why we needed this. The bench lives in `simulator/benches/render.rs::bench_render_one_frame_full_vs_roi` and reports timings only — no perf assertion (project convention).

## Test plan
- [x] `cargo fmt -p simulator --check`
- [x] `cargo clippy -p simulator --all-targets -- -W clippy::all` (no new warnings in added code)
- [x] `cargo test -p simulator` (294 pass / 0 fail / 3 ignored)
- [x] `cargo bench -p simulator --bench render -- render_one_frame_roi` produces the table above