### PR TITLE
deps: bump cfl-foundations to 3b3aa27 (read-noise no-zero-clamp)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "meter-math"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=cde0b96#cde0b96afcff9c6a4db7ec9db31d0169ae1b48b9"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=3b3aa27#3b3aa27654b48c7940eed1cb7800ca0ca4ad8f88"
 dependencies = [
  "log",
  "nalgebra",
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=cde0b96#cde0b96afcff9c6a4db7ec9db31d0169ae1b48b9"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=3b3aa27#3b3aa27654b48c7940eed1cb7800ca0ca4ad8f88"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "shared-wasm"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=cde0b96#cde0b96afcff9c6a4db7ec9db31d0169ae1b48b9"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=3b3aa27#3b3aa27654b48c7940eed1cb7800ca0ca4ad8f88"
 dependencies = [
  "num-traits",
  "serde",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -28,9 +28,9 @@ env_logger = "0.11"           # Environment-based logger
 url = "2.5"                   # URL parsing and manipulation
 nalgebra = { version = "0.32", features = ["serde-serialize"] } # Linear algebra (quaternions for orientation)
 # Foundation crates from cfl-foundations.
-shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "cde0b96", default-features = false, features = ["frame-writer"] }
-meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "cde0b96" }
-shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "cde0b96" }
+shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "3b3aa27", default-features = false, features = ["frame-writer"] }
+meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "3b3aa27" }
+shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "3b3aa27" }
 
 rand = "0.9"
 rand_distr = "0.5"


### PR DESCRIPTION
Bumps the `cfl-foundations` git pins (`shared`, `meter-math`, `shared-wasm`) from `cde0b96` to `3b3aa27`.

## What it picks up
The single upstream change since the current pin is **#20 "read noise: don't clamp electrons at zero"**. `apply_gaussian_read_noise` previously did `(pixel + noise).max(0.0)`, discarding the downward half of every read-noise excursion. At near-zero background that collapsed >50% of pixels onto one floor value → `MAD = 0` → `source_snr` returns `f64::MAX`.

This is the **complementary half** of the sensor black-level work landed here in #128/#130:
- #130 made `quantize_image` apply the black-level bias *before* the floor clamp (well/upper clamp only, single ADC floor).
- #20 removes the electron-space `.max(0.0)` so the symmetric read noise actually reaches that stage.

Together: with a black-level pedestal present, the noisy background stays positive, negative excursions survive, and MAD-based SNR stays finite end-to-end (the original #127 goal, now fixed across both repos).

## Impact / safety
- Both simulator read-noise consumers route through `shared` (`generate_sensor_noise` → `generate_noise_with_precomputed_params`, and the motion-blur path's `apply_gaussian_read_noise`), so the fix flows through with no simulator code changes.
- No behavior change at zero black level — the downstream ADC clamp in `quantize_image` still floors the final DN.
- Full suite green (301 lib + 12 integration), build + clippy clean.

Diff is the three `rev` pins plus `Cargo.lock`.