### PR TITLE
serde: make SensorArray JSON round-trip bit-exact

### DIFF
--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -37,7 +37,7 @@ rand_distr = "0.5"
 indicatif = "0.17"
 num_cpus = "1.16"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["float_roundtrip"] }
 
 plotters = { version = "0.3", default-features = false, features = [
     "bitmap_backend",

--- a/simulator/src/hardware/sensor_array.rs
+++ b/simulator/src/hardware/sensor_array.rs
@@ -395,6 +395,39 @@ mod tests {
     }
 
     #[test]
+    fn test_sensor_array_json_round_trip() {
+        // The full SensorArray field chain (PositionedSensor -> SensorConfig ->
+        // QuantumEfficiency / ReadNoiseEstimator / DarkCurrentEstimator / SensorGeometry
+        // -> shared unit types) must survive a disk-shaped JSON round-trip so the
+        // focal-plane config can be persisted and shipped to the frontend without a
+        // hand-rolled mirror DTO.
+        let original = SPENCER_ARRAY_PLAN.clone();
+
+        let json = serde_json::to_string(&original).expect("serialize SensorArray");
+        let restored: SensorArray = serde_json::from_str(&json).expect("deserialize SensorArray");
+
+        assert_eq!(restored.sensor_count(), original.sensor_count());
+        assert_eq!(restored.total_pixel_count(), original.total_pixel_count());
+        for (orig, back) in original.sensors.iter().zip(restored.sensors.iter()) {
+            assert_eq!(back.sensor.name, orig.sensor.name);
+            assert_eq!(back.position.x_mm, orig.position.x_mm);
+            assert_eq!(back.position.y_mm, orig.position.y_mm);
+            assert_eq!(
+                back.sensor.dimensions.get_pixel_width_height(),
+                orig.sensor.dimensions.get_pixel_width_height()
+            );
+            assert_eq!(back.sensor.bit_depth, orig.sensor.bit_depth);
+        }
+
+        // Re-serializing the restored array yields byte-identical JSON, which exercises
+        // the entire nested chain (QE curve, noise/dark-current estimators, unit types)
+        // and fails loudly if a future field is not serde round-trippable. Bit-exact f64
+        // round-tripping relies on serde_json's `float_roundtrip` feature (Cargo.toml).
+        let json_again = serde_json::to_string(&restored).expect("re-serialize SensorArray");
+        assert_eq!(json, json_again);
+    }
+
+    #[test]
     fn test_mm_to_pixels_padded_gap_between_sensors() {
         let sensor = GSENSE4040BSI.clone();
         let (width, _) = sensor.dimensions.get_width_height();


### PR DESCRIPTION
## What

Makes a persisted `SensorArray` (e.g. `SPENCER_ARRAY_PLAN`) reload bit-for-bit identical to what was written.

- Enable `serde_json`'s **`float_roundtrip`** feature. The default float parser is not correctly-rounded and was shifting pixel sizes (a `uom` `Length`) by 1 ULP on load — `3.76 * 1e-6` serialized as `3.7599999999999996e-6` but parsed back one ULP higher and re-serialized as `3.76e-6`. The feature swaps in the precise parser so parse is the exact inverse of serialization.
- Add `test_sensor_array_json_round_trip`: serialize → deserialize → re-serialize `SPENCER_ARRAY_PLAN` and assert byte-identical JSON. This exercises the entire nested chain (`QuantumEfficiency`, `ReadNoiseEstimator`, `DarkCurrentEstimator`, `SensorGeometry`, shared unit types) and fails loudly if a future field is not serde round-trippable.

## Why

Closes #125. The requested serde derives already landed in #110 and are on `main`; the gap that remained was the precision guarantee downstream persistence (tracking-test-bench / scene-camera) actually needs — a config written to disk and shipped to the frontend must reload identically. Without `float_roundtrip`, hashing or equality-checking serialized configs would spuriously differ.

## Testing

- `cargo test --package simulator --lib` — 298 passed
- `cargo fmt`, `cargo clippy -- -W clippy::all` — clean
- `Cargo.lock` unchanged (feature toggle, no new deps)