### PR TITLE
sensor: configurable black-level / bias pedestal

### DIFF
--- a/simulator/src/hardware/sensor.rs
+++ b/simulator/src/hardware/sensor.rs
@@ -161,6 +161,13 @@ pub struct SensorConfig {
     /// Full well capacity in electrons (saturation limit)
     pub max_well_depth_e: f64,
 
+    /// Constant black-level / bias pedestal in DN, added to every pixel as the
+    /// final additive offset before ADC clamping. Lifts the background off the
+    /// quantization floor so the noise distribution stays well-defined at low
+    /// signal. A value of 0 disables the pedestal.
+    #[serde(default)]
+    pub black_level_dn: u16,
+
     /// Maximum sustainable frame rate in Hz
     pub max_frame_rate_fps: f64,
 }
@@ -231,6 +238,7 @@ mod tests {
             bit_depth: 8,
             dn_per_electron: 3.0,
             max_well_depth_e: 1e20,
+            black_level_dn: 0,
             max_frame_rate_fps: 30.0,
         };
 
@@ -264,6 +272,7 @@ mod tests {
             bit_depth: 8,
             dn_per_electron: 3.0,
             max_well_depth_e: 1e20,
+            black_level_dn: 0,
             max_frame_rate_fps: 30.0,
         };
         let (width, height) = sensor.dimensions.get_width_height();
@@ -400,6 +409,7 @@ mod tests {
             bit_depth: 8,
             dn_per_electron: 3.0,
             max_well_depth_e: 1e20,
+            black_level_dn: 0,
             max_frame_rate_fps: 30.0,
         };
 
@@ -458,6 +468,7 @@ mod tests {
             bit_depth: 16,
             dn_per_electron: 0.5,
             max_well_depth_e: 10_000.0,
+            black_level_dn: 0,
             max_frame_rate_fps: 30.0,
         };
         assert_relative_eq!(
@@ -478,6 +489,7 @@ mod tests {
             bit_depth: 12,
             dn_per_electron: 1.0,
             max_well_depth_e: 10_000.0,
+            black_level_dn: 0,
             max_frame_rate_fps: 30.0,
         };
         assert_relative_eq!(
@@ -592,6 +604,7 @@ pub mod models {
             bit_depth: 12,
             dn_per_electron: 0.35,
             max_well_depth_e: 39_200.0,
+            black_level_dn: 0,
             max_frame_rate_fps: 24.0,
         }
     });
@@ -636,6 +649,7 @@ pub mod models {
             bit_depth: 12,
             dn_per_electron: 0.35,
             max_well_depth_e: 21_000.0,
+            black_level_dn: 0,
             max_frame_rate_fps: 88.0,
         }
     });
@@ -682,6 +696,7 @@ pub mod models {
             bit_depth: 12,
             dn_per_electron: 7.42,
             max_well_depth_e: 7_500.0,
+            black_level_dn: 0,
             max_frame_rate_fps: 120.0,
         }
     });
@@ -736,6 +751,7 @@ pub mod models {
             bit_depth: 16,
             dn_per_electron: 1.0 / 0.4,
             max_well_depth_e: 26_000.0,
+            black_level_dn: 0,
             max_frame_rate_fps: 21.33,
         }
     });

--- a/simulator/src/image_proc/render.rs
+++ b/simulator/src/image_proc/render.rs
@@ -364,13 +364,14 @@ pub fn quantize_image(electron_img: &Array2<f64>, sensor: &SensorConfig) -> Arra
     let max_dn = ((1 << sensor.bit_depth) - 1) as f64;
     let well_depth = sensor.max_well_depth_e;
     let dn_per_e = sensor.dn_per_electron;
+    let black_level_dn = sensor.black_level_dn as f64;
 
     let mut quantized = Array2::<u16>::zeros(electron_img.raw_dim());
     Zip::from(&mut quantized)
         .and(electron_img)
         .par_for_each(|out, &total_e| {
             let clipped_e = total_e.clamp(0.0, well_depth);
-            let dn = clipped_e * dn_per_e;
+            let dn = clipped_e * dn_per_e + black_level_dn;
             *out = dn.clamp(0.0, max_dn).round() as u16;
         });
     quantized
@@ -608,6 +609,7 @@ mod tests {
             bit_depth,
             dn_per_electron,
             max_well_depth_e,
+            black_level_dn: 0,
             max_frame_rate_fps: 30.0,
         }
     }
