### PR TITLE
Split motion_blur into focused submodules

### DIFF
--- a/simulator/src/sims/motion_blur/accumulator.rs
+++ b/simulator/src/sims/motion_blur/accumulator.rs
@@ -1,0 +1,102 @@
+//! Per-tile mean-electron accumulation for the motion-blur renderer.
+
+use ndarray::Array2;
+use rayon::prelude::*;
+
+/// Per-tile mean-electron accumulator (pre-Poisson).
+///
+/// Stars are splatted in as mean-electron contributions (not draws) so
+/// that all sub-samples, the zodiacal uniform, and the dark-current uniform
+/// can be combined into a single Poisson lambda.
+#[derive(Debug, Clone)]
+pub struct SensorAccumulator {
+    /// Accumulated mean electrons from star subsample splats.
+    pub star_mean_electrons: Array2<f64>,
+}
+
+impl SensorAccumulator {
+    /// Allocate a zeroed accumulator shaped `(height, width)`.
+    pub fn zero(width: usize, height: usize) -> Self {
+        Self {
+            star_mean_electrons: Array2::zeros((height, width)),
+        }
+    }
+
+    /// Splat one star's mean electrons (already integrated over `dt`, not
+    /// Poisson-sampled) into the accumulator via Simpson's rule over the
+    /// Airy disk.
+    ///
+    /// `total_electrons` is the expected number of electrons this subsample
+    /// contributes across the disk — i.e. the star's mean-electron rate at
+    /// the star's chromatic effective PSF, multiplied by aperture area and
+    /// the subsample duration.
+    pub fn splat_psf(
+        &mut self,
+        px: f64,
+        py: f64,
+        total_electrons: f64,
+        psf: &shared::image_proc::airy::PixelScaledAiryDisk,
+    ) {
+        crate::image_proc::deposit::splat_deposit(
+            &mut self.star_mean_electrons,
+            px,
+            py,
+            total_electrons,
+            psf,
+        );
+    }
+
+    /// Splat one galaxy's mean electrons (already integrated over `dt`,
+    /// not Poisson-sampled) into the same accumulator stars use, via
+    /// the galaxy's `SersicSplat` deposit. The single-Poisson invariant
+    /// (INVARIANTS §1) is preserved because galaxies land on the same
+    /// `star_mean_electrons` buffer that the unified Poisson eventually
+    /// samples — galaxy and star shot noise are co-sampled from the
+    /// per-pixel `Poisson(λ_total)` of the combined mean.
+    pub fn splat_galaxy(
+        &mut self,
+        px: f64,
+        py: f64,
+        total_electrons: f64,
+        sersic: &crate::image_proc::sersic_splat::SersicSplat,
+    ) {
+        crate::image_proc::deposit::splat_deposit(
+            &mut self.star_mean_electrons,
+            px,
+            py,
+            total_electrons,
+            sersic,
+        );
+    }
+
+    /// Consume the accumulator and return the combined mean-electron image
+    /// = star mean + zodiacal uniform + dark-current uniform (pre-Poisson).
+    ///
+    /// The accumulator's existing `star_mean_electrons` buffer is reused —
+    /// no second 488 MB allocation, no read-then-write of a fresh array.
+    /// The scalar background is added in place via rayon-parallel
+    /// element-wise iteration (ndarray's `rayon` feature is enabled).
+    pub fn into_combined_mean(mut self, zodiacal_per_px: f64, dark_per_px: f64) -> Array2<f64> {
+        let bg = (zodiacal_per_px + dark_per_px).max(0.0);
+        if bg > 0.0 {
+            self.star_mean_electrons
+                .par_iter_mut()
+                .for_each(|pixel| *pixel += bg);
+        }
+        self.star_mean_electrons
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sensor_accumulator_combined_mean() {
+        let mut acc = SensorAccumulator::zero(4, 4);
+        acc.star_mean_electrons[[1, 1]] = 5.0;
+        let combined = acc.into_combined_mean(2.0, 1.0);
+        assert_eq!(combined[[0, 0]], 3.0); // 0 + 2 + 1
+        assert_eq!(combined[[1, 1]], 8.0); // 5 + 2 + 1
+    }
+}

--- a/simulator/src/sims/motion_blur/metadata.rs
+++ b/simulator/src/sims/motion_blur/metadata.rs
@@ -1,0 +1,147 @@
+//! Assembly of the per-render `metadata.json` document.
+//!
+//! Turns a completed [`RenderScene`] plus its per-frame schedules into the
+//! [`RenderMetadata`] serialized alongside the rendered PNGs.
+
+use std::collections::BTreeMap;
+
+use chrono::SecondsFormat;
+
+use crate::hardware::SatelliteConfig;
+use crate::scene_galaxy::Galaxy;
+use crate::sims::motion_blur_metadata::{
+    sensor_dir_name, sensor_relative_png_path, EquatorialMeta, FrameMeta, HardwareMeta,
+    RenderConfigMeta, RenderMetadata, SensorMeta, StarMeta, TrajectoryMeta, WaypointMeta,
+    ZodiacalMeta,
+};
+use crate::sims::orientation::{boresight_of, roll_of};
+use crate::sims::trajectory::TrajectoryError;
+
+use super::render::{MotionBlurConfig, RenderScene};
+use super::schedule::SubsampleSchedule;
+
+pub(super) fn build_render_metadata(
+    scene: &RenderScene,
+    satellites: &[SatelliteConfig],
+    config: &MotionBlurConfig,
+    frame_plans: &[(usize, SubsampleSchedule)],
+    sensor_count: usize,
+) -> Result<RenderMetadata, TrajectoryError> {
+    let rendered_at = chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+
+    let start = scene.trajectory.start_time();
+    let end = scene.trajectory.end_time();
+    let trajectory_meta = TrajectoryMeta {
+        duration_s: (end - start).as_secs_f64(),
+        start_time_s: start.as_secs_f64(),
+        end_time_s: end.as_secs_f64(),
+        waypoints: scene
+            .trajectory
+            .waypoints()
+            .iter()
+            .map(|wp| {
+                let q = wp.orientation;
+                let bore = boresight_of(&q);
+                WaypointMeta {
+                    time_s: wp.time.as_secs_f64(),
+                    quat: q,
+                    boresight: EquatorialMeta {
+                        ra_deg: bore.ra_degrees(),
+                        dec_deg: bore.dec_degrees(),
+                    },
+                    roll_deg: roll_of(&q).to_degrees(),
+                }
+            })
+            .collect(),
+    };
+
+    let mut frames: Vec<FrameMeta> = Vec::with_capacity(frame_plans.len());
+    for (frame_idx, schedule) in frame_plans {
+        let mid_t = (schedule.frame_start + schedule.exposure / 2)
+            .min(scene.trajectory.end_time())
+            .max(scene.trajectory.start_time());
+        let q = scene.trajectory.orientation_at(mid_t)?;
+        let bore = boresight_of(&q);
+        let mut paths: BTreeMap<String, String> = BTreeMap::new();
+        for sensor_idx in 0..sensor_count {
+            paths.insert(
+                sensor_dir_name(sensor_idx),
+                sensor_relative_png_path(sensor_idx, *frame_idx),
+            );
+        }
+        frames.push(FrameMeta {
+            idx: *frame_idx,
+            t_s: schedule.frame_start.as_secs_f64(),
+            exposure_s: schedule.exposure.as_secs_f64(),
+            quat: q,
+            boresight: EquatorialMeta {
+                ra_deg: bore.ra_degrees(),
+                dec_deg: bore.dec_degrees(),
+            },
+            roll_deg: roll_of(&q).to_degrees(),
+            n_stamps: schedule.stamps_per_exposure,
+            paths,
+        });
+    }
+
+    let stars: Vec<StarMeta> = scene
+        .sources
+        .catalog_stars
+        .iter()
+        .map(|s| StarMeta {
+            id: s.id,
+            // starfield::StarData does not currently expose a name
+            // field; left None until an upstream catalog wires it in.
+            name: None,
+            ra_deg: s.position.ra_degrees(),
+            dec_deg: s.position.dec_degrees(),
+            magnitude: s.magnitude,
+            color_index: s.b_v,
+        })
+        .collect();
+
+    let galaxies: Vec<Galaxy> = scene.sources.galaxies.to_vec();
+
+    let sensors: Vec<SensorMeta> = (0..sensor_count)
+        .map(|i| {
+            let ps = &scene.fp.array.sensors[i];
+            let (width, height) = ps.sensor.dimensions.get_pixel_width_height();
+            SensorMeta {
+                idx: i,
+                name: satellites[i].sensor.name.clone(),
+                dimensions_px: [width, height],
+                position_mm: [ps.position.x_mm, ps.position.y_mm],
+            }
+        })
+        .collect();
+
+    let hardware = HardwareMeta {
+        telescope: config.telescope_name.clone(),
+        temperature_c: config.temperature_c,
+        sensors,
+    };
+
+    let render_config = RenderConfigMeta {
+        exposure_s: config.exposure.as_secs_f64(),
+        timestep_s: config.timestep.as_secs_f64(),
+        max_drift_per_stamp_px: config.max_drift_per_stamp_px,
+        seed: config.base_seed.unwrap_or(0),
+        force_static: config.force_static,
+        catalog_path: config.catalog_path.to_string_lossy().into_owned(),
+        zodiacal: ZodiacalMeta {
+            elongation_deg: scene.sources.zodiacal.elongation(),
+            latitude_deg: scene.sources.zodiacal.latitude(),
+        },
+    };
+
+    Ok(RenderMetadata {
+        version: "1.1".to_string(),
+        rendered_at,
+        trajectory: trajectory_meta,
+        frames,
+        stars,
+        galaxies,
+        hardware,
+        render_config,
+    })
+}

--- a/simulator/src/sims/motion_blur/mod.rs
+++ b/simulator/src/sims/motion_blur/mod.rs
@@ -1,0 +1,51 @@
+//! Parallel motion-blur renderer for focal-plane trajectories.
+//!
+//! Each frame's exposure window is integrated as a single flat
+//! stratified-Monte-Carlo sequence of PSF stamps. The total stamp
+//! count is chosen adaptively from a per-stamp drift budget so the
+//! trajectory's angular path between consecutive stamps stays below
+//! a fraction of a pixel; for a static trajectory the schedule
+//! collapses to a single stamp.
+//!
+//! # Noise model
+//!
+//! A single unified Poisson draw is taken per `(frame, sensor)` over the
+//! mean-electron image comprising:
+//!
+//! - Star contributions accumulated across all stamps (each stamp
+//!   contributes `flux × dt` electrons where `dt = exposure / stamps_per_exposure`).
+//! - A uniform zodiacal mean evaluated at the frame's central boresight.
+//! - A uniform dark-current mean from the per-sensor dark current rate
+//!   times the full exposure duration.
+//!
+//! Gaussian read noise is added separately after the Poisson draw because
+//! it is an electronic readout effect, not a photon shot-noise contribution.
+//!
+//! # Parallelism
+//!
+//! The top-level entry point parallelizes over `(frame_idx, sensor_idx)`
+//! pairs via rayon. Each tile independently consumes its pre-filtered
+//! star slice, materializes a per-sensor mean-electron accumulator,
+//! draws noise, quantizes, and writes its PNG. Nothing is reduced
+//! across tiles.
+//!
+//! # Layout
+//!
+//! - [`schedule`] — [`SubsampleSchedule`] and the per-stamp time grid.
+//! - [`accumulator`] — [`SensorAccumulator`] electron accumulation.
+//! - [`render`] — the render pipeline ([`render_motion_trajectory`],
+//!   [`render_one_frame`], [`render_one_frame_roi`]) and its tile/frame
+//!   orchestration.
+//! - [`metadata`] — assembly of the per-render `metadata.json`.
+
+mod accumulator;
+mod metadata;
+mod render;
+mod schedule;
+
+pub use accumulator::SensorAccumulator;
+pub use render::{
+    render_motion_trajectory, render_one_frame, render_one_frame_roi, FluxCache, LightSources,
+    MotionBlurConfig,
+};
+pub use schedule::{SubsampleSchedule, DEFAULT_MAX_DRIFT_PER_STAMP_PX};

--- a/simulator/src/sims/motion_blur/render.rs
+++ b/simulator/src/sims/motion_blur/render.rs
@@ -1,40 +1,15 @@
-//! Parallel motion-blur renderer for focal-plane trajectories.
+//! The motion-blur render pipeline: per-frame planning, per-tile
+//! mean-electron assembly, unified Poisson + read noise, quantization,
+//! and PNG output.
 //!
-//! Each frame's exposure window is integrated as a single flat
-//! stratified-Monte-Carlo sequence of PSF stamps. The total stamp
-//! count is chosen adaptively from a per-stamp drift budget so the
-//! trajectory's angular path between consecutive stamps stays below
-//! a fraction of a pixel; for a static trajectory the schedule
-//! collapses to a single stamp.
-//!
-//! # Noise model
-//!
-//! A single unified Poisson draw is taken per `(frame, sensor)` over the
-//! mean-electron image comprising:
-//!
-//! - Star contributions accumulated across all stamps (each stamp
-//!   contributes `flux × dt` electrons where `dt = exposure / stamps_per_exposure`).
-//! - A uniform zodiacal mean evaluated at the frame's central boresight.
-//! - A uniform dark-current mean from the per-sensor dark current rate
-//!   times the full exposure duration.
-//!
-//! Gaussian read noise is added separately after the Poisson draw because
-//! it is an electronic readout effect, not a photon shot-noise contribution.
-//!
-//! # Parallelism
-//!
-//! The top-level entry point parallelizes over `(frame_idx, sensor_idx)`
-//! pairs via rayon. Each tile independently consumes its pre-filtered
-//! star slice, materializes a per-sensor mean-electron accumulator,
-//! draws noise, quantizes, and writes its PNG. Nothing is reduced
-//! across tiles.
+//! See the [`motion_blur`](super) module docs for the overall noise
+//! model and parallelism strategy.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use chrono::SecondsFormat;
 use image::{ImageBuffer, Luma};
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use log::{debug, info};
@@ -54,206 +29,14 @@ use crate::photometry::photoconversion::SourceFlux;
 use crate::photometry::spectrum::Spectrum;
 use crate::photometry::zodiacal::{SolarAngularCoordinates, ZodiacalLight};
 use crate::scene_galaxy::{project_galaxies_to_sensors, Galaxy, GalaxyInFrame};
-use crate::sims::motion_blur_metadata::{
-    sensor_dir_name, sensor_relative_png_path, EquatorialMeta, FrameMeta, HardwareMeta,
-    RenderConfigMeta, RenderMetadata, SensorMeta, StarMeta, TrajectoryMeta, WaypointMeta,
-    ZodiacalMeta,
-};
-use crate::sims::orientation::{boresight_of, roll_of};
+use crate::sims::motion_blur_metadata::{sensor_dir_name, sensor_relative_png_path};
+use crate::sims::orientation::boresight_of;
 use crate::sims::quasi_random;
 use crate::sims::trajectory::{Trajectory, TrajectoryError};
 use crate::star_math::star_data_to_fluxes;
 
-/// Default per-stamp drift budget (in pixels). The total stamp count is
-/// derived as `ceil(total_drift_rad / (DEFAULT_MAX_DRIFT_PER_STAMP_PX * pixel_scale_rad))`.
-pub const DEFAULT_MAX_DRIFT_PER_STAMP_PX: f64 = 0.1;
-
-/// Time-domain stamp schedule inside an exposure window.
-///
-/// A `SubsampleSchedule` describes a single flat sequence of
-/// PSF-stamp times across the exposure: the window is divided into
-/// `stamps_per_exposure` equal-width sub-bins and each stamp lands at
-/// a uniform-random offset within its sub-bin (stratified Monte
-/// Carlo). Stratification preserves smooth-integrand convergence
-/// while removing the systematic bias a regular grid produces against
-/// trajectory tones near `k / Δt_stamp`.
-///
-/// Each stamp queries the trajectory at its own time, projects every
-/// in-field star, and deposits `flux / stamps_per_exposure` electrons
-/// at the per-time projected pixel position.
-///
-/// `envelope_padding_rad` is the safety padding the *envelope
-/// prefilter* uses to inflate the focal-plane AABB so that any star
-/// whose excursion brings it onto the sensor at any point during the
-/// exposure is retained. It is the only thing the renderer needs from
-/// "scene-state cadence" — there is no separate subsample-level loop
-/// for scene state.
-#[derive(Debug, Clone, Copy)]
-pub struct SubsampleSchedule {
-    /// Absolute trajectory time at which the frame's exposure starts.
-    pub frame_start: Duration,
-    /// Total exposure duration for this frame.
-    pub exposure: Duration,
-    /// Total number of stratified-MC PSF stamps across the exposure (>= 1).
-    pub stamps_per_exposure: usize,
-    /// Peak excursion of the trajectory from the frame's mid-time
-    /// orientation, in radians. The envelope prefilter inflates the
-    /// focal-plane AABB by this amount (converted to mm) on top of
-    /// its own PSF-extent padding.
-    pub envelope_padding_rad: f64,
-}
-
-impl SubsampleSchedule {
-    /// Per-stamp duration: `exposure / stamps_per_exposure`. Each
-    /// stamp's electron contribution is integrated over this `dt`.
-    pub fn dt(&self) -> Duration {
-        Duration::from_secs_f64(
-            self.exposure.as_secs_f64() / self.stamps_per_exposure.max(1) as f64,
-        )
-    }
-
-    /// Quasi-random stamp times across the entire exposure window,
-    /// derived from the 1D golden-ratio low-discrepancy sequence (see
-    /// [`crate::sims::quasi_random`]). Returns a vector of length
-    /// `stamps_per_exposure.max(1)`. Stamp `j` lands at
-    /// `frame_start + offset_j · exposure`, where `offset_j` is the
-    /// `j`-th element of the golden-ratio sequence with the given
-    /// `phase` shift.
-    ///
-    /// The golden-ratio sequence is **deterministic** — no RNG is
-    /// consumed. `phase` is the only source of per-tile variation;
-    /// the renderer derives it from the tile seed via
-    /// [`crate::sims::quasi_random::phase_from_seed`].
-    pub fn stamp_times(&self, phase: f64) -> Vec<Duration> {
-        let total = self.stamps_per_exposure.max(1);
-        let exposure_s = self.exposure.as_secs_f64();
-        let t0 = self.frame_start.as_secs_f64();
-        crate::sims::quasi_random::golden_offsets(total, phase)
-            .into_iter()
-            .map(|u| Duration::from_secs_f64(t0 + u * exposure_s))
-            .collect()
-    }
-
-    /// Frame mid-time, used as the reference orientation for envelope
-    /// prefiltering and zodiacal evaluation.
-    pub fn mid_time(&self) -> Duration {
-        self.frame_start + self.exposure / 2
-    }
-
-    /// Construct a schedule from a per-stamp drift budget plus a peak
-    /// excursion (both in radians). Stamp count is
-    /// `ceil(total_drift_rad / (max_drift_per_stamp_px * pixel_scale_rad))`,
-    /// minimum 1. Envelope padding stores `peak_excursion_rad` directly
-    /// for later mm conversion in [`envelope_prefilter`].
-    pub fn from_drift_budget(
-        frame_start: Duration,
-        exposure: Duration,
-        total_drift_rad_over_exposure: f64,
-        peak_excursion_rad: f64,
-        pixel_scale_rad: f64,
-        max_drift_per_stamp_px: f64,
-    ) -> Self {
-        let stamps_per_exposure = if total_drift_rad_over_exposure <= 0.0
-            || pixel_scale_rad <= 0.0
-            || max_drift_per_stamp_px <= 0.0
-        {
-            1
-        } else {
-            let budget_rad = max_drift_per_stamp_px * pixel_scale_rad;
-            ((total_drift_rad_over_exposure / budget_rad).ceil() as usize).max(1)
-        };
-        Self {
-            frame_start,
-            exposure,
-            stamps_per_exposure,
-            envelope_padding_rad: peak_excursion_rad.max(0.0),
-        }
-    }
-}
-
-/// Per-tile mean-electron accumulator (pre-Poisson).
-///
-/// Stars are splatted in as mean-electron contributions (not draws) so
-/// that all sub-samples, the zodiacal uniform, and the dark-current uniform
-/// can be combined into a single Poisson lambda.
-#[derive(Debug, Clone)]
-pub struct SensorAccumulator {
-    /// Accumulated mean electrons from star subsample splats.
-    pub star_mean_electrons: Array2<f64>,
-}
-
-impl SensorAccumulator {
-    /// Allocate a zeroed accumulator shaped `(height, width)`.
-    pub fn zero(width: usize, height: usize) -> Self {
-        Self {
-            star_mean_electrons: Array2::zeros((height, width)),
-        }
-    }
-
-    /// Splat one star's mean electrons (already integrated over `dt`, not
-    /// Poisson-sampled) into the accumulator via Simpson's rule over the
-    /// Airy disk.
-    ///
-    /// `total_electrons` is the expected number of electrons this subsample
-    /// contributes across the disk — i.e. the star's mean-electron rate at
-    /// the star's chromatic effective PSF, multiplied by aperture area and
-    /// the subsample duration.
-    pub fn splat_psf(
-        &mut self,
-        px: f64,
-        py: f64,
-        total_electrons: f64,
-        psf: &shared::image_proc::airy::PixelScaledAiryDisk,
-    ) {
-        crate::image_proc::deposit::splat_deposit(
-            &mut self.star_mean_electrons,
-            px,
-            py,
-            total_electrons,
-            psf,
-        );
-    }
-
-    /// Splat one galaxy's mean electrons (already integrated over `dt`,
-    /// not Poisson-sampled) into the same accumulator stars use, via
-    /// the galaxy's `SersicSplat` deposit. The single-Poisson invariant
-    /// (INVARIANTS §1) is preserved because galaxies land on the same
-    /// `star_mean_electrons` buffer that the unified Poisson eventually
-    /// samples — galaxy and star shot noise are co-sampled from the
-    /// per-pixel `Poisson(λ_total)` of the combined mean.
-    pub fn splat_galaxy(
-        &mut self,
-        px: f64,
-        py: f64,
-        total_electrons: f64,
-        sersic: &crate::image_proc::sersic_splat::SersicSplat,
-    ) {
-        crate::image_proc::deposit::splat_deposit(
-            &mut self.star_mean_electrons,
-            px,
-            py,
-            total_electrons,
-            sersic,
-        );
-    }
-
-    /// Consume the accumulator and return the combined mean-electron image
-    /// = star mean + zodiacal uniform + dark-current uniform (pre-Poisson).
-    ///
-    /// The accumulator's existing `star_mean_electrons` buffer is reused —
-    /// no second 488 MB allocation, no read-then-write of a fresh array.
-    /// The scalar background is added in place via rayon-parallel
-    /// element-wise iteration (ndarray's `rayon` feature is enabled).
-    pub fn into_combined_mean(mut self, zodiacal_per_px: f64, dark_per_px: f64) -> Array2<f64> {
-        let bg = (zodiacal_per_px + dark_per_px).max(0.0);
-        if bg > 0.0 {
-            self.star_mean_electrons
-                .par_iter_mut()
-                .for_each(|pixel| *pixel += bg);
-        }
-        self.star_mean_electrons
-    }
-}
+use super::accumulator::SensorAccumulator;
+use super::schedule::{SubsampleSchedule, DEFAULT_MAX_DRIFT_PER_STAMP_PX};
 
 /// Per-tile flux cache keyed by `(star_id, sensor_idx)`.
 ///
@@ -289,10 +72,10 @@ pub struct LightSources<'a> {
 /// at render start by [`project_galaxies_to_sensors`] from
 /// `sources.galaxies` — a single galaxy may appear in more than one
 /// sensor's list if its halo subtends them.
-struct RenderScene<'a> {
-    trajectory: &'a Trajectory,
-    sources: LightSources<'a>,
-    fp: &'a FocalPlaneConfig,
+pub(super) struct RenderScene<'a> {
+    pub(super) trajectory: &'a Trajectory,
+    pub(super) sources: LightSources<'a>,
+    pub(super) fp: &'a FocalPlaneConfig,
     projected_galaxies: Vec<Vec<GalaxyInFrame>>,
 }
 
