### PR TITLE
Advance foundations pin for clock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "meter-math"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=5f2a802#5f2a802f0f958f1a678bc456fe85b4fd4b404109"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=3db3f41#3db3f41fcb301830cd82210478e688dd5f0d27e6"
 dependencies = [
  "log",
  "nalgebra",
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=5f2a802#5f2a802f0f958f1a678bc456fe85b4fd4b404109"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=3db3f41#3db3f41fcb301830cd82210478e688dd5f0d27e6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "shared-wasm"
 version = "0.1.0"
-source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=5f2a802#5f2a802f0f958f1a678bc456fe85b4fd4b404109"
+source = "git+https://github.com/CosmicFrontierLabs/cfl-foundations?rev=3db3f41#3db3f41fcb301830cd82210478e688dd5f0d27e6"
 dependencies = [
  "num-traits",
  "serde",

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -28,9 +28,9 @@ env_logger = "0.11"           # Environment-based logger
 url = "2.5"                   # URL parsing and manipulation
 nalgebra = { version = "0.32", features = ["serde-serialize"] } # Linear algebra (quaternions for orientation)
 # Foundation crates from cfl-foundations.
-shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "5f2a802", default-features = false, features = ["frame-writer"] }
-meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "5f2a802" }
-shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "5f2a802" }
+shared = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "3db3f41", default-features = false, features = ["frame-writer"] }
+meter-math = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "3db3f41" }
+shared-wasm = { git = "https://github.com/CosmicFrontierLabs/cfl-foundations", rev = "3db3f41" }
 
 rand = "0.9"
 rand_distr = "0.5"


### PR DESCRIPTION
## Summary

Advance focalplane's three cfl-foundations dependencies together.

- consume the merged projector ownership change from cfl-foundations #31
- make the new generic `clock` package available at the same foundations revision
- retain exactly one source identity for `shared`, `shared-wasm`, and `meter-math`

## Why

tracking-test-bench is moving its injectable clock into cfl-foundations. Its direct foundations dependencies must remain on the same revision as focalplane's transitive dependencies or Cargo resolves duplicate shared types. This pin is the middle step: after it lands, tracking-test-bench #1414 can advance its focalplane and direct foundations pins atomically.

## Verification

- `Cargo.lock` contains three foundations packages at `3db3f41` and zero at `5f2a802`
- `cargo check --workspace`
- `cargo test --workspace` — 321 passed, 2 ignored
- `cargo clippy --workspace -- -W clippy::all`
- `git diff --check`

Workspace all-target strict clippy still reports pre-existing test-target findings unrelated to this two-file pin update.