@@ -868,6 +870,37 @@ mod tests {
 
         assert_eq!(quantized[[0, 0]], 5);
         assert_eq!(quantized[[0, 1]], 50);
+    }
+
+    #[test]
+    fn test_quantize_image_black_level_pedestal() {
+        // 12-bit sensor (max 4095), unity gain, well depth 1000 e-, 50 DN pedestal.
+        let mut sensor = create_test_sensor(12, 1.0, 1000.0);
+        sensor.black_level_dn = 50;
+        let mut electron_img = Array2::<f64>::zeros((2, 2));
+
+        electron_img[[0, 0]] = 0.0; // Floor lifted to the pedestal
+        electron_img[[0, 1]] = 100.0; // Signal sits on top of the pedestal
+        electron_img[[1, 0]] = 2000.0; // Above well: clamps to well, then adds pedestal
+
+        let quantized = quantize_image(&electron_img, &sensor);
+
+        assert_eq!(quantized[[0, 0]], 50);
+        assert_eq!(quantized[[0, 1]], 150);
+        assert_eq!(quantized[[1, 0]], 1050);
+    }
+
+    #[test]
+    fn test_quantize_image_black_level_clamps_to_adc_max() {
+        // Pedestal pushing signal past the ADC ceiling clamps to max_dn (255 at 8-bit).
+        let mut sensor = create_test_sensor(8, 1.0, 1000.0);
+        sensor.black_level_dn = 50;
+        let mut electron_img = Array2::<f64>::zeros((1, 1));
+        electron_img[[0, 0]] = 250.0; // 250 + 50 = 300, clamps to 255
+
+        let quantized = quantize_image(&electron_img, &sensor);
+
+        assert_eq!(quantized[[0, 0]], 255);
     }
 
     #[test]

--- a/simulator/src/scene_galaxy.rs
+++ b/simulator/src/scene_galaxy.rs
@@ -314,6 +314,7 @@ mod tests {
             bit_depth: 16,
             dn_per_electron: 1.0,
             max_well_depth_e: 1e20,
+            black_level_dn: 0,
             max_frame_rate_fps: 30.0,
         };
         SatelliteConfig::new(telescope, sensor, Temperature::from_celsius(-10.0))


### PR DESCRIPTION
## What
Adds a configurable **black-level / bias pedestal** (`black_level_dn`) to the sensor model, applied as the final additive DN offset in `quantize_image` — physically placed *after* gain conversion, *before* the ADC clamp.

```rust
let dn = clipped_e * dn_per_e + black_level_dn as f64;
*out = dn.clamp(0.0, max_dn).round() as u16;
```

Because every render path (`RenderEngine`, `render_tile_array_roi`, the detection bin) funnels through `quantize_image`, the pedestal applies consistently everywhere with one change.

## Why
The render applies Poisson + Gaussian read noise then quantizes to `u16` with no bias offset. At near-zero background, read noise is symmetric about 0 → negatives clamp to 0 and sub-DN positives round to 0 → **>50% of background pixels become exactly 0 DN**. That breaks MAD-based noise estimators downstream: `MAD = 0` → `noise_rms = 1.4826 * 0 = 0` → `SNR = f64::MAX` in FGS/monocle ROI tracking. A small pedestal lifts the background above the quantization floor so the median/MAD stay well-defined.

This replaces the post-render workaround in tracking-test-bench#960 by placing the pedestal correctly inside the sensor signal chain, so every consumer inherits it.

## Design notes
- **Type is `u16`, not `f64`** — DN is ADC counts (inherently integer), the output frame is `u16`, and real sensors set black level in an integer register. The CLAUDE.md "use f64 for astronomical calculations" rule is about physics quantities; a black-level pedestal is a hardware/ADC quantity, so integer is the correct fit.
- **`#[serde(default)]`** — old configs without the field deserialize to 0; round-trip compatibility (cf. #126) preserved.
- **Default 0 everywhere** — behavior-neutral; no existing frame changes.

## Not in this PR (follow-up)
- Real model pedestals stay 0. Setting nonzero tens-of-DN values on IMX455/GSENSE to actually fix the downstream MAD=0 bug in sim needs a real per-sensor black-level number — left as a follow-up.
- `saturating_reading()` unchanged (pedestal is a floor, not a ceiling).

## Tests
- `test_quantize_image_black_level_pedestal` — floor lifts to pedestal, signal stacks on top, well-clamp-then-pedestal ordering.
- `test_quantize_image_black_level_clamps_to_adc_max` — pedestal past the ADC ceiling clamps to `max_dn`.

Full suite green (299 lib + 12 integration), clippy clean, fmt applied.

Closes #127

<!-- refresh checks against cleaned body -->