### PR TITLE
simulator: bump cfl-foundations shared df12139 -> 4bb8287

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "meter-math"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=df12139#df12139cec616178626a0d8217e6187c819a4aa7"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=4bb8287#4bb828741eb128d41de475518dff0b373532d198"
 dependencies = [
  "log",
  "nalgebra",
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=df12139#df12139cec616178626a0d8217e6187c819a4aa7"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=4bb8287#4bb828741eb128d41de475518dff0b373532d198"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "shared-wasm"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=df12139#df12139cec616178626a0d8217e6187c819a4aa7"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=4bb8287#4bb828741eb128d41de475518dff0b373532d198"
 dependencies = [
  "num-traits",
  "serde",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -28,9 +28,9 @@ env_logger = "0.11"           # Environment-based logger
 url = "2.5"                   # URL parsing and manipulation
 nalgebra = { version = "0.32", features = ["serde-serialize"] } # Linear algebra (quaternions for orientation)
 # Foundation crates from cfl-foundations.
-shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "df12139", default-features = false, features = ["frame-writer"] }
-meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "df12139" }
-shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "df12139" }
+shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "4bb8287", default-features = false, features = ["frame-writer"] }
+meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "4bb8287" }
+shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "4bb8287" }
 
 rand = "0.9"
 rand_distr = "0.5"


### PR DESCRIPTION
Picks up the centroid background-subtraction fix ([cfl-foundations#27](https://github.com/CosmicFrontierLabs/cfl-foundations/pull/27)).

`compute_centroid_from_mask[_with_saturation]` gained a `background` argument. `simulator` does not call that function, so this is a transparent dependency bump — `simulator` builds and tests green against `4bb8287`. It lets downstream consumers (tracking-test-bench) unify the whole graph on `4bb8287` instead of carrying a `[patch]` override.