### PR TITLE
simulator: bump cfl-foundations shared dc87a0f -> df12139

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "meter-math"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=dc87a0f#dc87a0f6c93b76cb8fc500cbd08792299b7a32a4"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=df12139#df12139cec616178626a0d8217e6187c819a4aa7"
 dependencies = [
  "log",
  "nalgebra",
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=dc87a0f#dc87a0f6c93b76cb8fc500cbd08792299b7a32a4"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=df12139#df12139cec616178626a0d8217e6187c819a4aa7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "shared-wasm"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=dc87a0f#dc87a0f6c93b76cb8fc500cbd08792299b7a32a4"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=df12139#df12139cec616178626a0d8217e6187c819a4aa7"
 dependencies = [
  "num-traits",
  "serde",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -28,9 +28,9 @@ env_logger = "0.11"           # Environment-based logger
 url = "2.5"                   # URL parsing and manipulation
 nalgebra = { version = "0.32", features = ["serde-serialize"] } # Linear algebra (quaternions for orientation)
 # Foundation crates from cfl-foundations.
-shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "dc87a0f", default-features = false, features = ["frame-writer"] }
-meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "dc87a0f" }
-shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "dc87a0f" }
+shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "df12139", default-features = false, features = ["frame-writer"] }
+meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "df12139" }
+shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "df12139" }
 
 rand = "0.9"
 rand_distr = "0.5"


### PR DESCRIPTION
Bumps `simulator`'s `cfl-foundations` pin (`shared`/`meter-math`/`shared-wasm`)
`dc87a0f` → `df12139` to pick up the SNR shot-noise fix
([cfl-foundations #25](https://github.com/CosmicFrontierLabs/cfl-foundations/pull/25)).

`simulator` does not call the SNR functions, so this is a pure dependency bump
(builds clean). It's the prerequisite for **tracking-test-bench** to move its
direct `shared` pin to `df12139` while keeping shared types (`AABB`, etc.)
unified across the `simulator` boundary — without this, the two `shared` revs
would resolve to distinct copies and fail to unify.