### PR TITLE
motion_blur: bundle stars+galaxies+zodi into LightSources

### DIFF
--- a/simulator/benches/render.rs
+++ b/simulator/benches/render.rs
@@ -9,7 +9,9 @@ use simulator::hardware::SatelliteConfig;
 use simulator::image_proc::render::{add_stars_to_image, quantize_image, StarInFrame};
 use simulator::photometry::photoconversion::{SourceFlux, SpotFlux};
 use simulator::photometry::zodiacal::SolarAngularCoordinates;
-use simulator::sims::motion_blur::{render_one_frame, render_one_frame_roi, MotionBlurConfig};
+use simulator::sims::motion_blur::{
+    render_one_frame, render_one_frame_roi, LightSources, MotionBlurConfig,
+};
 use simulator::sims::orientation::orientation_from_pointing;
 use simulator::sims::trajectory::{Trajectory, Waypoint};
 use starfield::catalogs::StarData;
@@ -206,16 +208,20 @@ fn bench_render_one_frame_full_vs_roi(c: &mut Criterion) {
         min_col + roi_side - 1,
     );
 
+    let sources = LightSources {
+        catalog_stars: &stars,
+        per_sensor_galaxies: &[],
+        zodiacal: zodi,
+    };
+
     let mut group = c.benchmark_group("render_one_frame_roi");
     group.sample_size(10);
     group.bench_function("full_9568x6380", |b| {
         b.iter(|| {
             render_one_frame(
                 black_box(&traj),
-                black_box(&stars),
-                black_box(&[]),
+                black_box(&sources),
                 black_box(&fp),
-                black_box(zodi),
                 black_box(Duration::ZERO),
                 black_box(0),
                 black_box(&cfg),
@@ -228,10 +234,8 @@ fn bench_render_one_frame_full_vs_roi(c: &mut Criterion) {
         b.iter(|| {
             render_one_frame_roi(
                 black_box(&traj),
-                black_box(&stars),
-                black_box(&[]),
+                black_box(&sources),
                 black_box(&fp),
-                black_box(zodi),
                 black_box(Duration::ZERO),
                 black_box(0),
                 black_box(&cfg),

--- a/simulator/src/bin/motion_simulator.rs
+++ b/simulator/src/bin/motion_simulator.rs
@@ -6,6 +6,7 @@ use simulator::hardware::sensor_array::{SensorArray, SPENCER_ARRAY_PLAN};
 use simulator::shared_args::{DurationArg, SensorModel, SharedSimulationArgs};
 use simulator::sims::context_render::{render_context_frame, ContextRenderConfig};
 use simulator::sims::jitter::build_pink_trajectory;
+use simulator::sims::motion_blur::LightSources;
 use simulator::sims::trajectory::{
     fov_envelope, prefetch_catalog_for_envelope, render_trajectory, Trajectory,
     TrajectoryRenderConfig, Waypoint,
@@ -813,9 +814,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             timestep: args.timestep.0,
             exposure: args.shared.exposure.0,
             focal_plane: &focal_plane,
-            catalog_stars: &stars,
-            per_sensor_galaxies: &per_sensor_galaxies,
-            zodiacal: args.shared.coordinates,
+            sources: LightSources {
+                catalog_stars: &stars,
+                per_sensor_galaxies: &per_sensor_galaxies,
+                zodiacal: args.shared.coordinates,
+            },
             output_dir: output_path,
             base_seed: Some(args.seed),
             max_drift_per_stamp_px: Some(args.max_drift_per_stamp_px),

--- a/simulator/src/sims/motion_blur.rs
+++ b/simulator/src/sims/motion_blur.rs
@@ -263,24 +263,25 @@ impl SensorAccumulator {
 /// repeating that work for every sub-orientation.
 pub type FluxCache = HashMap<(u64, usize), SourceFlux>;
 
+/// All light contributing to a rendered frame: foreground point sources
+/// (stars), extended sources (galaxies, pre-projected per sensor), and
+/// the diffuse sky background (zodiacal model parameters).
+#[derive(Clone, Copy)]
+pub struct LightSources<'a> {
+    pub catalog_stars: &'a [StarData],
+    pub per_sensor_galaxies: &'a [Vec<GalaxyInFrame>],
+    pub zodiacal: SolarAngularCoordinates,
+}
+
 /// Static inputs shared across every `(frame, sensor)` tile in a render.
 ///
-/// Bundles the trajectory, the full star catalog, the focal-plane hardware,
-/// and the scene's zodiacal coordinates so downstream functions take a single
-/// `&RenderScene` rather than four independent references.
+/// Bundles the trajectory, the scene's light sources, and the focal-plane
+/// hardware so downstream functions take a single `&RenderScene` rather
+/// than several independent references.
 struct RenderScene<'a> {
     trajectory: &'a Trajectory,
-    catalog_stars: &'a [StarData],
-    /// Per-sensor list of pre-projected galaxies (`Scene::with_galaxies`
-    /// shape). Empty inner vecs = no galaxies. Galaxies are projected
-    /// *once* per render at the trajectory's mid-time orientation —
-    /// exact for static trajectories, an approximation for drifting
-    /// trajectories where the galaxy positions would shift sub-pixel
-    /// across the exposure (acceptable until measured-radial-profile
-    /// rendering motivates the upgrade).
-    per_sensor_galaxies: &'a [Vec<GalaxyInFrame>],
+    sources: LightSources<'a>,
     fp: &'a FocalPlaneConfig,
-    zodiacal: SolarAngularCoordinates,
 }
 
 /// Per-frame render plan produced by the serial planning pass.
@@ -637,6 +638,7 @@ fn build_tile_mean_image(
     // trajectories (start == end) are exact.
     let t_splat_galaxies = Instant::now();
     let galaxies = scene
+        .sources
         .per_sensor_galaxies
         .get(sensor_idx)
         .map(|v| v.as_slice())
@@ -870,7 +872,7 @@ fn plan_frame<'a>(
 
     let first_sat = &ctx.satellites[0];
     let zodiacal_per_px_per_s =
-        zodiacal_per_px_per_s_at(zlight, first_sat, &scene.zodiacal, &mid_bore);
+        zodiacal_per_px_per_s_at(zlight, first_sat, &scene.sources.zodiacal, &mid_bore);
     let exposure_s = schedule.exposure.as_secs_f64();
     let zodiacal_per_px: Vec<f64> = ctx
         .sensor_ratios
@@ -880,7 +882,7 @@ fn plan_frame<'a>(
 
     let stars = envelope_prefilter(
         scene.trajectory,
-        scene.catalog_stars,
+        scene.sources.catalog_stars,
         &schedule,
         scene.fp,
         ctx.padding_mm,
@@ -921,13 +923,10 @@ fn plan_frame<'a>(
 /// `None` for a fresh per-call cache; pass `Some(...)` to reuse a cache
 /// across an outer loop over many frames with the same catalog and
 /// focal plane.
-#[allow(clippy::too_many_arguments)]
 pub fn render_one_frame(
     trajectory: &Trajectory,
-    catalog_stars: &[StarData],
-    per_sensor_galaxies: &[Vec<GalaxyInFrame>],
+    sources: &LightSources<'_>,
     fp: &FocalPlaneConfig,
-    zodiacal: SolarAngularCoordinates,
     frame_start: Duration,
     frame_idx: usize,
     config: &MotionBlurConfig,
@@ -936,10 +935,8 @@ pub fn render_one_frame(
     let ctx = RenderContext::from_focal_plane(fp)?;
     let scene = RenderScene {
         trajectory,
-        catalog_stars,
-        per_sensor_galaxies,
+        sources: *sources,
         fp,
-        zodiacal,
     };
     let zlight = ZodiacalLight::new();
     let plan = plan_frame(&scene, &ctx, &zlight, frame_idx, frame_start, config)?;
@@ -1004,10 +1001,8 @@ pub fn render_one_frame(
 #[allow(clippy::too_many_arguments)]
 pub fn render_one_frame_roi(
     trajectory: &Trajectory,
-    catalog_stars: &[StarData],
-    per_sensor_galaxies: &[Vec<GalaxyInFrame>],
+    sources: &LightSources<'_>,
     fp: &FocalPlaneConfig,
-    zodiacal: SolarAngularCoordinates,
     frame_start: Duration,
     frame_idx: usize,
     config: &MotionBlurConfig,
@@ -1021,10 +1016,8 @@ pub fn render_one_frame_roi(
     }
     let scene = RenderScene {
         trajectory,
-        catalog_stars,
-        per_sensor_galaxies,
+        sources: *sources,
         fp,
-        zodiacal,
     };
     let zlight = ZodiacalLight::new();
     let plan = plan_frame(&scene, &ctx, &zlight, frame_idx, frame_start, config)?;
@@ -1039,19 +1032,17 @@ pub fn render_one_frame_roi(
 ///
 /// Returns the total number of frames rendered.
 ///
-/// `per_sensor_galaxies` is the per-sensor pre-projected galaxy list
-/// (the `Scene::with_galaxies` shape). Pass an empty `Vec` per sensor
-/// for star-only renders. Galaxies are projected once at the
-/// trajectory's mid-time orientation and splatted at full-exposure
-/// flux per tile — exact for static trajectories, an approximation
-/// for drifting trajectories where a sub-pixel galaxy shift across
-/// the exposure becomes detectable.
+/// `sources.per_sensor_galaxies` is the per-sensor pre-projected
+/// galaxy list (the `Scene::with_galaxies` shape). Pass an empty
+/// `Vec` per sensor for star-only renders. Galaxies are projected
+/// once at the trajectory's mid-time orientation and splatted at
+/// full-exposure flux per tile — exact for static trajectories, an
+/// approximation for drifting trajectories where a sub-pixel galaxy
+/// shift across the exposure becomes detectable.
 pub fn render_motion_trajectory(
     trajectory: &Trajectory,
-    catalog_stars: &[StarData],
-    per_sensor_galaxies: &[Vec<GalaxyInFrame>],
+    sources: &LightSources<'_>,
     fp: &FocalPlaneConfig,
-    zodiacal: SolarAngularCoordinates,
     config: &MotionBlurConfig,
     output_dir: &Path,
 ) -> Result<usize, TrajectoryError> {
@@ -1060,10 +1051,8 @@ pub fn render_motion_trajectory(
 
     let scene = RenderScene {
         trajectory,
-        catalog_stars,
-        per_sensor_galaxies,
+        sources: *sources,
         fp,
-        zodiacal,
     };
 
     let frame_times = trajectory.frame_times(config.timestep);
@@ -1319,6 +1308,7 @@ fn build_render_metadata(
     }
 
     let stars: Vec<StarMeta> = scene
+        .sources
         .catalog_stars
         .iter()
         .map(|s| StarMeta {
@@ -1357,8 +1347,8 @@ fn build_render_metadata(
         force_static: config.force_static,
         catalog_path: config.catalog_path.to_string_lossy().into_owned(),
         zodiacal: ZodiacalMeta {
-            elongation_deg: scene.zodiacal.elongation(),
-            latitude_deg: scene.zodiacal.latitude(),
+            elongation_deg: scene.sources.zodiacal.elongation(),
+            latitude_deg: scene.sources.zodiacal.latitude(),
         },
     };
 
@@ -1601,16 +1591,12 @@ mod tests {
             ..Default::default()
         };
         let tmp = tempfile::tempdir().unwrap();
-        let frames = render_motion_trajectory(
-            &traj,
-            &[],
-            &[],
-            fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            &cfg,
-            tmp.path(),
-        )
-        .unwrap();
+        let sources = LightSources {
+            catalog_stars: &[],
+            per_sensor_galaxies: &[],
+            zodiacal: SolarAngularCoordinates::zodiacal_minimum(),
+        };
+        let frames = render_motion_trajectory(&traj, &sources, fp, &cfg, tmp.path()).unwrap();
         frames
     }
 
@@ -1645,16 +1631,12 @@ mod tests {
             ..Default::default()
         };
         let tmp = tempfile::tempdir().unwrap();
-        let frames = render_motion_trajectory(
-            &traj,
-            &[],
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            &cfg,
-            tmp.path(),
-        )
-        .unwrap();
+        let sources = LightSources {
+            catalog_stars: &[],
+            per_sensor_galaxies: &[],
+            zodiacal: SolarAngularCoordinates::zodiacal_minimum(),
+        };
+        let frames = render_motion_trajectory(&traj, &sources, &fp, &cfg, tmp.path()).unwrap();
         assert!(frames >= 1);
     }
 
@@ -1687,17 +1669,13 @@ mod tests {
             ..Default::default()
         };
         let tmp = tempfile::tempdir().unwrap();
+        let sources = LightSources {
+            catalog_stars: &stars,
+            per_sensor_galaxies: &[],
+            zodiacal: SolarAngularCoordinates::zodiacal_minimum(),
+        };
         // Render normally to exercise the cache.
-        let frames = render_motion_trajectory(
-            &traj,
-            &stars,
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            &cfg,
-            tmp.path(),
-        )
-        .unwrap();
+        let frames = render_motion_trajectory(&traj, &sources, &fp, &cfg, tmp.path()).unwrap();
         assert!(frames >= 3);
         // Cache size bound: at most num_stars * sensor_count.
         // We can't peek from outside the function, so rely on invariant by
@@ -1706,16 +1684,7 @@ mod tests {
         // The tightest assertion we can make without instrumenting the
         // internals is: a second run with the same inputs renders the same
         // number of frames, which would fail if the path were non-idempotent.
-        let frames2 = render_motion_trajectory(
-            &traj,
-            &stars,
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            &cfg,
-            tmp.path(),
-        )
-        .unwrap();
+        let frames2 = render_motion_trajectory(&traj, &sources, &fp, &cfg, tmp.path()).unwrap();
         assert_eq!(frames, frames2);
     }
 
@@ -1891,26 +1860,13 @@ mod tests {
         };
         let tmp_a = tempfile::tempdir().unwrap();
         let tmp_b = tempfile::tempdir().unwrap();
-        render_motion_trajectory(
-            &traj,
-            &stars,
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            &cfg,
-            tmp_a.path(),
-        )
-        .unwrap();
-        render_motion_trajectory(
-            &traj,
-            &stars,
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            &cfg,
-            tmp_b.path(),
-        )
-        .unwrap();
+        let sources = LightSources {
+            catalog_stars: &stars,
+            per_sensor_galaxies: &[],
+            zodiacal: SolarAngularCoordinates::zodiacal_minimum(),
+        };
+        render_motion_trajectory(&traj, &sources, &fp, &cfg, tmp_a.path()).unwrap();
+        render_motion_trajectory(&traj, &sources, &fp, &cfg, tmp_b.path()).unwrap();
         let name = "sensor_00/frame_000000.png";
         let a = std::fs::read(tmp_a.path().join(name)).unwrap();
         let b = std::fs::read(tmp_b.path().join(name)).unwrap();
@@ -1958,26 +1914,13 @@ mod tests {
         };
         let tmp_coarse = tempfile::tempdir().unwrap();
         let tmp_fine = tempfile::tempdir().unwrap();
-        render_motion_trajectory(
-            &traj,
-            &stars,
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            &cfg_coarse,
-            tmp_coarse.path(),
-        )
-        .unwrap();
-        render_motion_trajectory(
-            &traj,
-            &stars,
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            &cfg_fine,
-            tmp_fine.path(),
-        )
-        .unwrap();
+        let sources = LightSources {
+            catalog_stars: &stars,
+            per_sensor_galaxies: &[],
+            zodiacal: SolarAngularCoordinates::zodiacal_minimum(),
+        };
+        render_motion_trajectory(&traj, &sources, &fp, &cfg_coarse, tmp_coarse.path()).unwrap();
+        render_motion_trajectory(&traj, &sources, &fp, &cfg_fine, tmp_fine.path()).unwrap();
         let name = "sensor_00/frame_000000.png";
         let coarse = std::fs::read(tmp_coarse.path().join(name)).unwrap();
         let fine = std::fs::read(tmp_fine.path().join(name)).unwrap();
@@ -2025,30 +1968,13 @@ mod tests {
             ..Default::default()
         };
 
-        let first = render_one_frame(
-            &traj,
-            &stars,
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            Duration::ZERO,
-            0,
-            &cfg,
-            None,
-        )
-        .unwrap();
-        let second = render_one_frame(
-            &traj,
-            &stars,
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            Duration::ZERO,
-            0,
-            &cfg,
-            None,
-        )
-        .unwrap();
+        let sources = LightSources {
+            catalog_stars: &stars,
+            per_sensor_galaxies: &[],
+            zodiacal: SolarAngularCoordinates::zodiacal_minimum(),
+        };
+        let first = render_one_frame(&traj, &sources, &fp, Duration::ZERO, 0, &cfg, None).unwrap();
+        let second = render_one_frame(&traj, &sources, &fp, Duration::ZERO, 0, &cfg, None).unwrap();
 
         assert_eq!(first.len(), second.len());
         assert!(!first.is_empty(), "expected at least one sensor");
@@ -2089,30 +2015,16 @@ mod tests {
 
         let frame_idx = 0;
         let frame_start = Duration::ZERO;
-        let one = render_one_frame(
-            &traj,
-            &stars,
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            frame_start,
-            frame_idx,
-            &cfg,
-            None,
-        )
-        .unwrap();
+        let sources = LightSources {
+            catalog_stars: &stars,
+            per_sensor_galaxies: &[],
+            zodiacal: SolarAngularCoordinates::zodiacal_minimum(),
+        };
+        let one =
+            render_one_frame(&traj, &sources, &fp, frame_start, frame_idx, &cfg, None).unwrap();
 
         let tmp = tempfile::tempdir().unwrap();
-        render_motion_trajectory(
-            &traj,
-            &stars,
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            &cfg,
-            tmp.path(),
-        )
-        .unwrap();
+        render_motion_trajectory(&traj, &sources, &fp, &cfg, tmp.path()).unwrap();
 
         let png_path = tmp.path().join(sensor_relative_png_path(0, frame_idx));
         let img = image::open(&png_path).unwrap().to_luma16();
@@ -2166,36 +2078,19 @@ mod tests {
         // the two paths, so the chunk-keyed RNG streams advance through
         // the same pixels in the same order.
         let (fp, stars, traj, cfg) = roi_test_fixture();
-        let full = render_one_frame(
-            &traj,
-            &stars,
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            Duration::ZERO,
-            0,
-            &cfg,
-            None,
-        )
-        .unwrap();
+        let sources = LightSources {
+            catalog_stars: &stars,
+            per_sensor_galaxies: &[],
+            zodiacal: SolarAngularCoordinates::zodiacal_minimum(),
+        };
+        let full = render_one_frame(&traj, &sources, &fp, Duration::ZERO, 0, &cfg, None).unwrap();
 
         let sat = fp.satellite_for_sensor(0).unwrap();
         let (w, h) = sat.sensor.dimensions.get_pixel_width_height();
         let roi = AABB::from_coords(0, 0, h - 1, w - 1);
-        let roi_image = render_one_frame_roi(
-            &traj,
-            &stars,
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            Duration::ZERO,
-            0,
-            &cfg,
-            None,
-            roi,
-            0,
-        )
-        .unwrap();
+        let roi_image =
+            render_one_frame_roi(&traj, &sources, &fp, Duration::ZERO, 0, &cfg, None, roi, 0)
+                .unwrap();
 
         assert_eq!(roi_image.dim(), (h, w));
         assert_eq!(
@@ -2213,12 +2108,15 @@ mod tests {
         // buffer (see render_one_frame_roi docs).
         let (fp, stars, traj, cfg) = roi_test_fixture();
         let ctx = RenderContext::from_focal_plane(&fp).unwrap();
-        let scene = RenderScene {
-            trajectory: &traj,
+        let sources = LightSources {
             catalog_stars: &stars,
             per_sensor_galaxies: &[],
-            fp: &fp,
             zodiacal: SolarAngularCoordinates::zodiacal_minimum(),
+        };
+        let scene = RenderScene {
+            trajectory: &traj,
+            sources,
+            fp: &fp,
         };
         let zlight = ZodiacalLight::new();
         let plan = plan_frame(&scene, &ctx, &zlight, 0, Duration::ZERO, &cfg).unwrap();
@@ -2266,10 +2164,8 @@ mod tests {
         // Sanity check the quantized output too: dimension and dtype only.
         let roi_image = render_one_frame_roi(
             &traj,
-            &stars,
-            &[],
+            &sources,
             &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
             Duration::ZERO,
             0,
             &cfg,
@@ -2287,20 +2183,13 @@ mod tests {
         let sat = fp.satellite_for_sensor(0).unwrap();
         let (w, h) = sat.sensor.dimensions.get_pixel_width_height();
         let oob = AABB::from_coords(0, 0, h, w); // max equal to dim -> out of bounds (inclusive)
-        let err = render_one_frame_roi(
-            &traj,
-            &stars,
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            Duration::ZERO,
-            0,
-            &cfg,
-            None,
-            oob,
-            0,
-        )
-        .unwrap_err();
+        let sources = LightSources {
+            catalog_stars: &stars,
+            per_sensor_galaxies: &[],
+            zodiacal: SolarAngularCoordinates::zodiacal_minimum(),
+        };
+        let err = render_one_frame_roi(&traj, &sources, &fp, Duration::ZERO, 0, &cfg, None, oob, 0)
+            .unwrap_err();
         assert!(
             matches!(err, TrajectoryError::RoiOutOfBounds { .. }),
             "expected RoiOutOfBounds, got {err:?}"
@@ -2308,10 +2197,8 @@ mod tests {
 
         let bad_sensor = render_one_frame_roi(
             &traj,
-            &stars,
-            &[],
+            &sources,
             &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
             Duration::ZERO,
             0,
             &cfg,
@@ -2355,26 +2242,13 @@ mod tests {
         };
         let tmp_a = tempfile::tempdir().unwrap();
         let tmp_b = tempfile::tempdir().unwrap();
-        render_motion_trajectory(
-            &traj,
-            &stars,
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            &cfg,
-            tmp_a.path(),
-        )
-        .unwrap();
-        render_motion_trajectory(
-            &traj,
-            &stars,
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            &cfg,
-            tmp_b.path(),
-        )
-        .unwrap();
+        let sources = LightSources {
+            catalog_stars: &stars,
+            per_sensor_galaxies: &[],
+            zodiacal: SolarAngularCoordinates::zodiacal_minimum(),
+        };
+        render_motion_trajectory(&traj, &sources, &fp, &cfg, tmp_a.path()).unwrap();
+        render_motion_trajectory(&traj, &sources, &fp, &cfg, tmp_b.path()).unwrap();
 
         // Compare the PNG bytes of one frame. The new layout routes frame 0
         // of sensor 0 to `sensor_00/frame_000000.png`.
@@ -2414,16 +2288,12 @@ mod tests {
         let traj = static_trajectory();
         let cfg = minimal_metadata_cfg(5);
         let tmp = tempfile::tempdir().unwrap();
-        let frames = render_motion_trajectory(
-            &traj,
-            &[],
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            &cfg,
-            tmp.path(),
-        )
-        .unwrap();
+        let sources = LightSources {
+            catalog_stars: &[],
+            per_sensor_galaxies: &[],
+            zodiacal: SolarAngularCoordinates::zodiacal_minimum(),
+        };
+        let frames = render_motion_trajectory(&traj, &sources, &fp, &cfg, tmp.path()).unwrap();
         assert!(frames >= 2, "expected at least 2 frames, got {}", frames);
 
         let sensor_dir = tmp.path().join("sensor_00");
@@ -2447,16 +2317,12 @@ mod tests {
         let traj = static_trajectory();
         let cfg = minimal_metadata_cfg(17);
         let tmp = tempfile::tempdir().unwrap();
-        let frames = render_motion_trajectory(
-            &traj,
-            &[],
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            &cfg,
-            tmp.path(),
-        )
-        .unwrap();
+        let sources = LightSources {
+            catalog_stars: &[],
+            per_sensor_galaxies: &[],
+            zodiacal: SolarAngularCoordinates::zodiacal_minimum(),
+        };
+        let frames = render_motion_trajectory(&traj, &sources, &fp, &cfg, tmp.path()).unwrap();
         let raw = std::fs::read_to_string(tmp.path().join("metadata.json")).unwrap();
         let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
 
@@ -2502,16 +2368,12 @@ mod tests {
         let traj = static_trajectory();
         let cfg = minimal_metadata_cfg(23);
         let tmp = tempfile::tempdir().unwrap();
-        render_motion_trajectory(
-            &traj,
-            &[],
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            &cfg,
-            tmp.path(),
-        )
-        .unwrap();
+        let sources = LightSources {
+            catalog_stars: &[],
+            per_sensor_galaxies: &[],
+            zodiacal: SolarAngularCoordinates::zodiacal_minimum(),
+        };
+        render_motion_trajectory(&traj, &sources, &fp, &cfg, tmp.path()).unwrap();
         let raw = std::fs::read_to_string(tmp.path().join("metadata.json")).unwrap();
         let meta: crate::sims::motion_blur_metadata::RenderMetadata =
             serde_json::from_str(&raw).unwrap();
@@ -2565,16 +2427,12 @@ mod tests {
         let fp = tiny_fp();
         let cfg = minimal_metadata_cfg(31);
         let tmp = tempfile::tempdir().unwrap();
-        render_motion_trajectory(
-            &traj,
-            &[],
-            &[],
-            &fp,
-            SolarAngularCoordinates::zodiacal_minimum(),
-            &cfg,
-            tmp.path(),
-        )
-        .unwrap();
+        let sources = LightSources {
+            catalog_stars: &[],
+            per_sensor_galaxies: &[],
+            zodiacal: SolarAngularCoordinates::zodiacal_minimum(),
+        };
+        render_motion_trajectory(&traj, &sources, &fp, &cfg, tmp.path()).unwrap();
         let raw = std::fs::read_to_string(tmp.path().join("metadata.json")).unwrap();
         let meta: crate::sims::motion_blur_metadata::RenderMetadata =
             serde_json::from_str(&raw).unwrap();

--- a/simulator/src/sims/trajectory.rs
+++ b/simulator/src/sims/trajectory.rs
@@ -10,9 +10,8 @@ use thiserror::Error;
 use crate::hardware::satellite::FocalPlaneConfig;
 use crate::image_proc::render::{StarInFocalPlane, StarInFrame};
 use crate::photometry::photoconversion::SourceFlux;
-use crate::photometry::zodiacal::SolarAngularCoordinates;
 use crate::sims::motion_blur::{
-    render_motion_trajectory, MotionBlurConfig, DEFAULT_MAX_DRIFT_PER_STAMP_PX,
+    render_motion_trajectory, LightSources, MotionBlurConfig, DEFAULT_MAX_DRIFT_PER_STAMP_PX,
 };
 use crate::sims::orientation::{boresight_of, orientation_from_pointing};
 use crate::star_math::star_data_to_fluxes;
@@ -493,16 +492,11 @@ pub struct TrajectoryRenderConfig<'a> {
     pub exposure: Duration,
     /// Focal plane hardware configuration.
     pub focal_plane: &'a FocalPlaneConfig,
-    /// Pre-fetched catalog stars covering the full trajectory envelope.
-    pub catalog_stars: &'a [StarData],
-    /// Per-sensor pre-projected galaxies (`Scene::with_galaxies` shape).
-    /// Defaults to an empty slice — callers that don't render galaxies
-    /// pass `&[]` and the inner vec slot is filled with empties at the
-    /// motion-blur layer. See `crate::sims::nsa_galaxies` for the
-    /// builder that produces this shape from an NSA FITS file.
-    pub per_sensor_galaxies: &'a [Vec<crate::scene_galaxy::GalaxyInFrame>],
-    /// Solar angular coordinates for zodiacal background.
-    pub zodiacal: SolarAngularCoordinates,
+    /// All light contributing to the rendered frames: foreground stars,
+    /// pre-projected per-sensor galaxies, and diffuse zodiacal background.
+    /// See [`LightSources`] and `crate::sims::nsa_galaxies` for the
+    /// builder that produces the galaxy shape from an NSA FITS file.
+    pub sources: LightSources<'a>,
     /// Directory to write 16-bit PNG output frames.
     pub output_dir: &'a Path,
     /// Optional RNG seed for reproducible noise.
@@ -552,10 +546,8 @@ pub fn render_trajectory(config: &TrajectoryRenderConfig) -> Result<usize, Traje
     };
     render_motion_trajectory(
         config.trajectory,
-        config.catalog_stars,
-        config.per_sensor_galaxies,
+        &config.sources,
         config.focal_plane,
-        config.zodiacal,
         &motion_cfg,
         config.output_dir,
     )


### PR DESCRIPTION
## Summary

- Adds `pub struct LightSources<'a>` to `simulator::sims::motion_blur` bundling `(catalog_stars, per_sensor_galaxies, zodiacal)` — the three values that always travel together to describe everything contributing light to a rendered frame.
- Replaces those three independent arguments with a single `&LightSources<'_>` on every public render entry point, plus the corresponding field on `TrajectoryRenderConfig` and the internal `RenderScene`.
- Pure signature refactor: same code path, no semantic change. Tests pass byte-identically (no test bytes/assertions changed, only call-site arg shape).

## Motivation

`render_one_frame_roi` carries `#[allow(clippy::too_many_arguments)]` mostly because of these three sibling arguments. They never appear apart in any render entry point — bundling them is the right shape for upcoming scene-camera plumbing and drops 3 args off every public render call.

## Loci touched

- `pub struct LightSources<'a>` added in `simulator/src/sims/motion_blur.rs` (alongside `RenderScene`), `#[derive(Clone, Copy)]` since all fields are cheap (two slice refs + a 16-byte `SolarAngularCoordinates`).
- `pub fn render_one_frame` — 3 args -> 1, drops `#[allow(clippy::too_many_arguments)]` (down to 7 args, at the clippy threshold).
- `pub fn render_one_frame_roi` — 3 args -> 1.
- `pub fn render_motion_trajectory` — 3 args -> 1.
- `pub struct TrajectoryRenderConfig<'a>` — `catalog_stars`/`per_sensor_galaxies`/`zodiacal` fields replaced with one `sources: LightSources<'a>`; consumer `render_trajectory` updated.
- `struct RenderScene<'a>` (private) — also refactored to hold a `LightSources<'a>` field for internal consistency.
- Test call sites (all in `motion_blur.rs`), `simulator/src/bin/motion_simulator.rs`, and `simulator/benches/render.rs` mechanically updated.

## clippy allow on `render_one_frame_roi`

Verified empirically: removing the `#[allow]` re-trips `clippy::too_many_arguments` because the ROI variant still has 9 args after the bundle (`trajectory`, `sources`, `fp`, `frame_start`, `frame_idx`, `config`, `flux_cache`, `roi`, `sensor_idx`) vs the clippy threshold of 7. Allow kept; the bundle does take it from "too_many_arguments + 3 sibling args" down to "too_many_arguments with no obvious further bundle."

`render_one_frame` lands at 7 args after the refactor, so its `#[allow]` is removed.

## Diff size

- Net: 160 insertions, 303 deletions (mostly the test fixtures collapsing from 8-line render calls into 1-line ones).
- Signature LOC delta on the four loci is small (a few lines), but the per-call mechanical-edit savings are large.

## Loci intentionally NOT touched

`scene_runner.rs`, `single_detection.rs`, `scene_galaxy.rs` — each touches only one of zodiacal / galaxies, never the full triple, so bundling would force them to fabricate empty-stars inputs.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p simulator -- -W clippy::all` clean
- [x] `cargo test -p simulator` — 294 lib tests + 12 motion_simulator tests pass
- [x] `cargo bench -p simulator --no-run` builds
- [x] `cargo clippy --workspace -- -W clippy::all` clean