### PR TITLE
sensor: apply black level before the electron floor clamp

### DIFF
--- a/simulator/src/image_proc/render.rs
+++ b/simulator/src/image_proc/render.rs
@@ -370,8 +370,8 @@ pub fn quantize_image(electron_img: &Array2<f64>, sensor: &SensorConfig) -> Arra
     Zip::from(&mut quantized)
         .and(electron_img)
         .par_for_each(|out, &total_e| {
-            let clipped_e = total_e.clamp(0.0, well_depth);
-            let dn = clipped_e * dn_per_e + black_level_dn;
+            let capped_e = total_e.min(well_depth);
+            let dn = capped_e * dn_per_e + black_level_dn;
             *out = dn.clamp(0.0, max_dn).round() as u16;
         });
     quantized
@@ -901,6 +901,29 @@ mod tests {
         let quantized = quantize_image(&electron_img, &sensor);
 
         assert_eq!(quantized[[0, 0]], 255);
+    }
+
+    #[test]
+    fn test_quantize_image_black_level_preserves_sub_floor_noise() {
+        // The pedestal is an analog, pre-ADC bias: it must be applied before the
+        // 0 floor so sub-zero read-noise excursions survive as spread, not collapse
+        // onto a single flat value. With bias 50 DN and gain 2.5, a symmetric dip
+        // and peak about a zero-mean background must land on distinct DN values.
+        let mut sensor = create_test_sensor(12, 2.5, 1000.0);
+        sensor.black_level_dn = 50;
+        let mut electron_img = Array2::<f64>::zeros((1, 3));
+        electron_img[[0, 0]] = -2.0; // noise dip below background: -2*2.5+50 = 45
+        electron_img[[0, 1]] = 0.0; //  background mean:            0*2.5+50 = 50
+        electron_img[[0, 2]] = 2.0; //  noise peak above background:  2*2.5+50 = 55
+
+        let quantized = quantize_image(&electron_img, &sensor);
+
+        assert_eq!(quantized[[0, 0]], 45);
+        assert_eq!(quantized[[0, 1]], 50);
+        assert_eq!(quantized[[0, 2]], 55);
+        // The dip is preserved (not flattened to 50), so a background built from
+        // such excursions has MAD > 0 rather than the degenerate MAD = 0.
+        assert_ne!(quantized[[0, 0]], quantized[[0, 1]]);
     }
 
     #[test]


### PR DESCRIPTION
Fixes the placement bug from #128 (follow-up #129).

## Problem
`quantize_image` clamped electrons to `[0, well]` **before** adding the black-level pedestal:
```rust
let clipped_e = total_e.clamp(0.0, well_depth);  // negatives squashed to 0 here
let dn = clipped_e * dn_per_e + black_level_dn;
*out = dn.clamp(0.0, max_dn).round() as u16;
```
Read noise is added symmetric-about-mean in electron space. At near-zero background, ~half the pixels go negative, get floored to 0 by the lower clamp, then `+black_level` lands them all on exactly `black_level_dn`. The lifted floor is flat — constant level, zero spread — so `median = black_level`, `MAD = 0`, and downstream MAD-based SNR returns `f64::MAX`. That is the exact failure #127 set out to remove; #128 added the pedestal one clamp too late.

## Fix
A real sensor bias is an analog, pre-ADC offset, precisely so read noise is not clipped at 0. Clamp electrons at the upper/well bound only and let the bias plus the single ADC clamp set the floor:
```rust
let capped_e = total_e.min(well_depth);
let dn = capped_e * dn_per_e + black_level_dn;
*out = dn.clamp(0.0, max_dn).round() as u16;
```
With a pedestal >= a few x read-noise sigma, the noisy signal stays positive, sub-floor dips survive, and `MAD > 0`.

## Safety
Behavior is **identical for the default `black_level_dn = 0`** — a negative electron value yields a negative DN that the ADC clamp floors to 0 either way, so no existing caller changes. Only the bias>0 path (the intended feature) differs.

## Tests
- New `test_quantize_image_black_level_preserves_sub_floor_noise`: a symmetric dip/peak about a zero-mean background (bias 50, gain 2.5) lands on distinct DN (45 / 50 / 55) instead of collapsing to 50.
- Existing black-level and well-clamp tests still pass (well upper bound preserved via `min`).

Full suite green (301 lib + 12 integration), clippy clean, fmt applied.

Closes #129