### PR TITLE
simulator: bump cfl-foundations shared to dc87a0f (image_proc::resize)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "meter-math"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=5e0a0bb#5e0a0bbc533a2aa2c5786e637695f1c92407b1f2"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=dc87a0f#dc87a0f6c93b76cb8fc500cbd08792299b7a32a4"
 dependencies = [
  "log",
  "nalgebra",
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=5e0a0bb#5e0a0bbc533a2aa2c5786e637695f1c92407b1f2"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=dc87a0f#dc87a0f6c93b76cb8fc500cbd08792299b7a32a4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "shared-wasm"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=5e0a0bb#5e0a0bbc533a2aa2c5786e637695f1c92407b1f2"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=dc87a0f#dc87a0f6c93b76cb8fc500cbd08792299b7a32a4"
 dependencies = [
  "num-traits",
  "serde",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -28,9 +28,9 @@ env_logger = "0.11"           # Environment-based logger
 url = "2.5"                   # URL parsing and manipulation
 nalgebra = { version = "0.32", features = ["serde-serialize"] } # Linear algebra (quaternions for orientation)
 # Foundation crates from cfl-foundations.
-shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "5e0a0bb", default-features = false, features = ["frame-writer"] }
-meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "5e0a0bb" }
-shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "5e0a0bb" }
+shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "dc87a0f", default-features = false, features = ["frame-writer"] }
+meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "dc87a0f" }
+shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "dc87a0f" }
 
 rand = "0.9"
 rand_distr = "0.5"


### PR DESCRIPTION
Bump the `shared`/`meter-math`/`shared-wasm` pins from `5e0a0bb` to `dc87a0f` — which is `5e0a0bb` + one additive commit (cfl-foundations#24, `image_proc::resize`). No API change; builds clean.

Keeps simulator's `shared` rev in step with downstream so consumers (tracking-test-bench) can adopt `shared::image_proc::resize` without the `shared` crate (and `AABB`, etc.) splitting across two revs and failing to unify at the scene-camera↔simulator boundary.