@@ -1284,7 +1067,7 @@ pub fn render_motion_trajectory(
 
     // Assemble and write metadata.json describing the render. Every PNG path
     // recorded here is relative (forward-slash) to `output_dir`.
-    let metadata = build_render_metadata(
+    let metadata = super::metadata::build_render_metadata(
         &scene,
         &ctx.satellites,
         config,
@@ -1315,132 +1098,6 @@ pub fn render_motion_trajectory(
 /// serial planning pass plus the render config and per-sensor satellite
 /// configs. Static scene inputs (trajectory, catalog, focal plane, zodiacal
 /// coords) come through the [`RenderScene`] handle.
-fn build_render_metadata(
-    scene: &RenderScene,
-    satellites: &[SatelliteConfig],
-    config: &MotionBlurConfig,
-    frame_plans: &[(usize, SubsampleSchedule)],
-    sensor_count: usize,
-) -> Result<RenderMetadata, TrajectoryError> {
-    let rendered_at = chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
-
-    let start = scene.trajectory.start_time();
-    let end = scene.trajectory.end_time();
-    let trajectory_meta = TrajectoryMeta {
-        duration_s: (end - start).as_secs_f64(),
-        start_time_s: start.as_secs_f64(),
-        end_time_s: end.as_secs_f64(),
-        waypoints: scene
-            .trajectory
-            .waypoints()
-            .iter()
-            .map(|wp| {
-                let q = wp.orientation;
-                let bore = boresight_of(&q);
-                WaypointMeta {
-                    time_s: wp.time.as_secs_f64(),
-                    quat: q,
-                    boresight: EquatorialMeta {
-                        ra_deg: bore.ra_degrees(),
-                        dec_deg: bore.dec_degrees(),
-                    },
-                    roll_deg: roll_of(&q).to_degrees(),
-                }
-            })
-            .collect(),
-    };
-
-    let mut frames: Vec<FrameMeta> = Vec::with_capacity(frame_plans.len());
-    for (frame_idx, schedule) in frame_plans {
-        let mid_t = (schedule.frame_start + schedule.exposure / 2)
-            .min(scene.trajectory.end_time())
-            .max(scene.trajectory.start_time());
-        let q = scene.trajectory.orientation_at(mid_t)?;
-        let bore = boresight_of(&q);
-        let mut paths: BTreeMap<String, String> = BTreeMap::new();
-        for sensor_idx in 0..sensor_count {
-            paths.insert(
-                sensor_dir_name(sensor_idx),
-                sensor_relative_png_path(sensor_idx, *frame_idx),
-            );
-        }
-        frames.push(FrameMeta {
-            idx: *frame_idx,
-            t_s: schedule.frame_start.as_secs_f64(),
-            exposure_s: schedule.exposure.as_secs_f64(),
-            quat: q,
-            boresight: EquatorialMeta {
-                ra_deg: bore.ra_degrees(),
-                dec_deg: bore.dec_degrees(),
-            },
-            roll_deg: roll_of(&q).to_degrees(),
-            n_stamps: schedule.stamps_per_exposure,
-            paths,
-        });
-    }
-
-    let stars: Vec<StarMeta> = scene
-        .sources
-        .catalog_stars
-        .iter()
-        .map(|s| StarMeta {
-            id: s.id,
-            // starfield::StarData does not currently expose a name
-            // field; left None until an upstream catalog wires it in.
-            name: None,
-            ra_deg: s.position.ra_degrees(),
-            dec_deg: s.position.dec_degrees(),
-            magnitude: s.magnitude,
-            color_index: s.b_v,
-        })
-        .collect();
-
-    let galaxies: Vec<Galaxy> = scene.sources.galaxies.to_vec();
-
-    let sensors: Vec<SensorMeta> = (0..sensor_count)
-        .map(|i| {
-            let ps = &scene.fp.array.sensors[i];
-            let (width, height) = ps.sensor.dimensions.get_pixel_width_height();
-            SensorMeta {
-                idx: i,
-                name: satellites[i].sensor.name.clone(),
-                dimensions_px: [width, height],
-                position_mm: [ps.position.x_mm, ps.position.y_mm],
-            }
-        })
-        .collect();
-
-    let hardware = HardwareMeta {
-        telescope: config.telescope_name.clone(),
-        temperature_c: config.temperature_c,
-        sensors,
-    };
-
-    let render_config = RenderConfigMeta {
-        exposure_s: config.exposure.as_secs_f64(),
-        timestep_s: config.timestep.as_secs_f64(),
-        max_drift_per_stamp_px: config.max_drift_per_stamp_px,
-        seed: config.base_seed.unwrap_or(0),
-        force_static: config.force_static,
-        catalog_path: config.catalog_path.to_string_lossy().into_owned(),
-        zodiacal: ZodiacalMeta {
-            elongation_deg: scene.sources.zodiacal.elongation(),
-            latitude_deg: scene.sources.zodiacal.latitude(),
-        },
-    };
-
-    Ok(RenderMetadata {
-        version: "1.1".to_string(),
-        rendered_at,
-        trajectory: trajectory_meta,
-        frames,
-        stars,
-        galaxies,
-        hardware,
-        render_config,
-    })
-}
-
 /// Per-pixel-per-second zodiacal electron rate at a given boresight for a
 /// specific satellite (combined QE + aperture + per-pixel solid angle).
 fn zodiacal_per_px_per_s_at(
@@ -1493,7 +1150,7 @@ mod tests {
     use crate::hardware::sensor::models::GSENSE4040BSI;
     use crate::hardware::sensor_array::SensorArray;
     use crate::hardware::telescope::TelescopeConfig;
-    use crate::sims::orientation::orientation_from_pointing;
+    use crate::sims::orientation::{orientation_from_pointing, roll_of};
     use crate::sims::trajectory::Waypoint;
     use approx::assert_abs_diff_eq;
     use nalgebra::UnitQuaternion;
@@ -1552,96 +1209,6 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let frames = render_motion_trajectory(traj, sources, fp, cfg, tmp.path()).unwrap();
         (tmp, frames)
-    }
-
-    #[test]
-    fn test_from_drift_budget_static_gives_one_stamp() {
-        let sched = SubsampleSchedule::from_drift_budget(
-            Duration::ZERO,
-            Duration::from_secs(1),
-            0.0, // zero drift
-            0.0, // zero excursion
-            1e-6,
-            0.1,
-        );
-        assert_eq!(sched.stamps_per_exposure, 1);
-        assert_eq!(sched.envelope_padding_rad, 0.0);
-    }
-
-    #[test]
-    fn test_from_drift_budget_picks_total_stamps_from_path_length() {
-        // 10 px of total path length at pixel_scale=1e-5 rad/px with a
-        // 0.1 px per-stamp budget should yield 100 total stamps.
-        let pixel_scale = 1e-5_f64;
-        let drift_px = 10.0;
-        let budget_px = 0.1;
-        let excursion_rad = 0.5_f64 * pixel_scale; // arbitrary positive
-        let sched = SubsampleSchedule::from_drift_budget(
-            Duration::ZERO,
-            Duration::from_secs(1),
-            drift_px * pixel_scale,
-            excursion_rad,
-            pixel_scale,
-            budget_px,
-        );
-        let expected = (drift_px / budget_px).ceil() as usize;
-        assert_eq!(sched.stamps_per_exposure, expected);
-        assert_abs_diff_eq!(sched.envelope_padding_rad, excursion_rad, epsilon = 1e-15);
-    }
-
-    #[test]
-    fn test_stamp_times_span_the_exposure_window() {
-        // Stamps must all fall inside [frame_start, frame_start + exposure).
-        let sched = SubsampleSchedule {
-            frame_start: Duration::from_secs(10),
-            exposure: Duration::from_secs(4),
-            stamps_per_exposure: 16,
-            envelope_padding_rad: 0.0,
-        };
-        let stamps = sched.stamp_times(0.0);
-        assert_eq!(stamps.len(), 16);
-        let lo = 10.0;
-        let hi = 14.0;
-        for t in &stamps {
-            let v = t.as_secs_f64();
-            assert!(v >= lo && v < hi, "stamp {v} outside [{lo}, {hi})");
-        }
-    }
-
-    #[test]
-    fn test_stamp_times_are_reproducible_for_same_phase() {
-        // The R2 stamp times are a pure function of (schedule, phase).
-        let sched = SubsampleSchedule {
-            frame_start: Duration::ZERO,
-            exposure: Duration::from_secs(1),
-            stamps_per_exposure: 128,
-            envelope_padding_rad: 0.0,
-        };
-        let a = sched.stamp_times(0.123);
-        let b = sched.stamp_times(0.123);
-        assert_eq!(a, b);
-        let c = sched.stamp_times(0.124);
-        assert_ne!(a, c);
-    }
-
-    #[test]
-    fn test_mid_time_is_exposure_midpoint() {
-        let sched = SubsampleSchedule {
-            frame_start: Duration::from_secs(10),
-            exposure: Duration::from_secs(4),
-            stamps_per_exposure: 4,
-            envelope_padding_rad: 0.0,
-        };
-        assert_eq!(sched.mid_time(), Duration::from_secs(12));
-    }
-
-    #[test]
-    fn test_sensor_accumulator_combined_mean() {
-        let mut acc = SensorAccumulator::zero(4, 4);
-        acc.star_mean_electrons[[1, 1]] = 5.0;
-        let combined = acc.into_combined_mean(2.0, 1.0);
-        assert_eq!(combined[[0, 0]], 3.0); // 0 + 2 + 1
-        assert_eq!(combined[[1, 1]], 8.0); // 5 + 2 + 1
     }
 
     #[test]

--- a/simulator/src/sims/motion_blur/schedule.rs
+++ b/simulator/src/sims/motion_blur/schedule.rs
@@ -1,0 +1,201 @@
+//! Time-domain stamp scheduling for the motion-blur renderer.
+//!
+//! A [`SubsampleSchedule`] divides an exposure window into a flat
+//! stratified-Monte-Carlo sequence of PSF-stamp times; the stamp count is
+//! chosen adaptively from a per-stamp drift budget.
+
+use std::time::Duration;
+
+/// Default per-stamp drift budget (in pixels). The total stamp count is
+/// derived as `ceil(total_drift_rad / (DEFAULT_MAX_DRIFT_PER_STAMP_PX * pixel_scale_rad))`.
+pub const DEFAULT_MAX_DRIFT_PER_STAMP_PX: f64 = 0.1;
+
+/// Time-domain stamp schedule inside an exposure window.
+///
+/// A `SubsampleSchedule` describes a single flat sequence of
+/// PSF-stamp times across the exposure: the window is divided into
+/// `stamps_per_exposure` equal-width sub-bins and each stamp lands at
+/// a uniform-random offset within its sub-bin (stratified Monte
+/// Carlo). Stratification preserves smooth-integrand convergence
+/// while removing the systematic bias a regular grid produces against
+/// trajectory tones near `k / Δt_stamp`.
+///
+/// Each stamp queries the trajectory at its own time, projects every
+/// in-field star, and deposits `flux / stamps_per_exposure` electrons
+/// at the per-time projected pixel position.
+///
+/// `envelope_padding_rad` is the safety padding the *envelope
+/// prefilter* uses to inflate the focal-plane AABB so that any star
+/// whose excursion brings it onto the sensor at any point during the
+/// exposure is retained. It is the only thing the renderer needs from
+/// "scene-state cadence" — there is no separate subsample-level loop
+/// for scene state.
+#[derive(Debug, Clone, Copy)]
+pub struct SubsampleSchedule {
+    /// Absolute trajectory time at which the frame's exposure starts.
+    pub frame_start: Duration,
+    /// Total exposure duration for this frame.
+    pub exposure: Duration,
+    /// Total number of stratified-MC PSF stamps across the exposure (>= 1).
+    pub stamps_per_exposure: usize,
+    /// Peak excursion of the trajectory from the frame's mid-time
+    /// orientation, in radians. The envelope prefilter inflates the
+    /// focal-plane AABB by this amount (converted to mm) on top of
+    /// its own PSF-extent padding.
+    pub envelope_padding_rad: f64,
+}
+
+impl SubsampleSchedule {
+    /// Per-stamp duration: `exposure / stamps_per_exposure`. Each
+    /// stamp's electron contribution is integrated over this `dt`.
+    pub fn dt(&self) -> Duration {
+        Duration::from_secs_f64(
+            self.exposure.as_secs_f64() / self.stamps_per_exposure.max(1) as f64,
+        )
+    }
+
+    /// Quasi-random stamp times across the entire exposure window,
+    /// derived from the 1D golden-ratio low-discrepancy sequence (see
+    /// [`crate::sims::quasi_random`]). Returns a vector of length
+    /// `stamps_per_exposure.max(1)`. Stamp `j` lands at
+    /// `frame_start + offset_j · exposure`, where `offset_j` is the
+    /// `j`-th element of the golden-ratio sequence with the given
+    /// `phase` shift.
+    ///
+    /// The golden-ratio sequence is **deterministic** — no RNG is
+    /// consumed. `phase` is the only source of per-tile variation;
+    /// the renderer derives it from the tile seed via
+    /// [`crate::sims::quasi_random::phase_from_seed`].
+    pub fn stamp_times(&self, phase: f64) -> Vec<Duration> {
+        let total = self.stamps_per_exposure.max(1);
+        let exposure_s = self.exposure.as_secs_f64();
+        let t0 = self.frame_start.as_secs_f64();
+        crate::sims::quasi_random::golden_offsets(total, phase)
+            .into_iter()
+            .map(|u| Duration::from_secs_f64(t0 + u * exposure_s))
+            .collect()
+    }
+
+    /// Frame mid-time, used as the reference orientation for envelope
+    /// prefiltering and zodiacal evaluation.
+    pub fn mid_time(&self) -> Duration {
+        self.frame_start + self.exposure / 2
+    }
+
+    /// Construct a schedule from a per-stamp drift budget plus a peak
+    /// excursion (both in radians). Stamp count is
+    /// `ceil(total_drift_rad / (max_drift_per_stamp_px * pixel_scale_rad))`,
+    /// minimum 1. Envelope padding stores `peak_excursion_rad` directly
+    /// for later mm conversion in `envelope_prefilter`.
+    pub fn from_drift_budget(
+        frame_start: Duration,
+        exposure: Duration,
+        total_drift_rad_over_exposure: f64,
+        peak_excursion_rad: f64,
+        pixel_scale_rad: f64,
+        max_drift_per_stamp_px: f64,
+    ) -> Self {
+        let stamps_per_exposure = if total_drift_rad_over_exposure <= 0.0
+            || pixel_scale_rad <= 0.0
+            || max_drift_per_stamp_px <= 0.0
+        {
+            1
+        } else {
+            let budget_rad = max_drift_per_stamp_px * pixel_scale_rad;
+            ((total_drift_rad_over_exposure / budget_rad).ceil() as usize).max(1)
+        };
+        Self {
+            frame_start,
+            exposure,
+            stamps_per_exposure,
+            envelope_padding_rad: peak_excursion_rad.max(0.0),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_abs_diff_eq;
+
+    #[test]
+    fn test_from_drift_budget_static_gives_one_stamp() {
+        let sched = SubsampleSchedule::from_drift_budget(
+            Duration::ZERO,
+            Duration::from_secs(1),
+            0.0, // zero drift
+            0.0, // zero excursion
+            1e-6,
+            0.1,
+        );
+        assert_eq!(sched.stamps_per_exposure, 1);
+        assert_eq!(sched.envelope_padding_rad, 0.0);
+    }
+
+    #[test]
+    fn test_from_drift_budget_picks_total_stamps_from_path_length() {
+        // 10 px of total path length at pixel_scale=1e-5 rad/px with a
+        // 0.1 px per-stamp budget should yield 100 total stamps.
+        let pixel_scale = 1e-5_f64;
+        let drift_px = 10.0;
+        let budget_px = 0.1;
+        let excursion_rad = 0.5_f64 * pixel_scale; // arbitrary positive
+        let sched = SubsampleSchedule::from_drift_budget(
+            Duration::ZERO,
+            Duration::from_secs(1),
+            drift_px * pixel_scale,
+            excursion_rad,
+            pixel_scale,
+            budget_px,
+        );
+        let expected = (drift_px / budget_px).ceil() as usize;
+        assert_eq!(sched.stamps_per_exposure, expected);
+        assert_abs_diff_eq!(sched.envelope_padding_rad, excursion_rad, epsilon = 1e-15);
+    }
+
+    #[test]
+    fn test_stamp_times_span_the_exposure_window() {
+        // Stamps must all fall inside [frame_start, frame_start + exposure).
+        let sched = SubsampleSchedule {
+            frame_start: Duration::from_secs(10),
+            exposure: Duration::from_secs(4),
+            stamps_per_exposure: 16,
+            envelope_padding_rad: 0.0,
+        };
+        let stamps = sched.stamp_times(0.0);
+        assert_eq!(stamps.len(), 16);
+        let lo = 10.0;
+        let hi = 14.0;
+        for t in &stamps {
+            let v = t.as_secs_f64();
+            assert!(v >= lo && v < hi, "stamp {v} outside [{lo}, {hi})");
+        }
+    }
+
+    #[test]
+    fn test_stamp_times_are_reproducible_for_same_phase() {
+        // The R2 stamp times are a pure function of (schedule, phase).
+        let sched = SubsampleSchedule {
+            frame_start: Duration::ZERO,
+            exposure: Duration::from_secs(1),
+            stamps_per_exposure: 128,
+            envelope_padding_rad: 0.0,
+        };
+        let a = sched.stamp_times(0.123);
+        let b = sched.stamp_times(0.123);
+        assert_eq!(a, b);
+        let c = sched.stamp_times(0.124);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn test_mid_time_is_exposure_midpoint() {
+        let sched = SubsampleSchedule {
+            frame_start: Duration::from_secs(10),
+            exposure: Duration::from_secs(4),
+            stamps_per_exposure: 4,
+            envelope_padding_rad: 0.0,
+        };
+        assert_eq!(sched.mid_time(), Duration::from_secs(12));
+    }
+}


### PR DESCRIPTION
Closes #118.

> **Stacked on #115** (the `meawoppl/factor-motion-blur-test-fixtures` branch) because both touch the `motion_blur` test module. Merge #115 first; this PR's base auto-retargets to `main` afterward. The diff shown here is only the split.

`motion_blur.rs` was ~2800 lines bundling four concerns. This converts it into a `motion_blur/` directory module:

| file | concern | lines |
|---|---|---|
| `schedule.rs` | `SubsampleSchedule` + stamp timing | ~200 |
| `accumulator.rs` | `SensorAccumulator` electron accumulation | ~100 |
| `metadata.rs` | `metadata.json` (`RenderMetadata`) assembly | ~150 |
| `render.rs` | the render pipeline (renamed original) | ~2390 (~1100 impl + ~1090 integration tests) |
| `mod.rs` | module docs + public re-exports | ~50 |

## Notes
- **Public API unchanged.** `crate::sims::motion_blur::{render_motion_trajectory, render_one_frame, render_one_frame_roi, LightSources, MotionBlurConfig, SubsampleSchedule, SensorAccumulator, FluxCache, DEFAULT_MAX_DRIFT_PER_STAMP_PX}` are all re-exported from `mod.rs`. No downstream caller (`bin/motion_simulator`, `trajectory`, `scene_galaxy`, `image_proc::deposit`) changes.
- `RenderScene` and the three fields `build_render_metadata` reads are now `pub(super)` so `metadata.rs` can reach them — still private to the `motion_blur` module, not leaked crate-wide.
- The renamed file keeps git history (`R084` rename). Each moved concern's unit tests travel with its submodule; the pipeline/metadata integration tests (which share fixtures) stay in `render.rs`.
- **`render.rs` remains the dominant file** — its non-test core (~1100 lines) is the genuinely-cohesive render pipeline, and ~1090 lines are its integration tests. Splitting it further would fragment a single concern; left as-is intentionally.

Pure code-organization refactor, no behavior change.

## Verification
- `cargo test --package simulator --lib` — 297 passed, 0 failed
- `cargo fmt` + `cargo clippy --package simulator -- -W clippy::all` clean