### PR TITLE
dark_current: drop log_dark_currents cache, derive serde

### DIFF
--- a/simulator/src/hardware/dark_current.rs
+++ b/simulator/src/hardware/dark_current.rs
@@ -4,6 +4,7 @@
 //! temperatures based on sensor specifications and thermal models.
 
 use crate::algo::misc::{interp, InterpError};
+use serde::{Deserialize, Serialize};
 use shared::units::{Temperature, TemperatureExt};
 
 /// Minimum temperature for dark current interpolation table (°C)
@@ -18,15 +19,28 @@ const INTERPOLATION_POINTS: usize = 100;
 /// Dark current estimator that uses interpolation of temperature vs dark current curves
 /// to predict values at any temperature. Can be initialized either from reference values
 /// (using the 8°C doubling rule) or from explicit temperature/dark current data points.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DarkCurrentEstimator {
     /// Temperature values in degrees Celsius
+    #[serde(rename = "temperatures_c")]
     temperatures: Vec<f64>,
     /// Dark current values in electrons/pixel/second
+    #[serde(rename = "dark_currents_e_per_px_per_s")]
     dark_currents: Vec<f64>,
 }
 
 impl DarkCurrentEstimator {
+    /// Tabulated temperature sample points, in degrees Celsius, ascending.
+    pub fn temperatures_c(&self) -> &[f64] {
+        &self.temperatures
+    }
+
+    /// Tabulated dark-current values in electrons per pixel per second,
+    /// aligned with [`Self::temperatures_c`] index-by-index.
+    pub fn dark_currents_e_per_px_per_s(&self) -> &[f64] {
+        &self.dark_currents
+    }
+
     /// Generate temperature points for interpolation table
     fn generate_temperature_points() -> Vec<f64> {
         let mut temperatures = Vec::with_capacity(INTERPOLATION_POINTS);

--- a/simulator/src/hardware/dark_current.rs
+++ b/simulator/src/hardware/dark_current.rs
@@ -155,12 +155,7 @@ impl DarkCurrentEstimator {
     /// * `Ok(f64)` - Estimated dark current in electrons/pixel/second at target temperature
     /// * `Err(InterpError)` - If interpolation fails (e.g., out of bounds)
     pub fn estimate_at_temperature(&self, temperature: Temperature) -> Result<f64, InterpError> {
-        // Interpolate in log space to preserve exponential nature. The log
-        // table is computed on the fly: this is the only caller that needs
-        // log values, and it's called O(frames × sensors) per render — a
-        // few hundred ln() evaluations swamped by the rest of the per-frame
-        // work. Storing a cached log_dark_currents Vec would save
-        // microseconds and force a serde adapter to round-trip it.
+        // Interpolate in log space to preserve exponential nature.
         let target_temp_c = temperature.as_celsius();
         let log_dark_currents: Vec<f64> = self.dark_currents.iter().map(|&dc| dc.ln()).collect();
         let log_result = interp(target_temp_c, &self.temperatures, &log_dark_currents)?;

--- a/simulator/src/hardware/dark_current.rs
+++ b/simulator/src/hardware/dark_current.rs
@@ -24,8 +24,6 @@ pub struct DarkCurrentEstimator {
     temperatures: Vec<f64>,
     /// Dark current values in electrons/pixel/second
     dark_currents: Vec<f64>,
-    /// Log of dark current values for exponential interpolation
-    log_dark_currents: Vec<f64>,
 }
 
 impl DarkCurrentEstimator {
@@ -64,11 +62,9 @@ impl DarkCurrentEstimator {
             })
             .collect();
 
-        let log_dark_currents = dark_currents.iter().map(|&dc| dc.ln()).collect();
         Self {
             temperatures,
             dark_currents,
-            log_dark_currents,
         }
     }
 
@@ -115,11 +111,9 @@ impl DarkCurrentEstimator {
             })
             .collect();
 
-        let log_dark_currents = dark_currents.iter().map(|&dc| dc.ln()).collect();
         Self {
             temperatures,
             dark_currents,
-            log_dark_currents,
         }
     }
 
@@ -129,11 +123,9 @@ impl DarkCurrentEstimator {
     /// * `temperatures` - Temperature values in degrees Celsius (must be sorted ascending)
     /// * `dark_currents` - Dark current values in electrons/pixel/second
     pub fn from_curve(temperatures: Vec<f64>, dark_currents: Vec<f64>) -> Self {
-        let log_dark_currents = dark_currents.iter().map(|&dc| dc.ln()).collect();
         Self {
             temperatures,
             dark_currents,
-            log_dark_currents,
         }
     }
 
@@ -149,9 +141,15 @@ impl DarkCurrentEstimator {
     /// * `Ok(f64)` - Estimated dark current in electrons/pixel/second at target temperature
     /// * `Err(InterpError)` - If interpolation fails (e.g., out of bounds)
     pub fn estimate_at_temperature(&self, temperature: Temperature) -> Result<f64, InterpError> {
-        // Interpolate in log space to preserve exponential nature
+        // Interpolate in log space to preserve exponential nature. The log
+        // table is computed on the fly: this is the only caller that needs
+        // log values, and it's called O(frames × sensors) per render — a
+        // few hundred ln() evaluations swamped by the rest of the per-frame
+        // work. Storing a cached log_dark_currents Vec would save
+        // microseconds and force a serde adapter to round-trip it.
         let target_temp_c = temperature.as_celsius();
-        let log_result = interp(target_temp_c, &self.temperatures, &self.log_dark_currents)?;
+        let log_dark_currents: Vec<f64> = self.dark_currents.iter().map(|&dc| dc.ln()).collect();
+        let log_result = interp(target_temp_c, &self.temperatures, &log_dark_currents)?;
         // Convert back from log space
         Ok(log_result.exp())
     }


### PR DESCRIPTION
## Summary

\`DarkCurrentEstimator\` stored a precomputed \`log_dark_currents: Vec<f64>\` mirror of \`dark_currents\` for log-space interpolation, built eagerly in all three constructors. The cache was read in **exactly one place**: \`estimate_at_temperature\`, called O(frames × sensors) per render — a few hundred times total. The savings of a few hundred \`ln()\` evaluations are noise next to the per-pixel rendering work.

This PR:

1. **Drops the \`log_dark_currents\` field.** Three constructors no longer build it.
2. **Computes the log Vec inline** in the one caller that needs it (\`estimate_at_temperature\`). ~800 bytes allocated per call, negligible per frame.
3. **Derives \`Serialize\` / \`Deserialize\`** on the now-cache-free struct — pure additive, no \`#[serde(skip)]\` or \`#[serde(from = \"Raw\")]\` adapter needed.
4. **Adds \`temperatures_c()\` / \`dark_currents_e_per_px_per_s()\` accessors.** Same shape as \`QuantumEfficiency\`'s. Lets callers introspect the raw tables and pass them back to \`from_curve()\` for revalidation.

## Field renames

JSON keeps unit-explicit shape:

| Rust field | JSON key |
|---|---|
| \`temperatures\` | \`temperatures_c\` |
| \`dark_currents\` | \`dark_currents_e_per_px_per_s\` |

## Why this matters for scene serialization

Previously \`DarkCurrentEstimator\` was on the blocked list for end-to-end scene round-trip: round-tripping required either skipping the cached log with \`#[serde(skip, default)]\` + a reconstructor, or wrapping in a \`#[serde(from = \"Raw\")]\` adapter. Both were viable but neither was a one-liner.

With the cache gone, the derive is trivial and \`SensorConfig\` is now one upstream PR (cfl-foundations#18 — \`BilinearInterpolator\` serde) away from being fully serializable.

## Test plan

- [x] \`cargo fmt -p simulator\` clean
- [x] \`cargo build -p simulator --tests\` clean
- [x] \`cargo test -p simulator --lib\` — **296 passed, 0 failed, 3 ignored** (unchanged from main)
- [x] Numerical behavior unchanged — the log table is now computed at the same call site, with the same values, just not cached between calls.