### PR TITLE
CLAUDE.md: standardize on approx for float assertions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ scripts/install-hooks.sh
 - **Performance**: Prefer vectorized operations. Profile computation-heavy code.
 - **Testing**: NEVER special case testing in production algorithms. Tests should validate real algorithm behavior, not special-cased shortcuts. Do NOT use doctests - write proper unit tests in test modules instead.
 - **Performance Testing**: NEVER assert timing/speed in unit tests. CI environments vary widely in performance (threading, load, virtualization). Tests should report timing metrics for visibility but only assert correctness. If performance benchmarks are needed, create dedicated benchmark binaries that run in controlled environments.
+- **Float assertions**: Use `approx::assert_abs_diff_eq!(a, b, epsilon = eps)` (or `assert_relative_eq!` for relative comparisons) for float equality in tests; avoid hand-rolled `(a - b).abs() < eps`. The approx forms print both values and the actual delta on failure and are consistent with the rest of the codebase.
 - **Space context**: Avoid terrestrial telescope conventions (elevation/azimuth, horizon coordinates) - use generic pointing directions, celestial coordinates, or instrument-relative axes.
 
 ## Git Commits

--- a/simulator/src/sims/motion_blur_metadata.rs
+++ b/simulator/src/sims/motion_blur_metadata.rs
@@ -231,6 +231,8 @@ mod tests {
 
     #[test]
     fn test_render_metadata_round_trip_via_serde() {
+        use approx::assert_abs_diff_eq;
+
         use crate::photometry::photoconversion::{SourceFlux, SpotFlux};
         use shared::image_proc::airy::PixelScaledAiryDisk;
         use shared::units::{LengthExt, Wavelength};
@@ -302,8 +304,8 @@ mod tests {
         let g = &parsed.galaxies[0];
         assert_eq!(g.id, 12345);
         assert_eq!(g.name.as_deref(), Some("NGC test"));
-        assert!((g.position.ra_degrees() - 187.25).abs() < 1e-9);
-        assert!((g.position.dec_degrees() - 12.5).abs() < 1e-9);
+        assert_abs_diff_eq!(g.position.ra_degrees(), 187.25, epsilon = 1e-9);
+        assert_abs_diff_eq!(g.position.dec_degrees(), 12.5, epsilon = 1e-9);
         assert_eq!(g.profile.n, 1.5);
         assert_eq!(g.profile.axis_ratio, 0.7);
         assert_eq!(g.flux.electrons.flux, 7.0e-3);


### PR DESCRIPTION
Closes #122.

## Changes
1. **`CLAUDE.md`** — adds a *Code Style Guidelines* bullet: use `approx::assert_abs_diff_eq!` / `assert_relative_eq!` for float equality in tests; avoid hand-rolled `(a - b).abs() < eps`. The approx forms print both values plus the actual delta on failure and match the rest of the codebase.
2. **`motion_blur_metadata.rs`** — converts the ad-hoc float asserts in `test_render_metadata_round_trip_via_serde` to `assert_abs_diff_eq!` (added the local `use approx::assert_abs_diff_eq;`).

## Note on the third site
The issue listed three sites; only two remained. The aperture assert (`focal_plane.telescope.aperture` at the old line 212) is gone — the metadata schema changed to a `hardware.telescope` string (no `focal_plane` block), so there's no float comparison left there. The two galaxy-position asserts were converted.

A wider repo-wide sweep of `(a-b).abs() < eps` remains out of scope per the issue.

## Verification
- `cargo test --package simulator --lib motion_blur_metadata` — 4 passed
- `cargo fmt` + `cargo clippy --package simulator -- -W clippy::all` clean