### PR TITLE
Upgrade ndarray 0.16 -> 0.17 (simulator)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "meter-math"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=cde0b96#cde0b96afcff9c6a4db7ec9db31d0169ae1b48b9"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=5e0a0bb#5e0a0bbc533a2aa2c5786e637695f1c92407b1f2"
 dependencies = [
  "log",
  "nalgebra",
@@ -2265,9 +2265,9 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.16.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
  "matrixmultiply",
  "num-complex",
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=cde0b96#cde0b96afcff9c6a4db7ec9db31d0169ae1b48b9"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=5e0a0bb#5e0a0bbc533a2aa2c5786e637695f1c92407b1f2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "shared-wasm"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=cde0b96#cde0b96afcff9c6a4db7ec9db31d0169ae1b48b9"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=5e0a0bb#5e0a0bbc533a2aa2c5786e637695f1c92407b1f2"
 dependencies = [
  "num-traits",
  "serde",
@@ -3466,9 +3466,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "starfield"
-version = "0.12.6"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d36ee19cb4acc2746a3576cd0c6caddfabd9a9087c71d032623f1df585932f5"
+checksum = "065d0a9a42dae2090524cb239a24d6805f7f3d27cb43b0f81c2f06d7dd070abd"
 dependencies = [
  "base64",
  "byteorder",
@@ -3499,7 +3499,7 @@ dependencies = [
 [[package]]
 name = "starfield-datasource-utils"
 version = "0.1.0"
-source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=262051c#262051c9693a18bd35235711f4e8c0f8c0c4bf84"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=3613f1c#3613f1c663f3c35ce22ed09bb355029c1d5fc5b0"
 dependencies = [
  "indicatif",
  "reqwest",
@@ -3509,7 +3509,7 @@ dependencies = [
 [[package]]
 name = "starfield-gaia"
 version = "0.2.0"
-source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=262051c#262051c9693a18bd35235711f4e8c0f8c0c4bf84"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=3613f1c#3613f1c663f3c35ce22ed09bb355029c1d5fc5b0"
 dependencies = [
  "arrow",
  "cdshealpix",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "starfield-nsa"
 version = "0.2.0"
-source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=262051c#262051c9693a18bd35235711f4e8c0f8c0c4bf84"
+source = "git+https://github.com/OrbitalCommons/starfield-datasources.git?rev=3613f1c#3613f1c663f3c35ce22ed09bb355029c1d5fc5b0"
 dependencies = [
  "fitsio-pure 0.11.0",
  "nalgebra",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -9,12 +9,12 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
-starfield = { version = "0.12", features = ["photometry"] }
-starfield-nsa = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "262051c" }
-starfield-gaia = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "262051c" }
-starfield-datasource-utils = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "262051c" }
+starfield = { version = "0.13", features = ["photometry"] }
+starfield-nsa = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "3613f1c" }
+starfield-gaia = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "3613f1c" }
+starfield-datasource-utils = { git = "https://github.com/OrbitalCommons/starfield-datasources.git", rev = "3613f1c" }
 image = "0.25" # Image processing
-ndarray = { version = "0.16", features = [
+ndarray = { version = "0.17", features = [
     "rayon",
 ] } # Multidimensional arrays with parallel computing
 rayon = "1.7" # Parallel computing
@@ -29,9 +29,9 @@ env_logger = "0.11"           # Environment-based logger
 url = "2.5"                   # URL parsing and manipulation
 nalgebra = { version = "0.32", features = ["serde-serialize"] } # Linear algebra (quaternions for orientation)
 # Foundation crates from cfl-foundations.
-shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "cde0b96", default-features = false, features = ["frame-writer"] }
-meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "cde0b96" }
-shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "cde0b96" }
+shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "5e0a0bb", default-features = false, features = ["frame-writer"] }
+meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "5e0a0bb" }
+shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "5e0a0bb" }
 
 rand = "0.9"
 rand_distr = "0.5"


### PR DESCRIPTION
Closes #132.

Moves `simulator` to ndarray 0.17 so downstreams (e.g. tracking-test-bench) can unify on it — `simulator` exposes ndarray types (`Array2<u16>` frames) in its public render API.

## Changes
- `ndarray` 0.16 → 0.17, `starfield` 0.12 → 0.13
- Re-pin cfl-foundations `shared`/`meter-math`/`shared-wasm` → `5e0a0bb` (ndarray 0.17)
- Re-pin `starfield-nsa`/`starfield-gaia`/`starfield-datasource-utils` → `3613f1c` (starfield 0.13)

No source changes were required — our ndarray usage (`Zip::from`, `Array2::from_shape_vec`, `raw_dim`) is stable across 0.16 → 0.17.

## Coordinated upstream bumps (landed first)
- CosmicFrontierLabs/cfl-foundations#22 — `shared`/`meter-math` → ndarray 0.17
- OrbitalCommons/starfield — published 0.13.0
- OrbitalCommons/starfield-datasources#58 — workspace starfield 0.12 → 0.13

## Verification
`cargo build`, `cargo clippy -- -W clippy::all`, `cargo fmt --check` clean; `cargo test` → 297 passed, 0 failed. Single `ndarray 0.17.2` / `starfield 0.13.0` in the tree.