### PR TITLE
tests: convert ad-hoc float asserts to approx

### DIFF
--- a/simulator/src/image_proc/render.rs
+++ b/simulator/src/image_proc/render.rs
@@ -551,7 +551,7 @@ pub fn route_stars_to_sensors(
 
 #[cfg(test)]
 mod tests {
-    use approx::assert_relative_eq;
+    use approx::{assert_abs_diff_eq, assert_relative_eq};
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
 
@@ -1176,7 +1176,7 @@ mod tests {
         assert_eq!(unrolled.len(), 1);
         let (x0, y0) = (unrolled[0].x_mm, unrolled[0].y_mm);
         assert!(x0.abs() > 0.05, "expected meaningful x offset, got {x0}");
-        assert!(y0.abs() < 0.05, "expected near-zero y offset, got {y0}");
+        assert_abs_diff_eq!(y0, 0.0, epsilon = 0.05);
 
         // Roll by +pi/2 -> right-hand rule about +Z sends (x, 0) to (0, x).
         let rolled = project_stars_to_focal_plane_oriented(

--- a/simulator/src/sims/context_render.rs
+++ b/simulator/src/sims/context_render.rs
@@ -552,6 +552,7 @@ mod tests {
     use crate::hardware::sensor_array::SensorArray;
     use crate::hardware::telescope::TelescopeConfig;
     use crate::sims::orientation::orientation_from_pointing;
+    use approx::assert_abs_diff_eq;
     use shared::units::{Length, LengthExt, TemperatureExt};
     use starfield::Equatorial;
 
@@ -581,7 +582,7 @@ mod tests {
         assert!(bright > dim, "brighter stars must render larger");
         // Bright-end saturation: stars at or beyond mag_bright hit the max radius.
         let too_bright = mag_to_radius(Some(-5.0), &cfg);
-        assert!((too_bright - cfg.star_radius_max_px).abs() < 1e-9);
+        assert_abs_diff_eq!(too_bright, cfg.star_radius_max_px, epsilon = 1e-9);
         // Dim-end: beyond-mag_dim stars never render smaller than the floor
         // and never larger than the mag_dim star.
         let too_dim = mag_to_radius(Some(30.0), &cfg);

--- a/simulator/src/sims/jitter.rs
+++ b/simulator/src/sims/jitter.rs
@@ -482,7 +482,7 @@ pub fn build_trajectory_from_los_psd(
 mod tests {
     use super::*;
 
-    use approx::assert_relative_eq;
+    use approx::{assert_abs_diff_eq, assert_relative_eq};
     use rand::SeedableRng;
     use rustfft::{num_complex::Complex, FftPlanner};
 
@@ -655,7 +655,7 @@ mod tests {
         let var = series.iter().map(|s| (s - mean).powi(2)).sum::<f64>() / n_samples as f64;
 
         // Mean should be ~0 (DC bin zeroed).
-        assert!(mean.abs() < 1.0e-7, "mean={mean:e}");
+        assert_abs_diff_eq!(mean, 0.0, epsilon = 1.0e-7);
         // Variance should be within 10% of S0 * B (statistical fluctuation).
         let rel_err = (var - expected_var).abs() / expected_var;
         assert!(

--- a/simulator/src/sims/motion_blur.rs
+++ b/simulator/src/sims/motion_blur.rs
@@ -1641,7 +1641,7 @@ mod tests {
     fn test_max_drift_over_window_static_is_zero() {
         let traj = static_trajectory();
         let drift = max_drift_over_window(&traj, Duration::ZERO, Duration::from_secs(5)).unwrap();
-        assert!(drift.abs() < 1e-12);
+        assert_abs_diff_eq!(drift, 0.0, epsilon = 1e-12);
     }
 
     #[test]

--- a/simulator/src/sims/trajectory.rs
+++ b/simulator/src/sims/trajectory.rs
@@ -777,7 +777,7 @@ mod tests {
     fn test_angular_distance_same_point() {
         let a = make_pointing(45.0, 30.0);
         let dist = angular_distance_deg(&a, &a);
-        assert!(dist.abs() < 1e-10);
+        assert_abs_diff_eq!(dist, 0.0, epsilon = 1e-10);
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #122 / #123 — the repo-wide sweep that #122 scoped as a separate PR.

Of **29** `.abs() < …` sites, **23** are production guards (control flow, not assertions — left untouched) and **6** are `assert!`-form. This converts **5** of the 6 to `approx::assert_abs_diff_eq!`:

| File | Was | Now |
|---|---|---|
| `context_render.rs` | `assert!((too_bright - star_radius_max_px).abs() < 1e-9)` | `assert_abs_diff_eq!(too_bright, cfg.star_radius_max_px, epsilon = 1e-9)` |
| `trajectory.rs` | `assert!(dist.abs() < 1e-10)` | `assert_abs_diff_eq!(dist, 0.0, epsilon = 1e-10)` |
| `motion_blur.rs` | `assert!(drift.abs() < 1e-12)` | `assert_abs_diff_eq!(drift, 0.0, epsilon = 1e-12)` |
| `render.rs` | `assert!(y0.abs() < 0.05, "…")` | `assert_abs_diff_eq!(y0, 0.0, epsilon = 0.05)` |
| `jitter.rs` | `assert!(mean.abs() < 1.0e-7, "…")` | `assert_abs_diff_eq!(mean, 0.0, epsilon = 1.0e-7)` |

**Left as-is:** `trajectory.rs:762` `assert!(center.dec_degrees().abs() < 1.0)` — a loose sanity *bound*, not a float-equality, so the approx form doesn't fit.

Added `assert_abs_diff_eq` to the `approx` import in `render.rs` / `jitter.rs` (had only `assert_relative_eq`) and a fresh `use approx::assert_abs_diff_eq;` in `context_render.rs`.

## Verification
- `cargo test --package simulator --lib` — 297 passed
- `cargo fmt` + `cargo clippy --package simulator -- -W clippy::all` clean