### PR TITLE
Replace once_cell Lazy with std LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3401,7 +3401,6 @@ dependencies = [
  "nalgebra",
  "ndarray",
  "num_cpus",
- "once_cell",
  "plotters",
  "rand 0.9.4",
  "rand_distr 0.5.1",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -19,7 +19,6 @@ ndarray = { version = "0.16", features = [
 ] } # Multidimensional arrays with parallel computing
 rayon = "1.7" # Parallel computing
 float-cmp = "0.9" # Approximate floating point comparisons
-once_cell = "1.19" # Lazy static initialization
 thiserror = "2.0" # Error handling
 clap = { version = "4.5", features = [
     "derive",

--- a/simulator/src/hardware/sensor.rs
+++ b/simulator/src/hardware/sensor.rs
@@ -39,8 +39,8 @@
 
 #![allow(clippy::approx_constant)]
 
-use once_cell::sync::Lazy;
 use std::fmt;
+use std::sync::LazyLock;
 
 use crate::hardware::dark_current::DarkCurrentEstimator;
 use crate::hardware::read_noise::ReadNoiseEstimator;
@@ -533,7 +533,7 @@ pub mod models {
     }
 
     /// GSENSE4040BSI CMOS sensor with detailed QE curve from manufacturer data
-    pub static GSENSE4040BSI: Lazy<SensorConfig> = Lazy::new(|| {
+    pub static GSENSE4040BSI: LazyLock<SensorConfig> = LazyLock::new(|| {
         // QE data from QE-gsense4040bsi.csv (trunced to 3 decimal places)
         // We'll use a subset of the data to keep the vector size reasonable
         // while still capturing the important features of the curve
@@ -598,7 +598,7 @@ pub mod models {
 
     /// GSENSE6510BSI CMOS sensor with detailed QE curve from manufacturer chart found here
     /// <https://www.gpixel.com/en/details_155.html>
-    pub static GSENSE6510BSI: Lazy<SensorConfig> = Lazy::new(|| {
+    pub static GSENSE6510BSI: LazyLock<SensorConfig> = LazyLock::new(|| {
         let wavelengths = vec![
             150.0, 200.0, 210.0, 220.0, 230.0, 240.0, 250.0, 260.0, 270.0, 280.0, 290.0, 300.0,
             310.0, 320.0, 330.0, 340.0, 350.0, 360.0, 370.0, 380.0, 390.0, 400.0, 410.0, 420.0,
@@ -641,7 +641,7 @@ pub mod models {
     });
 
     /// HWK4123 CMOS sensor with detailed QE curve
-    pub static HWK4123: Lazy<SensorConfig> = Lazy::new(|| {
+    pub static HWK4123: LazyLock<SensorConfig> = LazyLock::new(|| {
         // Detailed QE curve data
         let wavelengths = vec![
             200.0, 250.0, 260.0, 270.0, 280.0, 290.0, 300.0, 310.0, 320.0, 330.0, 340.0, 350.0,
@@ -697,7 +697,7 @@ pub mod models {
     /// support a wide range of source brightnesses. See this document for more details:
     /// <https://docs.google.com/spreadsheets/d/16WdFvMo3rj3Z9252pq32agsLV-wm7YNacvqfkEgSOAI/edit?gid=1094380256#gid=1094380256>
     /// QE data from 300-400nm is from Ajay/Tohovavohu, past that is the QXY measurements
-    pub static IMX455: Lazy<SensorConfig> = Lazy::new(|| {
+    pub static IMX455: LazyLock<SensorConfig> = LazyLock::new(|| {
         // QE curve from manufacturer data
         // Note: We already have zero at the endpoints as required by QuantumEfficiency
         let wavelengths = vec![
@@ -741,7 +741,7 @@ pub mod models {
     });
 
     /// Collection of all available sensor models
-    pub static ALL_SENSORS: Lazy<Vec<SensorConfig>> = Lazy::new(|| {
+    pub static ALL_SENSORS: LazyLock<Vec<SensorConfig>> = LazyLock::new(|| {
         vec![
             GSENSE4040BSI.clone(),
             GSENSE6510BSI.clone(),

--- a/simulator/src/hardware/sensor_array.rs
+++ b/simulator/src/hardware/sensor_array.rs
@@ -4,8 +4,9 @@
 //! positioned in a focal plane, as commonly used in large astronomical cameras
 //! and survey instruments.
 
+use std::sync::LazyLock;
+
 use crate::hardware::sensor::{models::IMX455, SensorConfig};
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use shared::units::LengthExt;
 
@@ -199,7 +200,7 @@ impl SensorArray {
     }
 }
 
-pub static SPENCER_ARRAY_PLAN: Lazy<SensorArray> = Lazy::new(|| {
+pub static SPENCER_ARRAY_PLAN: LazyLock<SensorArray> = LazyLock::new(|| {
     /// Outer (low-y) pair |x| offset, mm.
     const OUTER_X_MM: f64 = 61.0;
     /// Inner (high-y) pair |x| offset, mm.

--- a/simulator/src/hardware/telescope.rs
+++ b/simulator/src/hardware/telescope.rs
@@ -35,9 +35,9 @@
 //! - **WEASEL**: Multi-spectral Earth observation system
 //!
 
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::f64::consts::PI;
+use std::sync::LazyLock;
 
 use crate::photometry::QuantumEfficiency;
 use shared::units::{Angle, AngleExt, Area, AreaExt, Length, LengthExt, Wavelength};
@@ -344,7 +344,7 @@ mod tests {
 pub mod models {
     use super::*;
 
-    pub static SMALL_50MM: Lazy<TelescopeConfig> = Lazy::new(|| {
+    pub static SMALL_50MM: LazyLock<TelescopeConfig> = LazyLock::new(|| {
         TelescopeConfig::new(
             "50mm",
             Length::from_meters(0.05), // 50mm aperture
@@ -354,7 +354,7 @@ pub mod models {
     });
 
     /// 50cm Demo telescope
-    pub static IDEAL_50CM: Lazy<TelescopeConfig> = Lazy::new(|| {
+    pub static IDEAL_50CM: LazyLock<TelescopeConfig> = LazyLock::new(|| {
         TelescopeConfig::new(
             "Ideal 50cm",
             Length::from_meters(0.5),  // 50cm aperture
@@ -364,7 +364,7 @@ pub mod models {
     });
 
     /// 1m Final telescope
-    pub static IDEAL_100CM: Lazy<TelescopeConfig> = Lazy::new(|| {
+    pub static IDEAL_100CM: LazyLock<TelescopeConfig> = LazyLock::new(|| {
         TelescopeConfig::new(
             "Ideal 100cm",
             Length::from_meters(1.0),  // 1m aperture
@@ -375,7 +375,7 @@ pub mod models {
 
     /// Officina Stellare Weasel - 50cm f/6.9 Catadioptric
     /// Bandpass: 450nm-900nm, 0.8 Strehl at 800nm, 42% obscuration ratio
-    pub static OFFICINA_STELLARE_WEASEL: Lazy<TelescopeConfig> = Lazy::new(|| {
+    pub static OFFICINA_STELLARE_WEASEL: LazyLock<TelescopeConfig> = LazyLock::new(|| {
         // Create QE curve for Weasel based on spectral data
         let wavelengths = vec![
             149.0, 175.0, 300.0, 395.0, 450.0, 545.0, 680.0, 820.0, 900.0, 1050.0, 1400.0, 1800.0,
@@ -399,7 +399,7 @@ pub mod models {
 
     /// Optech/Lina LS50 - 50cm f/10 Catadioptric  
     /// Bandpass: 400-1100nm, 0.8 Strehl at 833nm, 37% obscuration ratio
-    pub static OPTECH_LINA_LS50: Lazy<TelescopeConfig> = Lazy::new(|| {
+    pub static OPTECH_LINA_LS50: LazyLock<TelescopeConfig> = LazyLock::new(|| {
         let wavelengths = vec![
             149.0, 175.0, 300.0, 395.0, 400.0, 545.0, 680.0, 820.0, 1050.0, 1100.0, 1400.0, 1800.0,
             1801.0,
@@ -422,7 +422,7 @@ pub mod models {
 
     /// Optech/Lina LS35 - 35cm f/10 Catadioptric
     /// Bandpass: 400-1100nm, 0.8 Strehl at 833nm, 37% obscuration ratio  
-    pub static OPTECH_LINA_LS35: Lazy<TelescopeConfig> = Lazy::new(|| {
+    pub static OPTECH_LINA_LS35: LazyLock<TelescopeConfig> = LazyLock::new(|| {
         let wavelengths = vec![
             149.0, 175.0, 300.0, 395.0, 400.0, 545.0, 680.0, 820.0, 1050.0, 1100.0, 1400.0, 1800.0,
             1801.0,
@@ -445,7 +445,7 @@ pub mod models {
 
     /// Cosmic Frontier JBT .5m - 48.5cm f/12.3 Reflective
     /// Bandpass: broad spectrum, 0.8 Strehl at 550nm
-    pub static COSMIC_FRONTIER_JBT_50CM: Lazy<TelescopeConfig> = Lazy::new(|| {
+    pub static COSMIC_FRONTIER_JBT_50CM: LazyLock<TelescopeConfig> = LazyLock::new(|| {
         let wavelengths = vec![
             149.0, 175.0, 300.0, 395.0, 545.0, 680.0, 820.0, 1050.0, 1400.0, 1800.0, 1801.0,
         ];
@@ -467,7 +467,7 @@ pub mod models {
 
     /// Cosmic Frontier JBT MAX - 65cm f/12.3 Reflective
     /// Bandpass: broad spectrum, 0.8 Strehl at 550nm
-    pub static COSMIC_FRONTIER_JBT_MAX: Lazy<TelescopeConfig> = Lazy::new(|| {
+    pub static COSMIC_FRONTIER_JBT_MAX: LazyLock<TelescopeConfig> = LazyLock::new(|| {
         let wavelengths = vec![
             149.0, 175.0, 300.0, 395.0, 545.0, 680.0, 820.0, 1050.0, 1400.0, 1800.0, 1801.0,
         ];
@@ -489,7 +489,7 @@ pub mod models {
 
     /// Cosmic Frontier JBT 1.0m - 100cm f/12.3 Reflective
     /// Bandpass: broad spectrum, 0.8 Strehl at 550nm
-    pub static COSMIC_FRONTIER_JBT_1M: Lazy<TelescopeConfig> = Lazy::new(|| {
+    pub static COSMIC_FRONTIER_JBT_1M: LazyLock<TelescopeConfig> = LazyLock::new(|| {
         let wavelengths = vec![
             149.0, 175.0, 300.0, 395.0, 545.0, 680.0, 820.0, 1050.0, 1400.0, 1800.0, 1801.0,
         ];
@@ -511,7 +511,7 @@ pub mod models {
 
     /// Legacy Weasel telescope (keeping for backwards compatibility)
     /// Spectral ranges: PAN: 0.45 – 0.9 um, RGB: 0.45 – 0.68 um, SWIR: 0.9 – 1.7 um
-    pub static WEASEL: Lazy<TelescopeConfig> = Lazy::new(|| {
+    pub static WEASEL: LazyLock<TelescopeConfig> = LazyLock::new(|| {
         TelescopeConfig::new(
             "Weasel",
             Length::from_meters(0.47), // 470mm aperture

--- a/simulator/src/photometry/gaia.rs
+++ b/simulator/src/photometry/gaia.rs
@@ -51,8 +51,9 @@
 //! - **Accuracy**: Validated against in-flight calibration observations
 //! - **Updates**: Reflects post-launch instrument characterization
 
+use std::sync::LazyLock;
+
 use super::QuantumEfficiency;
-use once_cell::sync::Lazy;
 
 /// Official ESA Gaia G-band passband for precision stellar photometry.
 ///
@@ -103,7 +104,7 @@ use once_cell::sync::Lazy;
 /// - Ground-based photometric standards (Landolt, SDSS)
 /// - HST and other space telescope cross-calibrations
 /// - Laboratory measurements of instrument components
-pub static GAIA_PASSBAND: Lazy<QuantumEfficiency> = Lazy::new(|| {
+pub static GAIA_PASSBAND: LazyLock<QuantumEfficiency> = LazyLock::new(|| {
     // Wavelengths in nanometers (nm), stored initially as integers for compactness
     let wavelengths_int: Vec<i32> = vec![
         320, 321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337,

--- a/simulator/src/sims/context_render.rs
+++ b/simulator/src/sims/context_render.rs
@@ -15,12 +15,12 @@
 //! stars render as larger, more saturated Gaussian blobs.
 
 use std::path::Path;
+use std::sync::LazyLock;
 
 use ab_glyph::{FontRef, PxScale};
 use image::{ImageBuffer, Rgb};
 use imageproc::drawing::{draw_text_mut, text_size};
 use nalgebra::UnitQuaternion;
-use once_cell::sync::Lazy;
 use shared::units::LengthExt;
 use starfield::catalogs::StarData;
 
@@ -36,8 +36,8 @@ type RgbImage = ImageBuffer<Rgb<u8>, Vec<u8>>;
 /// Embedded DejaVu Sans Mono Bold — used for all context-view labels.
 /// Bold weight keeps thin strokes readable at small px scales.
 static FONT_DATA: &[u8] = include_bytes!("../../assets/fonts/DejaVuSansMono-Bold.ttf");
-static FONT: Lazy<FontRef<'static>> =
-    Lazy::new(|| FontRef::try_from_slice(FONT_DATA).expect("bundled font parses"));
+static FONT: LazyLock<FontRef<'static>> =
+    LazyLock::new(|| FontRef::try_from_slice(FONT_DATA).expect("bundled font parses"));
 
 /// Configuration for the context-view renderer.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Migrates simulator from `once_cell::sync::Lazy` to `std::sync::LazyLock`, which is stable since Rust 1.80 (the crate pins rust-version 1.88).

## Changes
- Swap `Lazy<T>`/`Lazy::new(...)` for `LazyLock<T>`/`LazyLock::new(...)` across all sites: sensor models, telescope configs, sensor array, Gaia passband, and the context-render font.
- Drop the `once_cell` dependency from `simulator/Cargo.toml`.

## Verification
- `cargo fmt`, `cargo clippy --package simulator -- -W clippy::all` clean
- `cargo test --package simulator` passes (297 lib + 12 integration tests)

Closes #117.