### PR TITLE
deps: update crossbeam-epoch to 0.9.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

- update `crossbeam-epoch` from 0.9.18 to 0.9.20 in the lockfile
- resolve RUSTSEC-2026-0204, an invalid-pointer dereference vulnerability in pointer formatting implementations

## Validation

- `cargo check --workspace`
- `cargo audit --ignore RUSTSEC-2020-0163 --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0119 --ignore RUSTSEC-2025-0134`

The audit now exits successfully. Six pre-existing allowed warnings remain and are unrelated to this vulnerability.

@meawoppl ready for review.