### PR TITLE
Repin cfl-foundations after bench split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "meter-math"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=4bb8287#4bb828741eb128d41de475518dff0b373532d198"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=299716d#299716d77760234cc0324721af1fab9f42ed4942"
 dependencies = [
  "log",
  "nalgebra",
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=4bb8287#4bb828741eb128d41de475518dff0b373532d198"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=299716d#299716d77760234cc0324721af1fab9f42ed4942"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "shared-wasm"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=4bb8287#4bb828741eb128d41de475518dff0b373532d198"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=299716d#299716d77760234cc0324721af1fab9f42ed4942"
 dependencies = [
  "num-traits",
  "serde",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -28,9 +28,9 @@ env_logger = "0.11"           # Environment-based logger
 url = "2.5"                   # URL parsing and manipulation
 nalgebra = { version = "0.32", features = ["serde-serialize"] } # Linear algebra (quaternions for orientation)
 # Foundation crates from cfl-foundations.
-shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "4bb8287", default-features = false, features = ["frame-writer"] }
-meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "4bb8287" }
-shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "4bb8287" }
+shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "299716d", default-features = false, features = ["frame-writer"] }
+meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "299716d" }
+shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "299716d" }
 
 rand = "0.9"
 rand_distr = "0.5"


### PR DESCRIPTION
## Summary

- repin `shared`, `meter-math`, and `shared-wasm` to CosmicFrontierLabs/cfl-foundations#30
- refresh the lockfile at the same foundation commit
- verify focalplane does not depend on the removed bench calibration modules

## Dependency order

This should merge after:

1. CosmicFrontierLabs/tracking-test-bench#1403
2. CosmicFrontierLabs/cfl-foundations#30

The pin currently targets the exact cfl-foundations PR head (`299716d77760234cc0324721af1fab9f42ed4942`). If upstream merges with a different commit SHA, this PR will be updated before becoming ready.

## Validation

- `cargo fmt --check`
- `cargo test` (322 passed, 3 ignored)
- `cargo clippy -- -W clippy::all`
