### PR TITLE
Advance the cfl-foundations pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "meter-math"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=299716d#299716d77760234cc0324721af1fab9f42ed4942"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=a721a6e#a721a6e5a0be541f3a10d3cbec5b0f40b242ae50"
 dependencies = [
  "log",
  "nalgebra",
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=299716d#299716d77760234cc0324721af1fab9f42ed4942"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=a721a6e#a721a6e5a0be541f3a10d3cbec5b0f40b242ae50"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "shared-wasm"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=299716d#299716d77760234cc0324721af1fab9f42ed4942"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=a721a6e#a721a6e5a0be541f3a10d3cbec5b0f40b242ae50"
 dependencies = [
  "num-traits",
  "serde",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -28,9 +28,9 @@ env_logger = "0.11"           # Environment-based logger
 url = "2.5"                   # URL parsing and manipulation
 nalgebra = { version = "0.32", features = ["serde-serialize"] } # Linear algebra (quaternions for orientation)
 # Foundation crates from cfl-foundations.
-shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "299716d", default-features = false, features = ["frame-writer"] }
-meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "299716d" }
-shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "299716d" }
+shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "a721a6e", default-features = false, features = ["frame-writer"] }
+meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "a721a6e" }
+shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "a721a6e" }
 
 rand = "0.9"
 rand_distr = "0.5"


### PR DESCRIPTION
Step 3 of moving the bench calibration modules out of `cfl-foundations` into `tracking-test-bench`.

Picks up cfl-foundations#30, which deleted `bad_pixel_map`, `optical_alignment` and the `config_storage` that held them. Nothing here referenced any of the three — this repo uses `cfl-foundations` for units, Airy disks, star detection, histograms and the star projector — and `simulator` takes `shared` with `default-features = false, features = ["frame-writer"]`, so it never enabled the removed `config-storage` feature either.

## Why this lands alone

`tracking-test-bench` has to pin the same `cfl-foundations` revision this repo does, or its graph resolves two copies of `shared` and types stop unifying across crate boundaries. That gives a strict order: this repo advances first and stays internally coherent, while the consumer sits safely on its old locked commit here plus the matching old foundations revision. Only afterwards does the consumer advance *both* of its edges — the lock on this repo and its direct foundations revisions — in one change. Advancing one edge alone there is the failure mode.

## Verification

`cargo check --workspace` and `cargo test --workspace` clean. The lockfile resolves exactly one foundations revision: three entries at the new commit, zero at the old.