### PR TITLE
metadata: collapse quat [f64;4] -> UnitQuaternion in WaypointMeta + FrameMeta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,6 +2208,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
+ "serde",
  "simba",
  "typenum",
 ]
@@ -2308,6 +2309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -27,7 +27,7 @@ clap = { version = "4.5", features = [
 log = "0.4"                   # Logging facade
 env_logger = "0.11"           # Environment-based logger
 url = "2.5"                   # URL parsing and manipulation
-nalgebra = "0.32"             # Linear algebra (quaternions for orientation)
+nalgebra = { version = "0.32", features = ["serde-serialize"] } # Linear algebra (quaternions for orientation)
 # Foundation crates from cfl-foundations.
 shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "7936ec9", default-features = false, features = ["frame-writer"] }
 meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "7936ec9" }

--- a/simulator/src/sims/motion_blur.rs
+++ b/simulator/src/sims/motion_blur.rs
@@ -1290,7 +1290,7 @@ fn build_render_metadata(
                 let bore = boresight_of(&q);
                 WaypointMeta {
                     time_s: wp.time.as_secs_f64(),
-                    quat: [q.w, q.i, q.j, q.k],
+                    quat: q,
                     boresight: EquatorialMeta {
                         ra_deg: bore.ra_degrees(),
                         dec_deg: bore.dec_degrees(),
@@ -1319,7 +1319,7 @@ fn build_render_metadata(
             idx: *frame_idx,
             t_s: schedule.frame_start.as_secs_f64(),
             exposure_s: schedule.exposure.as_secs_f64(),
-            quat: [q.w, q.i, q.j, q.k],
+            quat: q,
             boresight: EquatorialMeta {
                 ra_deg: bore.ra_degrees(),
                 dec_deg: bore.dec_degrees(),
@@ -2431,12 +2431,13 @@ mod tests {
     }
 
     #[test]
-    fn test_metadata_quat_is_wxyz_order() {
+    fn test_metadata_quat_round_trips_via_serde() {
         // Build a trajectory whose first waypoint has a known roll about the
-        // boresight. The UnitQuaternion for a rotation of angle θ about a
-        // unit axis has w = cos(θ/2). We emit quat = [w, x, y, z], so
-        // meta.waypoints[0].quat[0] must match cos(θ/2) under the composed
-        // orientation.
+        // boresight, then verify the metadata round-trips that quaternion
+        // exactly (component-for-component) and reproduces the original roll
+        // when re-evaluated through `roll_of`. Implementation-agnostic with
+        // respect to nalgebra's on-disk array layout — we read fields off
+        // the deserialized `UnitQuaternion` rather than indexing positions.
         use crate::sims::orientation::orientation_from_pointing;
 
         let pointing = Equatorial::from_degrees(45.0, 30.0);
@@ -2463,24 +2464,16 @@ mod tests {
         let meta: crate::sims::motion_blur_metadata::RenderMetadata =
             serde_json::from_str(&raw).unwrap();
 
-        // Expected quat comes directly from nalgebra's constructor to avoid
-        // re-deriving the half-angle formula under roll composition.
         let q_expected = orientation_from_pointing(&pointing, roll);
         let wp0 = &meta.trajectory.waypoints[0];
-        assert_abs_diff_eq!(wp0.quat[0], q_expected.w, epsilon = 1e-12);
-        assert_abs_diff_eq!(wp0.quat[1], q_expected.i, epsilon = 1e-12);
-        assert_abs_diff_eq!(wp0.quat[2], q_expected.j, epsilon = 1e-12);
-        assert_abs_diff_eq!(wp0.quat[3], q_expected.k, epsilon = 1e-12);
+        assert_abs_diff_eq!(wp0.quat.w, q_expected.w, epsilon = 1e-12);
+        assert_abs_diff_eq!(wp0.quat.i, q_expected.i, epsilon = 1e-12);
+        assert_abs_diff_eq!(wp0.quat.j, q_expected.j, epsilon = 1e-12);
+        assert_abs_diff_eq!(wp0.quat.k, q_expected.k, epsilon = 1e-12);
 
-        // Round-trip: reconstruct a UnitQuaternion from [w, x, y, z] and
-        // check that roll_of recovers the original roll.
-        let q_round = nalgebra::UnitQuaternion::from_quaternion(nalgebra::Quaternion::new(
-            wp0.quat[0],
-            wp0.quat[1],
-            wp0.quat[2],
-            wp0.quat[3],
-        ));
-        let recovered = roll_of(&q_round);
+        // Round-trip: roll_of evaluated on the deserialized quaternion
+        // recovers the original roll angle.
+        let recovered = roll_of(&wp0.quat);
         assert_abs_diff_eq!(recovered, roll, epsilon = 1e-9);
     }
 

--- a/simulator/src/sims/motion_blur_metadata.rs
+++ b/simulator/src/sims/motion_blur_metadata.rs
@@ -25,6 +25,7 @@
 
 use std::collections::BTreeMap;
 
+use nalgebra::UnitQuaternion;
 use serde::{Deserialize, Serialize};
 
 /// Root descriptor written as `metadata.json` at the output-directory root.
@@ -64,9 +65,12 @@ pub struct TrajectoryMeta {
 pub struct WaypointMeta {
     /// Waypoint time (seconds from trajectory origin).
     pub time_s: f64,
-    /// Orientation quaternion in `[w, x, y, z]` order (nalgebra's
-    /// `UnitQuaternion::{w, i, j, k}` maps directly to this layout).
-    pub quat: [f64; 4],
+    /// Orientation quaternion. Serializes as a 4-element JSON array in
+    /// nalgebra's native `[i, j, k, w]` order (imaginary parts first,
+    /// real part last) — same shape as `Quaternion::coords`. Consumers
+    /// reconstructing via `Quaternion::new(w, i, j, k)` must pull `w`
+    /// from index 3, not 0.
+    pub quat: UnitQuaternion<f64>,
     /// Boresight pointing derived from `quat`.
     pub boresight: EquatorialMeta,
     /// Roll angle derived from `quat`, in degrees.
@@ -91,8 +95,10 @@ pub struct FrameMeta {
     pub t_s: f64,
     /// Exposure duration for this frame, in seconds.
     pub exposure_s: f64,
-    /// Mid-frame orientation quaternion in `[w, x, y, z]` order.
-    pub quat: [f64; 4],
+    /// Mid-frame orientation quaternion. Serializes as a 4-element
+    /// JSON array in nalgebra's native `[i, j, k, w]` order (imaginary
+    /// parts first, real part last).
+    pub quat: UnitQuaternion<f64>,
     /// Mid-frame boresight pointing derived from `quat`.
     pub boresight: EquatorialMeta,
     /// Mid-frame roll angle derived from `quat`, in degrees.
@@ -227,7 +233,7 @@ mod tests {
                 end_time_s: 10.0,
                 waypoints: vec![WaypointMeta {
                     time_s: 0.0,
-                    quat: [1.0, 0.0, 0.0, 0.0],
+                    quat: UnitQuaternion::identity(),
                     boresight: EquatorialMeta {
                         ra_deg: 0.0,
                         dec_deg: 0.0,


### PR DESCRIPTION
## Summary

Enable nalgebra's `serde-serialize` feature and use it directly for orientation quaternions in `metadata.json`. `WaypointMeta::quat` and `FrameMeta::quat` change from explicit `[f64; 4]` arrays to `UnitQuaternion<f64>`; the build-site no longer hand-destructures into `[w, i, j, k]`.

## Schema break

nalgebra serializes `UnitQuaternion` as a 4-element JSON array in **`[i, j, k, w]`** order (imaginary parts first, real part last) — the inverse of the previous **`[w, i, j, k]`** layout.

Consumers reading the array positionally must update:

\`\`\`python
# Before
qw, qx, qy, qz = frame[\"quat\"]

# After
qx, qy, qz, qw = frame[\"quat\"]
\`\`\`

Doc-noted on both `WaypointMeta::quat` and `FrameMeta::quat`.

## Test changes

`test_metadata_quat_is_wxyz_order` is replaced by `test_metadata_quat_round_trips_via_serde`. The new test is implementation-agnostic: it asserts the deserialized `UnitQuaternion` matches the source pose component-by-component via `.w`/`.i`/`.j`/`.k` field access (not positional indexing) and that `roll_of()` recovers the original roll. No opinion on the wire layout — that's nalgebra's contract now.

## Scripts that accompany the repo

- \`scripts/los_psd_to_trajectory_csv.py\`, \`scripts/ody_to_trajectory_csv.py\`: write trajectory CSVs with **named** qw/qx/qy/qz columns. Unrelated to the metadata.json quat array layout — no updates needed.
- Any out-of-tree script that reads \`frames[*].quat\` from metadata.json positionally must swap its unpack to \`qx, qy, qz, qw\` (the `w` is at index 3, not 0). \`scripts/build_psd_test_set.py\` is one such example.

## Test plan

- [x] \`cargo fmt -p simulator\` clean
- [x] \`cargo build -p simulator --tests\` clean
- [x] \`cargo test -p simulator --lib\` — **294 passed, 0 failed, 3 ignored**