### PR TITLE
simulator: standardize CSV I/O with Serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3391,6 +3391,7 @@ dependencies = [
  "chrono",
  "clap",
  "criterion",
+ "csv",
  "env_logger",
  "float-cmp",
  "image",

--- a/analysis/plot_star_probability.py
+++ b/analysis/plot_star_probability.py
@@ -38,22 +38,8 @@ Path(args.output).parent.mkdir(parents=True, exist_ok=True)
 # Load CSV file
 print(f"Loading data from: {args.input}")
 
-# Read CSV, skipping header lines until we find "Detailed Results:"
-with open(args.input, 'r') as f:
-    lines = f.readlines()
-
-# Find the line with "Detailed Results:"
-data_start = None
-for i, line in enumerate(lines):
-    if 'Detailed Results:' in line:
-        data_start = i + 1
-        break
-
-if data_start is None:
-    raise ValueError("Could not find 'Detailed Results:' section in CSV")
-
-# Read the actual data
-df = pd.read_csv(args.input, skiprows=data_start)
+# The output is a standard CSV with a single header row.
+df = pd.read_csv(args.input)
 
 print(f"Loaded {len(df)} pointings")
 

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -38,6 +38,7 @@ indicatif = "0.17"
 num_cpus = "1.16"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
+csv = "1.3"
 
 plotters = { version = "0.3", default-features = false, features = [
     "bitmap_backend",

--- a/simulator/src/bin/motion_simulator.rs
+++ b/simulator/src/bin/motion_simulator.rs
@@ -100,51 +100,33 @@ fn build_line_trajectory(
 /// load; non-monotonic `time_s` is rejected.
 fn build_csv_trajectory(path: &std::path::Path) -> Result<Trajectory, Box<dyn std::error::Error>> {
     use nalgebra::{Quaternion, UnitQuaternion};
-    use std::io::{BufRead, BufReader};
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    struct CsvWaypoint {
+        time_s: f64,
+        qw: f64,
+        qx: f64,
+        qy: f64,
+        qz: f64,
+    }
 
     let file = std::fs::File::open(path).map_err(|e| format!("opening {}: {e}", path.display()))?;
-    let mut lines = BufReader::new(file).lines();
-
-    let header = lines
-        .next()
-        .ok_or_else(|| format!("{} is empty", path.display()))?
-        .map_err(|e| e.to_string())?;
-    let columns: Vec<&str> = header.split(',').map(str::trim).collect();
-    let idx = |name: &str| -> Result<usize, String> {
-        columns
-            .iter()
-            .position(|c| *c == name)
-            .ok_or_else(|| format!("{} is missing column `{name}`", path.display()))
-    };
-    let (i_t, i_qw, i_qx, i_qy, i_qz) = (
-        idx("time_s")?,
-        idx("qw")?,
-        idx("qx")?,
-        idx("qy")?,
-        idx("qz")?,
-    );
+    let mut reader = csv::ReaderBuilder::new()
+        .trim(csv::Trim::All)
+        .from_reader(file);
 
     let mut waypoints: Vec<Waypoint> = Vec::new();
     let mut last_t = f64::NEG_INFINITY;
-    for (line_no, line) in lines.enumerate() {
-        let line = line.map_err(|e| e.to_string())?;
-        if line.trim().is_empty() {
-            continue;
-        }
-        let cells: Vec<&str> = line.split(',').map(str::trim).collect();
-        let parse = |i: usize, name: &str| -> Result<f64, String> {
-            cells
-                .get(i)
-                .ok_or_else(|| format!("line {}: missing `{name}` cell", line_no + 2))?
-                .parse::<f64>()
-                .map_err(|e| format!("line {}: bad `{name}` value: {e}", line_no + 2))
-        };
-        let t_s = parse(i_t, "time_s")?;
+    while let Some(record) = reader.deserialize::<CsvWaypoint>().next() {
+        let record = record.map_err(|e| format!("{}: {e}", path.display()))?;
+        let line_no = reader.position().line();
+        let t_s = record.time_s;
         if t_s <= last_t {
             return Err(format!(
                 "{}: `time_s` must be strictly increasing (line {} has {} ≤ previous {})",
                 path.display(),
-                line_no + 2,
+                line_no,
                 t_s,
                 last_t,
             )
@@ -153,10 +135,7 @@ fn build_csv_trajectory(path: &std::path::Path) -> Result<Trajectory, Box<dyn st
         last_t = t_s;
 
         let q = UnitQuaternion::from_quaternion(Quaternion::new(
-            parse(i_qw, "qw")?,
-            parse(i_qx, "qx")?,
-            parse(i_qy, "qy")?,
-            parse(i_qz, "qz")?,
+            record.qw, record.qx, record.qy, record.qz,
         ));
         waypoints.push(Waypoint::new(
             std::time::Duration::from_secs_f64(t_s.max(0.0)),

--- a/simulator/src/bin/sensor-view-stats.rs
+++ b/simulator/src/bin/sensor-view-stats.rs
@@ -26,6 +26,7 @@ use clap::Parser;
 use indicatif::{ProgressBar, ProgressStyle};
 use log::info;
 use rayon::prelude::*;
+use serde::Serialize;
 use shared::star_projector::StarProjector;
 use shared::units::{Angle, AngleExt, LengthExt, Temperature, TemperatureExt};
 use simulator::hardware::SatelliteConfig;
@@ -35,9 +36,7 @@ use starfield::catalogs::minimal_catalog::MinimalCatalog;
 use starfield::catalogs::StarPosition;
 use starfield::framelib::random::RandomEquatorial;
 use starfield::Equatorial;
-use std::fs::File;
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Mutex;
 
 /// Configuration for one projector (pointing only, single satellite)
@@ -202,90 +201,34 @@ fn organize_results(
 fn write_results_to_csv(
     results: &[SkyPointingResult],
     args: &Args,
-    satellite: &SatelliteConfig,
-    fov_deg: Angle,
+    _satellite: &SatelliteConfig,
+    _fov_deg: Angle,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let csv_path = Path::new(&args.output_csv);
-    let mut csv_file = File::create(csv_path)
-        .unwrap_or_else(|_| panic!("Failed to create CSV file: {}", args.output_csv));
-
     info!("Writing results to CSV file: {}", args.output_csv);
-
-    // Write CSV header with configuration information
-    writeln!(csv_file, "Sensor View Statistics Results")?;
-    writeln!(csv_file, "Configuration Parameters:")?;
-    writeln!(csv_file, "Number of sky pointings: {}", args.pointings)?;
-    writeln!(csv_file, "Random seed: {}", args.seed)?;
-    writeln!(csv_file, "Star catalog: {}", args.catalog.display())?;
-    writeln!(csv_file)?;
-
-    // Write satellite information
-    writeln!(csv_file, "Satellite Configuration:")?;
-    writeln!(
-        csv_file,
-        "Sensor: {} - FOV: {:.4}° - Focal Length: {:.2}m - Aperture: {:.2}m",
-        satellite.sensor.name,
-        fov_deg.as_degrees(),
-        satellite.telescope.focal_length.as_meters(),
-        satellite.telescope.aperture.as_meters()
-    )?;
-    writeln!(csv_file)?;
-
-    // Write detailed data header
-    writeln!(csv_file, "Detailed Results:")?;
-    writeln!(
-        csv_file,
-        "pointing_num,ra_degrees,dec_degrees,total_stars_on_sensor,star_magnitudes"
-    )?;
-
-    // Write detailed results
-    for result in results {
-        let magnitudes_str = result
-            .star_magnitudes
-            .iter()
-            .map(|m| format!("{m:.2}"))
-            .collect::<Vec<_>>()
-            .join(";");
-
-        writeln!(
-            csv_file,
-            "{},{:.6},{:.6},{},\"{}\"",
-            result.pointing_num,
-            result.coordinates.ra_degrees(),
-            result.coordinates.dec_degrees(),
-            result.total_stars_on_sensor,
-            magnitudes_str
-        )?;
+    #[derive(Serialize)]
+    struct CsvRow {
+        pointing_num: u32,
+        ra_degrees: f64,
+        dec_degrees: f64,
+        total_stars_on_sensor: usize,
+        star_magnitudes: String,
     }
-
-    writeln!(csv_file)?;
-
-    // Write summary statistics
-    writeln!(csv_file, "Summary Statistics:")?;
-    writeln!(
-        csv_file,
-        "mean_total_stars,std_total_stars,min_total_stars,max_total_stars"
-    )?;
-
-    let total_stars: Vec<usize> = results.iter().map(|r| r.total_stars_on_sensor).collect();
-
-    let mean_total = total_stars.iter().sum::<usize>() as f64 / total_stars.len() as f64;
-
-    let var_total = total_stars
-        .iter()
-        .map(|&x| (x as f64 - mean_total).powi(2))
-        .sum::<f64>()
-        / total_stars.len() as f64;
-    let std_total = var_total.sqrt();
-
-    let min_total = *total_stars.iter().min().unwrap();
-    let max_total = *total_stars.iter().max().unwrap();
-
-    writeln!(
-        csv_file,
-        "{mean_total:.2},{std_total:.2},{min_total},{max_total}"
-    )?;
-
+    let mut writer = csv::Writer::from_path(&args.output_csv)?;
+    for result in results {
+        writer.serialize(CsvRow {
+            pointing_num: result.pointing_num,
+            ra_degrees: result.coordinates.ra_degrees(),
+            dec_degrees: result.coordinates.dec_degrees(),
+            total_stars_on_sensor: result.total_stars_on_sensor,
+            star_magnitudes: result
+                .star_magnitudes
+                .iter()
+                .map(|m| format!("{m:.2}"))
+                .collect::<Vec<_>>()
+                .join(";"),
+        })?;
+    }
+    writer.flush()?;
     Ok(())
 }
 

--- a/simulator/src/bin/single_detection_matrix.rs
+++ b/simulator/src/bin/single_detection_matrix.rs
@@ -10,16 +10,14 @@ use ndarray::{Array1, Array3};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use rayon::prelude::*;
+use serde::Serialize;
 use shared::range_arg::RangeArg;
-use shared::units::{LengthExt, Temperature, TemperatureExt};
+use shared::units::{Temperature, TemperatureExt};
 use simulator::hardware::sensor::models::ALL_SENSORS;
 use simulator::hardware::SatelliteConfig;
 use simulator::shared_args::SharedSimulationArgs;
 use simulator::sims::single_detection::{run_single_experiment, ExperimentParams};
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::Write;
-use std::path::Path;
 
 /// Command line arguments for sensor floor estimation
 #[derive(Parser, Debug)]
@@ -261,41 +259,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Print summary of results
     println!("\n===== Results Summary =====");
 
-    // Open CSV file for writing
-    let csv_path = Path::new(&args.output_csv);
-    let mut csv_file = File::create(csv_path)?;
-
     println!("Writing results to CSV file: {}", args.output_csv);
-
-    // Write CSV header
-    writeln!(csv_file, "Sensor Floor Estimation Results")?;
-    writeln!(csv_file, "Parameters:")?;
-    writeln!(csv_file, "Exposure: {} seconds", args.shared.exposure)?;
-    writeln!(
-        csv_file,
-        "Noise Floor Multiplier: {}",
-        args.shared.noise_multiple
-    )?;
-    writeln!(csv_file, "Telescope: {}", args.shared.telescope)?;
-    writeln!(
-        csv_file,
-        "Aperture diameter: {} m",
-        telescope_config.aperture.as_meters()
-    )?;
-    writeln!(
-        csv_file,
-        "Experiments per configuration: {}",
-        args.experiments
-    )?;
-    writeln!(csv_file, "PSF Disk Range (FWHM units): {}", args.disks)?;
-    writeln!(csv_file, "Star Magnitude Range: {}", args.mags)?;
-    writeln!(csv_file, "Exposure Range (ms): {}", args.exposures)?;
-    writeln!(
-        csv_file,
-        "Domain Size: {}x{} pixels",
-        args.domain, args.domain
-    )?;
-    writeln!(csv_file)?;
+    #[derive(Serialize)]
+    struct CsvRow<'a> {
+        sensor: &'a str,
+        q_value: f64,
+        exposure_ms: u128,
+        magnitude: f64,
+        detection_rate_percent: f64,
+        mean_position_error_mas: Option<f64>,
+        rms_position_error_pixels: Option<f64>,
+        spurious_detection_rate_percent: f64,
+    }
+    let mut csv_writer = csv::Writer::from_path(&args.output_csv)?;
 
     // Sort the sensor names for consistent output
     let mut sensors_ordered: Vec<_> = all_satellites
@@ -312,10 +288,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let spurious_rate_array = &spurious_rates[&sensor_name];
 
         println!("\n==== Sensor: {sensor_name} ====");
-
-        // Write sensor name to CSV
-        writeln!(csv_file, "SENSOR: {sensor_name}")?;
-        writeln!(csv_file)?;
 
         // Detection Rate Matrix - Console output (simplified, just show first exposure)
         println!(
@@ -346,113 +318,32 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!();
         }
 
-        // CSV Output - Detection Rate Matrix with disk and exposure unrolled
-        writeln!(csv_file, "Detection Rate Matrix (%)")?;
-
-        // CSV header: Disk, Exposure, then magnitude columns
-        write!(csv_file, "Q_Value,Exposure_ms,")?;
-        for mag in &mags {
-            write!(csv_file, "{mag:.2},")?;
-        }
-        writeln!(csv_file)?;
-
-        // Write all combinations of exposure and disk (exposure grouped together)
+        // One machine-readable row per sensor/configuration combination.
         for (exposure_idx, exposure) in exposures.iter().enumerate() {
             for (disk_idx, disk) in disks.iter().enumerate() {
-                write!(csv_file, "{:.2},{},", disk, exposure.as_millis())?;
                 for mag_idx in 0..mags.len() {
-                    let rate = detection_rate_array[[disk_idx, exposure_idx, mag_idx]];
-                    write!(csv_file, "{:.1},", rate * 100.0)?;
+                    let mas = results[[disk_idx, exposure_idx, mag_idx]];
+                    let pixels = pixel_results[[disk_idx, exposure_idx, mag_idx]];
+                    csv_writer.serialize(CsvRow {
+                        sensor: &sensor_name,
+                        q_value: *disk,
+                        exposure_ms: exposure.as_millis(),
+                        magnitude: mags[mag_idx],
+                        detection_rate_percent: detection_rate_array
+                            [[disk_idx, exposure_idx, mag_idx]]
+                            * 100.0,
+                        mean_position_error_mas: (!mas.is_nan()).then_some(mas),
+                        rms_position_error_pixels: (!pixels.is_nan()).then_some(pixels),
+                        spurious_detection_rate_percent: spurious_rate_array
+                            [[disk_idx, exposure_idx, mag_idx]]
+                            * 100.0,
+                    })?;
                 }
-                writeln!(csv_file)?;
             }
         }
-        writeln!(csv_file)?;
-
-        // Mean Position Error Matrix (mas)
-        writeln!(csv_file, "Mean Position Error Matrix (milliarcseconds)")?;
-
-        // CSV header: Disk, Exposure, then magnitude columns
-        write!(csv_file, "Q_Value,Exposure_ms,")?;
-        for mag in &mags {
-            write!(csv_file, "{mag:.2},")?;
-        }
-        writeln!(csv_file)?;
-
-        // Write all combinations of exposure and disk (exposure grouped together)
-        for (exposure_idx, exposure) in exposures.iter().enumerate() {
-            for (disk_idx, disk) in disks.iter().enumerate() {
-                write!(csv_file, "{:.2},{},", disk, exposure.as_millis())?;
-                for mag_idx in 0..mags.len() {
-                    let err = results[[disk_idx, exposure_idx, mag_idx]];
-                    if err.is_nan() {
-                        write!(csv_file, ",")?; // Empty cell for NaN
-                    } else {
-                        write!(csv_file, "{err:.4},")?;
-                    }
-                }
-                writeln!(csv_file)?;
-            }
-        }
-        writeln!(csv_file)?;
-
-        // RMS Position Error Matrix (pixels)
-        writeln!(csv_file, "RMS Position Error Matrix (pixels)")?;
-
-        // CSV header: Disk, Exposure, then magnitude columns
-        write!(csv_file, "Q_Value,Exposure_ms,")?;
-        for mag in &mags {
-            write!(csv_file, "{mag:.2},")?;
-        }
-        writeln!(csv_file)?;
-
-        // Write all combinations of exposure and disk (exposure grouped together)
-        for (exposure_idx, exposure) in exposures.iter().enumerate() {
-            for (disk_idx, disk) in disks.iter().enumerate() {
-                write!(csv_file, "{:.2},{},", disk, exposure.as_millis())?;
-                for mag_idx in 0..mags.len() {
-                    let err = pixel_results[[disk_idx, exposure_idx, mag_idx]];
-                    if err.is_nan() {
-                        write!(csv_file, ",")?; // Empty cell for NaN
-                    } else {
-                        write!(csv_file, "{err:.4},")?;
-                    }
-                }
-                writeln!(csv_file)?;
-            }
-        }
-        writeln!(csv_file)?;
-
-        // Spurious Detection Rate Matrix (%)
-        writeln!(csv_file, "Spurious Detection Rate Matrix (%)")?;
-
-        // CSV header: Disk, Exposure, then magnitude columns
-        write!(csv_file, "Q_Value,Exposure_ms,")?;
-        for mag in &mags {
-            write!(csv_file, "{mag:.2},")?;
-        }
-        writeln!(csv_file)?;
-
-        // Write all combinations of exposure and disk (exposure grouped together)
-        for (exposure_idx, exposure) in exposures.iter().enumerate() {
-            for (disk_idx, disk) in disks.iter().enumerate() {
-                write!(csv_file, "{:.2},{},", disk, exposure.as_millis())?;
-                for mag_idx in 0..mags.len() {
-                    let rate = spurious_rate_array[[disk_idx, exposure_idx, mag_idx]];
-                    write!(csv_file, "{:.2},", rate * 100.0)?;
-                }
-                writeln!(csv_file)?;
-            }
-        }
-        writeln!(csv_file)?;
-
-        // Add separator between sensors
-        writeln!(csv_file)?;
-        writeln!(csv_file, "-----------------------------------------------")?;
-        writeln!(csv_file)?;
-
         println!();
     }
+    csv_writer.flush()?;
 
     println!("CSV output completed: {}", args.output_csv);
 

--- a/simulator/src/shared_args.rs
+++ b/simulator/src/shared_args.rs
@@ -313,44 +313,29 @@ const ADDITIONAL_BRIGHT_STARS_CSV: &str = include_str!("../data/missing_bright_s
 /// - This ensures no ID collisions when merging with primary catalogs
 /// - Returns an error if CSV format is invalid or coordinates are out of bounds
 pub fn parse_additional_stars() -> Result<Vec<MinimalStar>, Box<dyn std::error::Error>> {
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "PascalCase")]
+    struct AdditionalStarRow {
+        #[serde(rename = "RA_deg")]
+        ra_deg: f64,
+        #[serde(rename = "Dec_deg")]
+        dec_deg: f64,
+        #[serde(rename = "Gaia_magnitude")]
+        gaia_magnitude: f64,
+    }
     let mut stars = Vec::new();
     let mut current_id = u64::MAX; // Start from maximum possible value and count backwards
-
-    for (line_num, line) in ADDITIONAL_BRIGHT_STARS_CSV.lines().enumerate() {
-        // Skip header line
-        if line_num == 0 {
-            continue;
-        }
-
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-
-        let parts: Vec<&str> = line.split(',').collect();
-        if parts.len() != 3 {
-            return Err(format!(
-                "Invalid CSV format at line {}: expected 3 columns, got {}",
-                line_num + 1,
-                parts.len()
-            )
-            .into());
-        }
-
-        let ra_deg = parts[0]
-            .trim()
-            .parse::<f64>()
-            .map_err(|e| format!("Invalid RA at line {}: {}", line_num + 1, e))?;
-        let dec_deg = parts[1]
-            .trim()
-            .parse::<f64>()
-            .map_err(|e| format!("Invalid Dec at line {}: {}", line_num + 1, e))?;
-        let magnitude = parts[2]
-            .trim()
-            .parse::<f64>()
-            .map_err(|e| format!("Invalid magnitude at line {}: {}", line_num + 1, e))?;
-
-        stars.push(MinimalStar::new(current_id, ra_deg, dec_deg, magnitude));
+    let mut reader = csv::ReaderBuilder::new()
+        .trim(csv::Trim::All)
+        .from_reader(ADDITIONAL_BRIGHT_STARS_CSV.as_bytes());
+    for row in reader.deserialize::<AdditionalStarRow>() {
+        let row = row?;
+        stars.push(MinimalStar::new(
+            current_id,
+            row.ra_deg,
+            row.dec_deg,
+            row.gaia_magnitude,
+        ));
         current_id = current_id.saturating_sub(1); // Count backwards, protecting against underflow
     }
 

--- a/simulator/src/sims/jitter.rs
+++ b/simulator/src/sims/jitter.rs
@@ -16,7 +16,6 @@
 //!    The CSV loader [`load_los_psd_csv`] parses the same file format
 //!    used by `scripts/los_psd_to_trajectory_csv.py`.
 
-use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -25,6 +24,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 use rand_distr::StandardNormal;
 use realfft::num_complex::Complex;
 use realfft::RealFftPlanner;
+use serde::{Deserialize, Serialize};
 use starfield::Equatorial;
 use thiserror::Error;
 
@@ -187,6 +187,13 @@ pub enum LosPsdLoadError {
         #[source]
         source: std::num::ParseFloatError,
     },
+    #[error("{path}: CSV record at line {line}: {source}")]
+    Csv {
+        path: PathBuf,
+        line: u64,
+        #[source]
+        source: csv::Error,
+    },
     #[error("{path}: needs at least 2 frequency rows, found {found}")]
     TooFewRows { path: PathBuf, found: usize },
     #[error("{path}: line {line}: `freq_hz` is not strictly ascending")]
@@ -218,60 +225,42 @@ pub fn load_los_psd_csv(path: impl AsRef<Path>) -> Result<LosPsd, LosPsdLoadErro
         path: path_ref.to_path_buf(),
         source,
     })?;
-    let reader = BufReader::new(file);
-
-    let mut header: Option<Vec<String>> = None;
+    let mut reader = csv::ReaderBuilder::new()
+        .comment(Some(b'#'))
+        .trim(csv::Trim::All)
+        .from_reader(file);
+    let headers = reader
+        .headers()
+        .map_err(|source| LosPsdLoadError::Csv {
+            path: path_ref.to_path_buf(),
+            line: source.position().map_or(1, |p| p.line()),
+            source,
+        })?
+        .clone();
+    if headers.is_empty() {
+        return Err(LosPsdLoadError::EmptyFile {
+            path: path_ref.to_path_buf(),
+        });
+    }
+    for column in ["freq_hz", "psd_los_x_rad2_per_hz", "psd_los_y_rad2_per_hz"] {
+        if !headers.iter().any(|header| header == column) {
+            return Err(LosPsdLoadError::MissingColumn {
+                path: path_ref.to_path_buf(),
+                column: column.to_owned(),
+            });
+        }
+    }
     let mut freq_hz: Vec<f64> = Vec::new();
     let mut psd_x: Vec<f64> = Vec::new();
     let mut psd_y: Vec<f64> = Vec::new();
-    let mut i_f = 0;
-    let mut i_x = 0;
-    let mut i_y = 0;
-
-    for (line_idx, line_result) in reader.lines().enumerate() {
-        let line_no = line_idx + 1;
-        let line = line_result.map_err(|source| LosPsdLoadError::Io {
+    while let Some(row) = reader.deserialize::<LosPsdCsvRow>().next() {
+        let row = row.map_err(|source| LosPsdLoadError::Csv {
             path: path_ref.to_path_buf(),
+            line: source.position().map_or(0, |p| p.line()),
             source,
         })?;
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            continue;
-        }
-        let cells: Vec<&str> = trimmed.split(',').map(str::trim).collect();
-
-        if header.is_none() {
-            let cols: Vec<String> = cells.iter().map(|c| c.to_string()).collect();
-            let find = |name: &str| -> Result<usize, LosPsdLoadError> {
-                cols.iter()
-                    .position(|c| c == name)
-                    .ok_or_else(|| LosPsdLoadError::MissingColumn {
-                        path: path_ref.to_path_buf(),
-                        column: name.to_string(),
-                    })
-            };
-            i_f = find("freq_hz")?;
-            i_x = find("psd_los_x_rad2_per_hz")?;
-            i_y = find("psd_los_y_rad2_per_hz")?;
-            header = Some(cols);
-            continue;
-        }
-
-        let parse_cell = |idx: usize, column: &str| -> Result<f64, LosPsdLoadError> {
-            let cell = cells.get(idx).ok_or_else(|| LosPsdLoadError::MissingCell {
-                path: path_ref.to_path_buf(),
-                line: line_no,
-                column: column.to_string(),
-            })?;
-            cell.parse::<f64>()
-                .map_err(|source| LosPsdLoadError::BadCell {
-                    path: path_ref.to_path_buf(),
-                    line: line_no,
-                    column: column.to_string(),
-                    source,
-                })
-        };
-        let f = parse_cell(i_f, "freq_hz")?;
+        let line_no = reader.position().line() as usize;
+        let f = row.freq_hz;
         if let Some(&prev) = freq_hz.last() {
             if f <= prev {
                 return Err(LosPsdLoadError::FrequencyNotAscending {
@@ -281,14 +270,8 @@ pub fn load_los_psd_csv(path: impl AsRef<Path>) -> Result<LosPsd, LosPsdLoadErro
             }
         }
         freq_hz.push(f);
-        psd_x.push(parse_cell(i_x, "psd_los_x_rad2_per_hz")?);
-        psd_y.push(parse_cell(i_y, "psd_los_y_rad2_per_hz")?);
-    }
-
-    if header.is_none() {
-        return Err(LosPsdLoadError::EmptyFile {
-            path: path_ref.to_path_buf(),
-        });
+        psd_x.push(row.psd_los_x_rad2_per_hz);
+        psd_y.push(row.psd_los_y_rad2_per_hz);
     }
     if freq_hz.len() < 2 {
         return Err(LosPsdLoadError::TooFewRows {
@@ -302,6 +285,13 @@ pub fn load_los_psd_csv(path: impl AsRef<Path>) -> Result<LosPsd, LosPsdLoadErro
         psd_x_rad2_per_hz: psd_x,
         psd_y_rad2_per_hz: psd_y,
     })
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct LosPsdCsvRow {
+    freq_hz: f64,
+    psd_los_x_rad2_per_hz: f64,
+    psd_los_y_rad2_per_hz: f64,
 }
 
 /// Body→world rotation defining the simulator body frame at the nominal
@@ -673,9 +663,18 @@ mod tests {
         let mut f = NamedTempFile::new().expect("tempfile");
         writeln!(f, "# synthetic LOS PSD for test").unwrap();
         writeln!(f, "# generated by jitter::tests::write_psd_csv").unwrap();
-        writeln!(f, "freq_hz,psd_los_x_rad2_per_hz,psd_los_y_rad2_per_hz").unwrap();
-        for (freq, px, py) in rows {
-            writeln!(f, "{},{:e},{:e}", freq, px, py).unwrap();
+        {
+            let mut writer = csv::Writer::from_writer(&mut f);
+            for &(freq_hz, psd_los_x_rad2_per_hz, psd_los_y_rad2_per_hz) in rows {
+                writer
+                    .serialize(LosPsdCsvRow {
+                        freq_hz,
+                        psd_los_x_rad2_per_hz,
+                        psd_los_y_rad2_per_hz,
+                    })
+                    .unwrap();
+            }
+            writer.flush().unwrap();
         }
         f.flush().unwrap();
         f


### PR DESCRIPTION
## Summary

- replace the jitter LOS-PSD, motion trajectory, and embedded bright-star hand parsers with `csv` + Serde
- emit standard, machine-readable row-oriented CSV from `sensor-view-stats` and `single_detection_matrix`
- update the star-probability plotting consumer for the clean CSV format

## Validation

- `cargo test -p simulator sims::jitter --lib`
- `cargo test -p simulator --bin motion_simulator build_csv_trajectory`
- `cargo test -p simulator test_parse_additional_stars --lib`
- `cargo check -p simulator --bins`

Closes #148
Closes #149
Closes #150
Closes #151
Closes #152

@meawoppl ready for review.

Supersedes #153 after removing the disallowed branch prefix.